### PR TITLE
[FU-131] 에러 핸들링 base 코드 구현

### DIFF
--- a/src/main/java/com/foru/freebe/errors/errorcode/CommonErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/CommonErrorCode.java
@@ -1,0 +1,19 @@
+package com.foru.freebe.errors.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "Invalid parameter included"),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Resource not exists"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error"),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/foru/freebe/errors/errorcode/ErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/ErrorCode.java
@@ -1,0 +1,11 @@
+package com.foru.freebe.errors.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    String name();
+
+    HttpStatus getHttpStatus();
+
+    String getMessage();
+}

--- a/src/main/java/com/foru/freebe/errors/exception/RestApiException.java
+++ b/src/main/java/com/foru/freebe/errors/exception/RestApiException.java
@@ -1,0 +1,12 @@
+package com.foru.freebe.errors.exception;
+
+import com.foru.freebe.errors.errorcode.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RestApiException extends RuntimeException {
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/foru/freebe/errors/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/foru/freebe/errors/handler/GlobalExceptionHandler.java
@@ -1,0 +1,98 @@
+package com.foru.freebe.errors.handler;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import com.foru.freebe.errors.errorcode.CommonErrorCode;
+import com.foru.freebe.errors.errorcode.ErrorCode;
+import com.foru.freebe.errors.exception.RestApiException;
+import com.foru.freebe.errors.response.ErrorResponse;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    // 우리가 직접 커스텀한 에러 API
+    @ExceptionHandler(RestApiException.class)
+    public ResponseEntity<Object> handleCustomException(RestApiException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return handleExceptionInternal(errorCode);
+    }
+
+    // 메서드 인자 타입 예외 처리
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Object> handleIllegalArgument(IllegalArgumentException e) {
+        ErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
+        return handleExceptionInternal(errorCode, e.getMessage());
+    }
+
+    // 메서드 인자의 유효성 검사가 실패했을 때 발생
+    // 주로 Spring의 @Valid, @Validated 애노테이션을 사용한 검증 실패시 발생
+    @Override
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+        MethodArgumentNotValidException e,
+        HttpHeaders headers,
+        HttpStatusCode status,
+        WebRequest request) {
+        ErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
+        return handleExceptionInternal(e, errorCode);
+    }
+
+    @ExceptionHandler({Exception.class})
+    public ResponseEntity<Object> handleAllException(Exception ex) {
+        ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
+        return handleExceptionInternal(errorCode);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+            .body(makeErrorResponse(errorCode));
+    }
+
+    private ErrorResponse makeErrorResponse(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+            .code(errorCode.name())
+            .message(errorCode.getMessage())
+            .build();
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode, String message) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+            .body(makeErrorResponse(errorCode, message));
+    }
+
+    private ErrorResponse makeErrorResponse(ErrorCode errorCode, String message) {
+        return ErrorResponse.builder()
+            .code(errorCode.name())
+            .message(message)
+            .build();
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(BindException e, ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+            .body(makeErrorResponse(e, errorCode));
+    }
+
+    private ErrorResponse makeErrorResponse(BindException e, ErrorCode errorCode) {
+        List<ErrorResponse.ValidationError> validationErrorList = e.getBindingResult()
+            .getFieldErrors()
+            .stream()
+            .map(ErrorResponse.ValidationError::of)
+            .collect(Collectors.toList());
+
+        return ErrorResponse.builder()
+            .code(errorCode.name())
+            .message(errorCode.getMessage())
+            .errors(validationErrorList)
+            .build();
+    }
+}

--- a/src/main/java/com/foru/freebe/errors/response/ErrorResponse.java
+++ b/src/main/java/com/foru/freebe/errors/response/ErrorResponse.java
@@ -1,0 +1,37 @@
+package com.foru.freebe.errors.response;
+
+import java.util.List;
+
+import org.springframework.validation.FieldError;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class ErrorResponse {
+    private final String code;
+    private final String message;
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final List<ValidationError> errors;
+
+    @Getter
+    @Builder
+    @RequiredArgsConstructor
+    public static class ValidationError {
+        private final String field;
+        private final String message;
+
+        public static ValidationError of(final FieldError fieldError) {
+            return ValidationError.builder()
+                .field(fieldError.getField())
+                .message(fieldError.getDefaultMessage())
+                .build();
+        }
+    }
+}


### PR DESCRIPTION
## 체크리스트

- ✅ 불필요한 주석 처리가 없는가?

## 작업 내역
- ErrorCode (Interface)
- CommonErrorCode
- ErrorResponse
- RestApiException
- GlobalExceptionHandler

ErrorCode를 기반으로 앞으로 있을 도메인 별로 Error를 커스텀할 계획입니다. CommonErrorCode의 경우 Invalid_Parameter, Internal_Server_Error와 같은 일반적인 Error를 담고 있습니다. 이와 같이 MemberErrorCode, ProductErrorCode 이런식으로 확장하면 좋을 것 같습니다.

RestApiException의 경우, 공통된 인터페이스 ErrorCode를 통해 다양한 오류 코드를 캡슐화하고 이를 통해 모든 예외를 통합적으로 처리합니다. 그리고 예외처리를 RestApiException 클래스로 추상화하면 향후 새로운 오류 코드를 추가하거나 비즈니스 로직에 맞춰 예외 처리 로직을 변경할 때 코드의 수정에 용이하게 위함입니다.

ErrorResponse는 error를 응답하는 클래스이고 내부에 정의되어 있는 errors 필드는 바인딩 에러와 같은 유효성 검사 에러를 처리하고, 응답 데이터에서 필드가 비어있을 경우 JSON에서 생략하기 위해 '@JsonInclude(JsonInclude.Include.NON_EMPTY)'를 사용하였습니다.

그리고 가장 중요한 GlobalExceptionHandler는 우리가 앞으로 타겟할 에러들을 커스텀해서 대응하기 위해 만든 클래스입니다. 즉, 에러 핸들링하기 위한 클래스입니다. 저희 서비스 내에서 발생할 가능성이 있는 에러들을 정의하여 핸들링할 수 있는 클래스이기 때문에 앞으로 확장해야 할 클래스입니다.

## 고민한 사항
RestApiException가 ErrorCode를 통해 다양한 오류 코드를 캡슐화하고 모든 예외를 통합적으로 처리한다고 위에 언급했지만 아직 이 클래스에 대한 이해도와 필요성에 대해 명확히 이해하지 못했습니다. 그러나 대부분의 레퍼런스에서 해당 클래스를 통해 관리하는 것을 권장하고 있고 현재는 빠르게 에러 파트를 구현하기 위해 추가해 놓았지만 추후에 추가로 스터디 후 저만의 레퍼런스 자료를 만들 계획입니다.

그리고 해당 레퍼런스에서 API 응답에 ResponseEntity로 감싸는 것을 보고 관련 자료를 살펴봤는데, HTTP 표준 규약을 지키면서 API를 개발할 때는 표준을 지키면서 개발하기 위해 ResponseEntity로 감싸서 응답해야 한다고 작성되어 있습니다. 그래서 가독성이 떨어지더라도 현재 개발되어 있는 ApiResponseDto에 ResponseEntity를 사용할 지 아니면 현재 그대로 ApiResponseDto로 유지할지에 대한 고민이 있습니다. 

## 리뷰 요청사항