### PR TITLE
[FU-132] Cors Configuration

### DIFF
--- a/src/main/java/com/foru/freebe/config/CorsConfig.java
+++ b/src/main/java/com/foru/freebe/config/CorsConfig.java
@@ -1,0 +1,26 @@
+package com.foru.freebe.config;
+
+import java.util.Arrays;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowCredentials(true);
+        configuration.setAllowedOrigins(Arrays.asList("https://www.freebe.co.kr", "http://localhost:3000"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setExposedHeaders(Arrays.asList("accessToken", "refreshToken"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}


### PR DESCRIPTION
## 체크리스트

- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
https://www.freebe.co.kr과 http://localhost:3000에 대한 CORS 설정

## 고민한 사항
- CORS 설정에는 jwtAuthenticationFilter 앞단에 CORS Filter를 추가하는 방식과 CorsConfigurationSource를 빈으로 등록하는 방식 두 가지가 있는데 어떤 방식이 더 적합할지에 대한 고민이 있었습니다. filter로 추가하게 되면 Spring MVC 레벨에서 제어가 가능하며, 빈으로 등록하게 되면 Spring Security와 Spring MVC에서 전역적으로 CORS를 설정할 수 있다는 차이가 있습니다. 일관된 CORS 처리와 추후 좀 더 세부적인 CORS 설정이 필요해질 수 있음을 고려하여 CorsConfigurationSource를 빈으로 등록하여 사용하기로 결정했습니다🤓

## 리뷰 요청사항
시급도 보통