### PR TITLE
[FU-181] 사진의뢰자 측에서 사진작가 프로필을 조회하는 API 구현

### DIFF
--- a/src/main/java/com/foru/freebe/errors/errorcode/CommonErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/CommonErrorCode.java
@@ -9,7 +9,8 @@ public enum CommonErrorCode implements ErrorCode {
 
     INVALID_PARAMETER(400, "Invalid parameter included"),
     RESOURCE_NOT_FOUND(404, "Resource not exists"),
-    INTERNAL_SERVER_ERROR(500, "Internal server error");
+    INTERNAL_SERVER_ERROR(500, "Internal server error"),
+    INVALID_MEMBER_ROLE_TYPE(404, "Invalid member role type");
 
     private final int httpStatus;
     private final String message;

--- a/src/main/java/com/foru/freebe/profile/Controller/CustomerProfileController.java
+++ b/src/main/java/com/foru/freebe/profile/Controller/CustomerProfileController.java
@@ -1,0 +1,32 @@
+package com.foru.freebe.profile.Controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.foru.freebe.common.dto.ApiResponse;
+import com.foru.freebe.profile.dto.ProfileResponse;
+import com.foru.freebe.profile.service.ProfileService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/customer")
+public class CustomerProfileController {
+    private final ProfileService profileService;
+
+    @GetMapping("/profile/{photographerId}")
+    public ApiResponse<ProfileResponse> getPhotographerProfile(
+        @Valid @PathVariable("photographerId") Long photographerId) {
+        ProfileResponse profileResponse = profileService.getPhotographerProfile(photographerId);
+
+        return ApiResponse.<ProfileResponse>builder()
+            .status(200)
+            .message("Good Response")
+            .data(profileResponse)
+            .build();
+    }
+}

--- a/src/main/java/com/foru/freebe/profile/Controller/CustomerProfileController.java
+++ b/src/main/java/com/foru/freebe/profile/Controller/CustomerProfileController.java
@@ -18,10 +18,10 @@ import lombok.RequiredArgsConstructor;
 public class CustomerProfileController {
     private final ProfileService profileService;
 
-    @GetMapping("/profile/{photographerId}")
+    @GetMapping("/profile/{uniqueUrl}")
     public ApiResponse<ProfileResponse> getPhotographerProfile(
-        @Valid @PathVariable("photographerId") Long photographerId) {
-        ProfileResponse profileResponse = profileService.getPhotographerProfile(photographerId);
+        @Valid @PathVariable("uniqueUrl") String uniqueUrl) {
+        ProfileResponse profileResponse = profileService.getPhotographerProfile(uniqueUrl);
 
         return ApiResponse.<ProfileResponse>builder()
             .status(200)

--- a/src/main/java/com/foru/freebe/profile/dto/LinkInfo.java
+++ b/src/main/java/com/foru/freebe/profile/dto/LinkInfo.java
@@ -1,0 +1,11 @@
+package com.foru.freebe.profile.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LinkInfo {
+    private String linkTitle;
+    private String linkUrl;
+}

--- a/src/main/java/com/foru/freebe/profile/dto/ProfileResponse.java
+++ b/src/main/java/com/foru/freebe/profile/dto/ProfileResponse.java
@@ -1,0 +1,16 @@
+package com.foru.freebe.profile.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProfileResponse {
+    private String bannerImageUrl;
+    private String profileImageUrl;
+    private String instagramId;
+    private String introductionContent;
+    private List<LinkInfo> linkInfos;
+}

--- a/src/main/java/com/foru/freebe/profile/entity/Link.java
+++ b/src/main/java/com/foru/freebe/profile/entity/Link.java
@@ -1,0 +1,38 @@
+package com.foru.freebe.profile.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Link {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "link_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "profile_id")
+    private Profile profile;
+
+    private String title;
+    private String url;
+
+    @Builder
+    public Link(Profile profile, String title, String url) {
+        this.profile = profile;
+        this.title = title;
+        this.url = url;
+    }
+}

--- a/src/main/java/com/foru/freebe/profile/entity/Profile.java
+++ b/src/main/java/com/foru/freebe/profile/entity/Profile.java
@@ -35,6 +35,8 @@ public class Profile extends BaseEntity {
 
     private String introductionContent;
 
+    private String profileImageUrl;
+
     private String bannerImageUrl;
 
     public void assignUniqueUrl(String uniqueUrl) {
@@ -42,9 +44,11 @@ public class Profile extends BaseEntity {
     }
 
     @Builder
-    public Profile(String uniqueUrl, String introductionContent, String bannerImageUrl, Member member) {
+    public Profile(String uniqueUrl, String introductionContent, String profileImageUrl, String bannerImageUrl,
+        Member member) {
         this.uniqueUrl = uniqueUrl;
         this.introductionContent = introductionContent;
+        this.profileImageUrl = profileImageUrl;
         this.bannerImageUrl = bannerImageUrl;
         this.member = member;
     }

--- a/src/main/java/com/foru/freebe/profile/repository/LinkRepository.java
+++ b/src/main/java/com/foru/freebe/profile/repository/LinkRepository.java
@@ -1,0 +1,12 @@
+package com.foru.freebe.profile.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.foru.freebe.profile.entity.Link;
+import com.foru.freebe.profile.entity.Profile;
+
+public interface LinkRepository extends JpaRepository<Link, Long> {
+    List<Link> findByProfile(Profile profile);
+}

--- a/src/main/java/com/foru/freebe/profile/repository/ProfileRepository.java
+++ b/src/main/java/com/foru/freebe/profile/repository/ProfileRepository.java
@@ -9,4 +9,6 @@ import com.foru.freebe.profile.entity.Profile;
 
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
     Optional<Profile> findByMember(Member member);
+
+    Optional<Profile> findByUniqueUrl(String uniqueUrl);
 }

--- a/src/main/java/com/foru/freebe/profile/service/ProfileService.java
+++ b/src/main/java/com/foru/freebe/profile/service/ProfileService.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Service;
 import com.foru.freebe.errors.errorcode.CommonErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
 import com.foru.freebe.member.entity.Member;
-import com.foru.freebe.member.entity.Role;
 import com.foru.freebe.member.repository.MemberRepository;
 import com.foru.freebe.profile.dto.LinkInfo;
 import com.foru.freebe.profile.dto.ProfileResponse;
@@ -45,15 +44,11 @@ public class ProfileService {
         return profile.getUniqueUrl();
     }
 
-    public ProfileResponse getPhotographerProfile(Long photographerId) {
-        Member photographer = memberRepository.findById(photographerId)
+    public ProfileResponse getPhotographerProfile(String uniqueUrl) {
+        Profile photographerProfile = profileRepository.findByUniqueUrl(uniqueUrl)
             .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
-        if (photographer.getRole() != Role.PHOTOGRAPHER) {
-            throw new RestApiException(CommonErrorCode.INVALID_MEMBER_ROLE_TYPE);
-        }
 
-        Profile photographerProfile = profileRepository.findByMember(photographer)
-            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+        Member photographer = photographerProfile.getMember();
 
         List<Link> links = linkRepository.findByProfile(photographerProfile);
 

--- a/src/main/java/com/foru/freebe/profile/service/ProfileService.java
+++ b/src/main/java/com/foru/freebe/profile/service/ProfileService.java
@@ -1,6 +1,8 @@
 package com.foru.freebe.profile.service;
 
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -8,8 +10,13 @@ import org.springframework.stereotype.Service;
 import com.foru.freebe.errors.errorcode.CommonErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
 import com.foru.freebe.member.entity.Member;
+import com.foru.freebe.member.entity.Role;
 import com.foru.freebe.member.repository.MemberRepository;
+import com.foru.freebe.profile.dto.LinkInfo;
+import com.foru.freebe.profile.dto.ProfileResponse;
+import com.foru.freebe.profile.entity.Link;
 import com.foru.freebe.profile.entity.Profile;
+import com.foru.freebe.profile.repository.LinkRepository;
 import com.foru.freebe.profile.repository.ProfileRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -19,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class ProfileService {
     private final MemberRepository memberRepository;
     private final ProfileRepository profileRepository;
+    private final LinkRepository linkRepository;
 
     @Value("${FREEBE_BASE_URL}")
     private String freebeBaseUrl;
@@ -35,6 +43,30 @@ public class ProfileService {
         }
 
         return profile.getUniqueUrl();
+    }
+
+    public ProfileResponse getPhotographerProfile(Long photographerId) {
+        Member photographer = memberRepository.findById(photographerId)
+            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+        if (photographer.getRole() != Role.PHOTOGRAPHER) {
+            throw new RestApiException(CommonErrorCode.INVALID_MEMBER_ROLE_TYPE);
+        }
+
+        Profile photographerProfile = profileRepository.findByMember(photographer)
+            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+
+        List<Link> links = linkRepository.findByProfile(photographerProfile);
+
+        List<LinkInfo> linkInfos = links.stream()
+            .map(link -> new LinkInfo(link.getTitle(), link.getUrl()))
+            .collect(Collectors.toList());
+
+        return new ProfileResponse(
+            photographerProfile.getBannerImageUrl(),
+            photographerProfile.getProfileImageUrl(),
+            photographer.getInstagramId(),
+            photographerProfile.getIntroductionContent(),
+            linkInfos);
     }
 
     private Profile createMemberProfile(Member member) {


### PR DESCRIPTION
## 체크리스트

- ✅ 불필요한 주석 처리가 없는가?

## 작업 내역
- Profile entity에 profileImageUrl 필드 추가 
(추후 회원가입 과정에서 profileImageUrl, InstagramId를 등록하는 서비스 로직 추가 예정입니다.)
- Link entity 추가 
- 사진작가 프로필 조회 API 구현

## 고민한 사항
- customer 측에서 필요한 서비스 로직은 이번 PR에 포함되어 있는 로직 하나로 끝일 것 같은데 굳이 ProfileService를 Customer, Photographer로 구분하는 게 좋은 판단인지 고민입니다..🥲
(의견을 남겨주시면 감사하겠습니다!)

## 리뷰 요청사항
- 이어서 작업할 테스크는 없는 관계로 시급도는 낮습니다!
- ProfileService 클래스 리뷰 부탁드립니다!