### PR TITLE
[FU-126] 이미지 업로드 및 리사이즈 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     implementation 'io.hypersistence:hypersistence-utils-hibernate-60:3.3.1'
     implementation 'com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation group: 'net.coobird', name: 'thumbnailator', version: '0.4.1'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/src/main/java/com/foru/freebe/S3ImageService.java
+++ b/src/main/java/com/foru/freebe/S3ImageService.java
@@ -1,0 +1,111 @@
+package com.foru.freebe;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import net.coobird.thumbnailator.Thumbnails;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.foru.freebe.errors.errorcode.CommonErrorCode;
+import com.foru.freebe.errors.exception.RestApiException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class S3ImageService {
+    private final AmazonS3 amazonS3;
+
+    @Value("${AWS_S3_BUCKET}")
+    private String bucketName;
+
+    public List<String> uploadOriginalImage(List<MultipartFile> images) throws IOException {
+        if (images.isEmpty()) {
+            throw new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND);
+        }
+        return uploadImageToS3(images);
+    }
+
+    public List<String> uploadThumbnailImage(List<MultipartFile> images) throws IOException {
+        if (images.isEmpty()) {
+            throw new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND);
+        }
+        return createThumbnail(images);
+    }
+
+    private List<String> uploadImageToS3(List<MultipartFile> images) throws IOException {
+        List<String> originalImageUrls = new ArrayList<>();
+        for (MultipartFile image : images) {
+            String originKey = "origin/" + image.getOriginalFilename();
+
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentLength(image.getSize());
+            metadata.setContentType(image.getContentType());
+
+            amazonS3.putObject(bucketName, originKey, image.getInputStream(), metadata);
+
+            String imageUrl = amazonS3.getUrl(bucketName, originKey).toString();
+            originalImageUrls.add(imageUrl);
+        }
+        return originalImageUrls;
+    }
+
+    private List<String> createThumbnail(List<MultipartFile> images) throws IOException {
+        List<String> thumbnailImageUrls = new ArrayList<>();
+        for (MultipartFile image : images) {
+            InputStream originalImageStream = image.getInputStream();
+
+            ByteArrayOutputStream thumbnailOutputStream = new ByteArrayOutputStream();
+            Thumbnails.of(originalImageStream)
+                .size(50, 50)
+                .toOutputStream(thumbnailOutputStream);
+
+            InputStream thumbnailInputStream = new ByteArrayInputStream(thumbnailOutputStream.toByteArray());
+
+            ObjectMetadata thumbnailMetadata = new ObjectMetadata();
+            thumbnailMetadata.setContentType("image/jpeg"); // 썸네일의 콘텐츠 타입 설정 (JPEG로 가정)
+
+            String thumbnailKey = "thumbnail/" + image.getOriginalFilename();
+            amazonS3.putObject(new PutObjectRequest(bucketName, thumbnailKey, thumbnailInputStream, thumbnailMetadata));
+
+            String imageUrl = amazonS3.getUrl(bucketName, thumbnailKey).toString();
+            thumbnailImageUrls.add(imageUrl);
+        }
+        return thumbnailImageUrls;
+    }
+
+    // TODO 추후 수정 및 삭제 API 티켓에서 사용할 예정
+    public void deleteImageFromS3(String imageAddress) {
+        String key = getKeyFromImageAddress(imageAddress);
+        try {
+            amazonS3.deleteObject(new DeleteObjectRequest(bucketName, key));
+        } catch (Exception e) {
+            throw new RestApiException(CommonErrorCode.IO_EXCEPTION);
+        }
+    }
+
+    private String getKeyFromImageAddress(String imageAddress) {
+        try {
+            URL url = new URL(imageAddress);
+            String decodingKey = URLDecoder.decode(url.getPath(), "UTF-8");
+            return decodingKey.substring(1); // 맨 앞의 '/' 제거
+        } catch (MalformedURLException | UnsupportedEncodingException e) {
+            throw new RestApiException(CommonErrorCode.IO_EXCEPTION);
+        }
+    }
+}

--- a/src/main/java/com/foru/freebe/common/service/S3ImageService.java
+++ b/src/main/java/com/foru/freebe/common/service/S3ImageService.java
@@ -29,23 +29,12 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class S3ImageService {
+    private static final int THUMBNAIL_SIZE = 200;
+
     private final AmazonS3 amazonS3;
 
     @Value("${AWS_S3_BUCKET}")
     private String bucketName;
-
-    // public List<String> uploadOriginalImage(List<MultipartFile> images) throws IOException {
-    //     if (images.isEmpty()) {
-    //         throw new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND);
-    //     }
-    //     return uploadImageToS3(images);
-    // }
-    // public List<String> uploadThumbnailImage(List<MultipartFile> images) throws IOException {
-    //     if (images.isEmpty()) {
-    //         throw new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND);
-    //     }
-    //     return createThumbnail(images);
-    // }
 
     public List<String> uploadOriginalImage(List<MultipartFile> images) throws IOException {
         List<String> originalImageUrls = new ArrayList<>();
@@ -71,7 +60,7 @@ public class S3ImageService {
 
             ByteArrayOutputStream thumbnailOutputStream = new ByteArrayOutputStream();
             Thumbnails.of(originalImageStream)
-                .size(200, 200)
+                .size(THUMBNAIL_SIZE, THUMBNAIL_SIZE)
                 .toOutputStream(thumbnailOutputStream);
 
             InputStream thumbnailInputStream = new ByteArrayInputStream(thumbnailOutputStream.toByteArray());

--- a/src/main/java/com/foru/freebe/common/service/S3ImageService.java
+++ b/src/main/java/com/foru/freebe/common/service/S3ImageService.java
@@ -1,4 +1,4 @@
-package com.foru.freebe;
+package com.foru.freebe.common.service;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -72,7 +72,7 @@ public class S3ImageService {
 
             ByteArrayOutputStream thumbnailOutputStream = new ByteArrayOutputStream();
             Thumbnails.of(originalImageStream)
-                .size(50, 50)
+                .size(200, 200)
                 .toOutputStream(thumbnailOutputStream);
 
             InputStream thumbnailInputStream = new ByteArrayInputStream(thumbnailOutputStream.toByteArray());

--- a/src/main/java/com/foru/freebe/common/service/S3ImageService.java
+++ b/src/main/java/com/foru/freebe/common/service/S3ImageService.java
@@ -34,21 +34,20 @@ public class S3ImageService {
     @Value("${AWS_S3_BUCKET}")
     private String bucketName;
 
+    // public List<String> uploadOriginalImage(List<MultipartFile> images) throws IOException {
+    //     if (images.isEmpty()) {
+    //         throw new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND);
+    //     }
+    //     return uploadImageToS3(images);
+    // }
+    // public List<String> uploadThumbnailImage(List<MultipartFile> images) throws IOException {
+    //     if (images.isEmpty()) {
+    //         throw new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND);
+    //     }
+    //     return createThumbnail(images);
+    // }
+
     public List<String> uploadOriginalImage(List<MultipartFile> images) throws IOException {
-        if (images.isEmpty()) {
-            throw new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND);
-        }
-        return uploadImageToS3(images);
-    }
-
-    public List<String> uploadThumbnailImage(List<MultipartFile> images) throws IOException {
-        if (images.isEmpty()) {
-            throw new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND);
-        }
-        return createThumbnail(images);
-    }
-
-    private List<String> uploadImageToS3(List<MultipartFile> images) throws IOException {
         List<String> originalImageUrls = new ArrayList<>();
         for (MultipartFile image : images) {
             String originKey = "origin/" + image.getOriginalFilename();
@@ -65,7 +64,7 @@ public class S3ImageService {
         return originalImageUrls;
     }
 
-    private List<String> createThumbnail(List<MultipartFile> images) throws IOException {
+    public List<String> uploadThumbnailImage(List<MultipartFile> images) throws IOException {
         List<String> thumbnailImageUrls = new ArrayList<>();
         for (MultipartFile image : images) {
             InputStream originalImageStream = image.getInputStream();

--- a/src/main/java/com/foru/freebe/common/service/S3ImageService.java
+++ b/src/main/java/com/foru/freebe/common/service/S3ImageService.java
@@ -17,10 +17,13 @@ import org.springframework.web.multipart.MultipartFile;
 
 import net.coobird.thumbnailator.Thumbnails;
 
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.foru.freebe.errors.errorcode.AwsErrorCode;
 import com.foru.freebe.errors.errorcode.CommonErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
 
@@ -82,8 +85,12 @@ public class S3ImageService {
         String key = getKeyFromImageAddress(imageAddress);
         try {
             amazonS3.deleteObject(new DeleteObjectRequest(bucketName, key));
+        } catch (AmazonS3Exception e) {
+            throw new RestApiException(AwsErrorCode.AMAZON_S3_EXCEPTION);
+        } catch (AmazonServiceException e) {
+            throw new RestApiException(AwsErrorCode.AMAZON_SERVICE_EXCEPTION);
         } catch (Exception e) {
-            throw new RestApiException(CommonErrorCode.IO_EXCEPTION);
+            throw new RestApiException(CommonErrorCode.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/main/java/com/foru/freebe/config/S3Config.java
+++ b/src/main/java/com/foru/freebe/config/S3Config.java
@@ -1,0 +1,32 @@
+package com.foru.freebe.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+public class S3Config {
+    @Value("${AWS_ACCESS_KEY}")
+    private String accessKey;
+    @Value("${AWS_SECRET_KEY}")
+    private String secretKey;
+    @Value("${AWS_REGION}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+            .standard()
+            .withCredentials(new AWSStaticCredentialsProvider(credentials))
+            .withRegion(region)
+            .build();
+    }
+}

--- a/src/main/java/com/foru/freebe/errors/errorcode/AwsErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/AwsErrorCode.java
@@ -1,0 +1,14 @@
+package com.foru.freebe.errors.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AwsErrorCode implements ErrorCode {
+    AMAZON_S3_EXCEPTION(404, "Amazon S3 exception"),
+    AMAZON_SERVICE_EXCEPTION(500, "Amazon service exception");
+
+    private final int httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/foru/freebe/errors/errorcode/CommonErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/CommonErrorCode.java
@@ -10,8 +10,7 @@ public enum CommonErrorCode implements ErrorCode {
     INVALID_PARAMETER(400, "Invalid parameter included"),
     RESOURCE_NOT_FOUND(404, "Resource not exists"),
     INTERNAL_SERVER_ERROR(500, "Internal server error"),
-    IO_EXCEPTION(500, "IoException occurred"),
-    ;
+    IO_EXCEPTION(500, "IoException occurred");
 
     private final int httpStatus;
     private final String message;

--- a/src/main/java/com/foru/freebe/errors/errorcode/CommonErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/CommonErrorCode.java
@@ -9,7 +9,9 @@ public enum CommonErrorCode implements ErrorCode {
 
     INVALID_PARAMETER(400, "Invalid parameter included"),
     RESOURCE_NOT_FOUND(404, "Resource not exists"),
-    INTERNAL_SERVER_ERROR(500, "Internal server error");
+    INTERNAL_SERVER_ERROR(500, "Internal server error"),
+    IO_EXCEPTION(500, "IoException occurred"),
+    ;
 
     private final int httpStatus;
     private final String message;

--- a/src/main/java/com/foru/freebe/errors/errorcode/ImageErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/ImageErrorCode.java
@@ -1,0 +1,14 @@
+package com.foru.freebe.errors.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ImageErrorCode implements ErrorCode {
+
+    PUT_OBJECT_EXCEPTION(500, "Failed to upload image to S3 due to an internal error");
+
+    private final int httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/foru/freebe/product/controller/PhotographerProductController.java
+++ b/src/main/java/com/foru/freebe/product/controller/PhotographerProductController.java
@@ -1,5 +1,6 @@
 package com.foru.freebe.product.controller;
 
+import java.io.IOException;
 import java.util.List;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -8,7 +9,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.foru.freebe.auth.model.MemberAdapter;
 import com.foru.freebe.common.dto.ApiResponse;
@@ -29,9 +32,10 @@ public class PhotographerProductController {
 
     @PostMapping("/product")
     public ApiResponse<Void> registerProduct(@AuthenticationPrincipal MemberAdapter memberAdapter,
-        @Valid @RequestBody ProductRegisterRequest productRegisterRequest) {
+        @RequestPart(value = "request") ProductRegisterRequest request,
+        @RequestPart(value = "images", required = false) List<MultipartFile> images) throws IOException {
         Member photographer = memberAdapter.getMember();
-        return productService.registerProduct(productRegisterRequest, photographer.getId());
+        return productService.registerProduct(request, images, photographer.getId());
     }
 
     @GetMapping("/product/list")

--- a/src/main/java/com/foru/freebe/product/dto/photographer/ProductRegisterRequest.java
+++ b/src/main/java/com/foru/freebe/product/dto/photographer/ProductRegisterRequest.java
@@ -13,8 +13,6 @@ public class ProductRegisterRequest {
     private String productTitle;
     private String productDescription;
     @NotNull
-    private List<String> productImageUrls;
-    @NotNull
     private List<ProductComponentDto> productComponents;
     private List<ProductOptionDto> productOptions;
     private List<ProductDiscountDto> productDiscounts;

--- a/src/main/java/com/foru/freebe/product/dto/photographer/RegisteredProductResponse.java
+++ b/src/main/java/com/foru/freebe/product/dto/photographer/RegisteredProductResponse.java
@@ -13,6 +13,7 @@ public class RegisteredProductResponse {
     private String productTitle;
     private Integer reservationCount;
     private ActiveStatus activeStatus;
+    //TODO 추후 상품 대표 사진에 대한 로직 처리와 함께 대표사진 경로에 대한 필드 추가
 
     @Builder
     public RegisteredProductResponse(Long productId, String productTitle, Integer reservationCount,

--- a/src/main/java/com/foru/freebe/product/entity/ProductImage.java
+++ b/src/main/java/com/foru/freebe/product/entity/ProductImage.java
@@ -24,8 +24,7 @@ public class ProductImage extends BaseEntity {
     @Column(name = "product_image_id")
     private Long id;
 
-    // TODO 추후 원본 이미지 리사이징 로직 구현 후 추가 예정
-    // @NotNull
+    @NotNull
     private String thumbnailUrl;
 
     @NotNull

--- a/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
@@ -1,11 +1,15 @@
 package com.foru.freebe.product.service;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.foru.freebe.common.dto.ApiResponse;
+import com.foru.freebe.common.service.S3ImageService;
 import com.foru.freebe.errors.errorcode.CommonErrorCode;
 import com.foru.freebe.errors.errorcode.ProductErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
@@ -41,14 +45,14 @@ public class PhotographerProductService {
     private final ProductDiscountRepository productDiscountRepository;
     private final MemberRepository memberRepository;
 
-    public ApiResponse<Void> registerProduct(ProductRegisterRequest productRegisterRequestDto, Long photographerId) {
+    private final S3ImageService s3ImageService;
+
+    public ApiResponse<Void> registerProduct(ProductRegisterRequest productRegisterRequestDto,
+        List<MultipartFile> images, Long photographerId) throws IOException {
         Member member = getMember(photographerId);
 
-        String productTitle = productRegisterRequestDto.getProductTitle();
-        String productDescription = productRegisterRequestDto.getProductDescription();
-
         Product productAsActive = registerActiveProduct(productRegisterRequestDto, member);
-        registerProductImage(productRegisterRequestDto.getProductImageUrls(), productAsActive);
+        registerProductImage(images, productAsActive);
         registerProductComponent(productRegisterRequestDto.getProductComponents(), productAsActive);
 
         if (productRegisterRequestDto.getProductOptions() != null) {
@@ -128,11 +132,17 @@ public class PhotographerProductService {
             .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
     }
 
-    private void registerProductImage(List<String> productImageUrls, Product product) {
-        for (String productImageUrl : productImageUrls) {
-            ProductImage productImage = ProductImage.createProductImage(null, productImageUrl, product);
+    private void registerProductImage(List<MultipartFile> images, Product product) throws IOException {
+        List<String> originalImageUrls = s3ImageService.uploadOriginalImage(images);
+        List<String> thumbnailImageUrls = s3ImageService.uploadThumbnailImage(images);
+
+        IntStream.range(0, originalImageUrls.size()).forEach(i -> {
+            ProductImage productImage = ProductImage.createProductImage(
+                thumbnailImageUrls.get(i),
+                originalImageUrls.get(i),
+                product);
             productImageRepository.save(productImage);
-        }
+        });
     }
 
     private void registerProductComponent(List<ProductComponentDto> productComponentDtoList, Product product) {

--- a/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
@@ -51,6 +51,10 @@ public class PhotographerProductService {
         List<MultipartFile> images, Long photographerId) throws IOException {
         Member member = getMember(photographerId);
 
+        if (images.isEmpty()) {
+            throw new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND);
+        }
+
         Product productAsActive = registerActiveProduct(productRegisterRequestDto, member);
         registerProductImage(images, productAsActive);
         registerProductComponent(productRegisterRequestDto.getProductComponents(), productAsActive);

--- a/src/main/java/com/foru/freebe/reservation/controller/CustomerReservationController.java
+++ b/src/main/java/com/foru/freebe/reservation/controller/CustomerReservationController.java
@@ -13,9 +13,9 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.foru.freebe.S3ImageService;
 import com.foru.freebe.auth.model.MemberAdapter;
 import com.foru.freebe.common.dto.ApiResponse;
+import com.foru.freebe.common.service.S3ImageService;
 import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.reservation.dto.BasicReservationInfoResponse;
 import com.foru.freebe.reservation.dto.FormRegisterRequest;

--- a/src/main/java/com/foru/freebe/reservation/controller/CustomerReservationController.java
+++ b/src/main/java/com/foru/freebe/reservation/controller/CustomerReservationController.java
@@ -1,13 +1,19 @@
 package com.foru.freebe.reservation.controller;
 
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
+import com.foru.freebe.S3ImageService;
 import com.foru.freebe.auth.model.MemberAdapter;
 import com.foru.freebe.common.dto.ApiResponse;
 import com.foru.freebe.member.entity.Member;
@@ -23,12 +29,15 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/customer")
 public class CustomerReservationController {
     private final CustomerReservationService customerReservationService;
+    private final S3ImageService s3ImageService;
 
-    @PostMapping("/reservation")
-    public ApiResponse<Void> registerReservationForm(@Valid @RequestBody FormRegisterRequest request,
-        @AuthenticationPrincipal MemberAdapter memberAdapter) {
+    @PostMapping(value = "/reservation", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE,
+        MediaType.APPLICATION_JSON_VALUE})
+    public ApiResponse<String> registerReservationForm(@RequestPart("request") FormRegisterRequest request,
+        @AuthenticationPrincipal MemberAdapter memberAdapter,
+        @RequestPart(value = "images", required = false) List<MultipartFile> images) throws IOException {
         Member customer = memberAdapter.getMember();
-        return customerReservationService.registerReservationForm(customer.getId(), request);
+        return customerReservationService.registerReservationForm(customer.getId(), request, images);
     }
 
     @GetMapping("/reservation/form/{productId}")

--- a/src/main/java/com/foru/freebe/reservation/dto/FormDetailsViewResponse.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/FormDetailsViewResponse.java
@@ -19,13 +19,15 @@ public class FormDetailsViewResponse {
     private CustomerDetails customerDetails;
     private Map<String, String> photoInfo;
     private Map<Integer, PreferredDate> preferredDates;
-    private List<String> preferredImages;
+    private List<String> originalImage;
+    private List<String> thumbnailImage;
     private String requestMemo;
 
     @Builder
     public FormDetailsViewResponse(Long reservationNumber, ReservationStatus currentReservationStatus,
         List<StatusHistory> statusHistory, String productTitle, CustomerDetails customerDetails,
-        Map<String, String> photoInfo, Map<Integer, PreferredDate> preferredDates, List<String> preferredImages,
+        Map<String, String> photoInfo, Map<Integer, PreferredDate> preferredDates, List<String> originalImage,
+        List<String> thumbnailImage,
         String requestMemo) {
         this.reservationNumber = reservationNumber;
         this.currentReservationStatus = currentReservationStatus;
@@ -34,7 +36,8 @@ public class FormDetailsViewResponse {
         this.customerDetails = customerDetails;
         this.photoInfo = photoInfo;
         this.preferredDates = preferredDates;
-        this.preferredImages = preferredImages;
+        this.originalImage = originalImage;
+        this.thumbnailImage = thumbnailImage;
         this.requestMemo = requestMemo;
     }
 

--- a/src/main/java/com/foru/freebe/reservation/dto/FormRegisterRequest.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/FormRegisterRequest.java
@@ -1,6 +1,5 @@
 package com.foru.freebe.reservation.dto;
 
-import java.util.List;
 import java.util.Map;
 
 import jakarta.validation.constraints.NotNull;
@@ -22,7 +21,7 @@ public class FormRegisterRequest {
 
     private Map<Integer, PreferredDate> preferredDates;
 
-    private List<String> preferredImages;
+    private Map<Integer, PhotoOption> photoOptions;
 
     private String customerMemo;
 

--- a/src/main/java/com/foru/freebe/reservation/dto/PhotoOption.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/PhotoOption.java
@@ -1,0 +1,10 @@
+package com.foru.freebe.reservation.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PhotoOption {
+    private String title;
+    private Integer quantity;
+    private Integer price;
+}

--- a/src/main/java/com/foru/freebe/reservation/dto/ReferenceImageUrls.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/ReferenceImageUrls.java
@@ -1,0 +1,18 @@
+package com.foru.freebe.reservation.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ReferenceImageUrls {
+    private List<String> originalImage;
+    private List<String> thumbnailImage;
+
+    @Builder
+    public ReferenceImageUrls(List<String> originalImage, List<String> thumbnailImage) {
+        this.originalImage = originalImage;
+        this.thumbnailImage = thumbnailImage;
+    }
+}

--- a/src/main/java/com/foru/freebe/reservation/entity/ReferenceImage.java
+++ b/src/main/java/com/foru/freebe/reservation/entity/ReferenceImage.java
@@ -27,19 +27,19 @@ public class ReferenceImage {
     private ReservationForm reservationForm;
 
     @NotNull
-    private String origin_url;
+    private String originUrl;
 
     @NotNull
-    private String thumbnail_url;
+    private String thumbnailUrl;
 
-    private ReferenceImage(String origin_url, String thumbnail_url, ReservationForm reservationForm) {
-        this.origin_url = origin_url;
-        this.thumbnail_url = thumbnail_url;
+    private ReferenceImage(String originUrl, String thumbnailUrl, ReservationForm reservationForm) {
+        this.originUrl = originUrl;
+        this.thumbnailUrl = thumbnailUrl;
         this.reservationForm = reservationForm;
     }
 
-    public static ReferenceImage updateReferenceImage(String origin_url, String thumbnail_url,
+    public static ReferenceImage updateReferenceImage(String originUrl, String thumbnailUrl,
         ReservationForm reservationForm) {
-        return new ReferenceImage(origin_url, thumbnail_url, reservationForm);
+        return new ReferenceImage(originUrl, thumbnailUrl, reservationForm);
     }
 }

--- a/src/main/java/com/foru/freebe/reservation/entity/ReferenceImage.java
+++ b/src/main/java/com/foru/freebe/reservation/entity/ReferenceImage.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -25,14 +26,20 @@ public class ReferenceImage {
     @JoinColumn(name = "reservation_form_id")
     private ReservationForm reservationForm;
 
-    private String referencingImage;
+    @NotNull
+    private String origin_url;
 
-    private ReferenceImage(String referencingImage, ReservationForm reservationForm) {
-        this.referencingImage = referencingImage;
+    @NotNull
+    private String thumbnail_url;
+
+    private ReferenceImage(String origin_url, String thumbnail_url, ReservationForm reservationForm) {
+        this.origin_url = origin_url;
+        this.thumbnail_url = thumbnail_url;
         this.reservationForm = reservationForm;
     }
 
-    public static ReferenceImage updateReferenceImage(String referencingImages, ReservationForm reservationForm) {
-        return new ReferenceImage(referencingImages, reservationForm);
+    public static ReferenceImage updateReferenceImage(String origin_url, String thumbnail_url,
+        ReservationForm reservationForm) {
+        return new ReferenceImage(origin_url, thumbnail_url, reservationForm);
     }
 }

--- a/src/main/java/com/foru/freebe/reservation/entity/ReservationForm.java
+++ b/src/main/java/com/foru/freebe/reservation/entity/ReservationForm.java
@@ -6,6 +6,7 @@ import org.hibernate.annotations.Type;
 
 import com.foru.freebe.common.entity.BaseEntity;
 import com.foru.freebe.member.entity.Member;
+import com.foru.freebe.reservation.dto.PhotoOption;
 import com.foru.freebe.reservation.dto.PreferredDate;
 
 import io.hypersistence.utils.hibernate.type.json.JsonType;
@@ -71,6 +72,11 @@ public class ReservationForm extends BaseEntity {
     private Map<String, String> photoInfo;
 
     @Type(JsonType.class)
+    @Column(name = "photo_option", columnDefinition = "longtext")
+    @NotNull(message = "PhotoOption must not be null")
+    private Map<Integer, PhotoOption> photoOption;
+
+    @Type(JsonType.class)
     @Column(name = "preferred_date", columnDefinition = "longtext")
     @NotNull(message = "Preferred Date must not be null")
     private Map<Integer, PreferredDate> preferredDate;
@@ -83,7 +89,7 @@ public class ReservationForm extends BaseEntity {
     public ReservationForm(Member photographer, Member customer, String instagramId, String productTitle,
         Long totalPrice, Boolean serviceTermAgreement, Boolean photographerTermAgreement,
         ReservationStatus reservationStatus, Map<String, String> photoInfo, Map<Integer, PreferredDate> preferredDate,
-        String customerMemo, String photographerMemo) {
+        Map<Integer, PhotoOption> photoOption, String customerMemo, String photographerMemo) {
         this.photographer = photographer;
         this.customer = customer;
         this.instagramId = instagramId;
@@ -94,6 +100,7 @@ public class ReservationForm extends BaseEntity {
         this.reservationStatus = reservationStatus;
         this.photoInfo = photoInfo;
         this.preferredDate = preferredDate;
+        this.photoOption = photoOption;
         this.customerMemo = customerMemo;
         this.photographerMemo = photographerMemo;
     }

--- a/src/main/java/com/foru/freebe/reservation/repository/ReferenceImageRepository.java
+++ b/src/main/java/com/foru/freebe/reservation/repository/ReferenceImageRepository.java
@@ -1,7 +1,6 @@
 package com.foru.freebe.reservation.repository;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,5 +8,5 @@ import com.foru.freebe.reservation.entity.ReferenceImage;
 import com.foru.freebe.reservation.entity.ReservationForm;
 
 public interface ReferenceImageRepository extends JpaRepository<ReferenceImage, Long> {
-    Optional<List<ReferenceImage>> findAllByReservationForm(ReservationForm reservationForm);
+    List<ReferenceImage> findAllByReservationForm(ReservationForm reservationForm);
 }

--- a/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
@@ -54,9 +54,8 @@ public class CustomerReservationService {
         Member photographer = findMember(formRegisterRequest.getPhotographerId());
 
         ReservationForm reservationForm = createReservationForm(formRegisterRequest, photographer, customer);
-
         validateReservationForm(formRegisterRequest);
-        // TODO 확인
+
         List<String> originalImageUrls = s3ImageService.uploadOriginalImage(images);
         List<String> thumbnailImageUrls = s3ImageService.uploadThumbnailImage(images);
         saveReservationForm(originalImageUrls, thumbnailImageUrls, reservationForm);

--- a/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
@@ -1,10 +1,13 @@
 package com.foru.freebe.reservation.service;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import com.foru.freebe.S3ImageService;
 import com.foru.freebe.common.dto.ApiResponse;
 import com.foru.freebe.errors.errorcode.CommonErrorCode;
 import com.foru.freebe.errors.errorcode.ProductErrorCode;
@@ -42,17 +45,22 @@ public class CustomerReservationService {
     private final ProductComponentRepository productComponentRepository;
     private final ProductOptionRepository productOptionRepository;
     private final ReferenceImageRepository referenceImageRepository;
+    private final S3ImageService s3ImageService;
 
-    public ApiResponse<Void> registerReservationForm(Long customerId, FormRegisterRequest formRegisterRequest) {
+    public ApiResponse<String> registerReservationForm(Long customerId, FormRegisterRequest formRegisterRequest,
+        List<MultipartFile> images) throws IOException {
         Member customer = findMember(customerId);
         Member photographer = findMember(formRegisterRequest.getPhotographerId());
 
         ReservationForm reservationForm = createReservationForm(formRegisterRequest, photographer, customer);
 
         validateReservationForm(formRegisterRequest);
-        saveReservationForm(formRegisterRequest, reservationForm);
+        // TODO 확인
+        List<String> originalImageUrls = s3ImageService.uploadOriginalImage(images);
+        List<String> thumbnailImageUrls = s3ImageService.uploadThumbnailImage(images);
+        saveReservationForm(originalImageUrls, thumbnailImageUrls, reservationForm);
 
-        return ApiResponse.<Void>builder()
+        return ApiResponse.<String>builder()
             .status(200)
             .message("Good Request")
             .data(null)
@@ -87,16 +95,18 @@ public class CustomerReservationService {
             .build();
     }
 
-    private void saveReservationForm(FormRegisterRequest formRegisterRequest, ReservationForm reservationForm) {
+    private void saveReservationForm(List<String> originalImageUrls, List<String> thumbnailImageUrls,
+        ReservationForm reservationForm) {
         ReservationForm newReservationForm = reservationFormRepository.save(reservationForm);
 
         reservationHistoryRepository.save(
             ReservationHistory.updateReservationStatus(newReservationForm, ReservationStatus.NEW));
 
-        formRegisterRequest.getPreferredImages()
-            .stream()
-            .map(referenceImage -> ReferenceImage.updateReferenceImage(referenceImage, reservationForm))
-            .forEach(referenceImageRepository::save);
+        for (int i = 0; i < originalImageUrls.size(); i++) {
+            ReferenceImage referenceImage = ReferenceImage.updateReferenceImage(originalImageUrls.get(i),
+                thumbnailImageUrls.get(i), reservationForm);
+            referenceImageRepository.save(referenceImage);
+        }
     }
 
     private Member findMember(Long id) {
@@ -111,6 +121,7 @@ public class CustomerReservationService {
                 request.getServiceTermAgreement(), request.getPhotographerTermAgreement(), ReservationStatus.NEW)
             .photoInfo(request.getPhotoInfo())
             .preferredDate(request.getPreferredDates())
+            .photoOption(request.getPhotoOptions())
             .customerMemo(request.getCustomerMemo());
         return builder.build();
     }

--- a/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
@@ -8,8 +8,8 @@ import java.util.stream.IntStream;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.foru.freebe.S3ImageService;
 import com.foru.freebe.common.dto.ApiResponse;
+import com.foru.freebe.common.service.S3ImageService;
 import com.foru.freebe.errors.errorcode.CommonErrorCode;
 import com.foru.freebe.errors.errorcode.ProductErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;

--- a/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
@@ -3,6 +3,7 @@ package com.foru.freebe.reservation.service;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -102,11 +103,14 @@ public class CustomerReservationService {
         reservationHistoryRepository.save(
             ReservationHistory.updateReservationStatus(newReservationForm, ReservationStatus.NEW));
 
-        for (int i = 0; i < originalImageUrls.size(); i++) {
-            ReferenceImage referenceImage = ReferenceImage.updateReferenceImage(originalImageUrls.get(i),
-                thumbnailImageUrls.get(i), reservationForm);
+        IntStream.range(0, originalImageUrls.size()).forEach(i -> {
+            ReferenceImage referenceImage = ReferenceImage.updateReferenceImage(
+                originalImageUrls.get(i),
+                thumbnailImageUrls.get(i),
+                reservationForm
+            );
             referenceImageRepository.save(referenceImage);
-        }
+        });
     }
 
     private Member findMember(Long id) {

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
@@ -127,12 +127,14 @@ public class PhotographerReservationService {
 
     private ReferenceImageUrls getPreferredImages(ReservationForm reservationForm) {
         List<ReferenceImage> referenceImages = referenceImageRepository.findAllByReservationForm(reservationForm);
-        List<String> originalImageUrls = new ArrayList<>();
-        List<String> thumbnailImageUrls = new ArrayList<>();
-        for (ReferenceImage referenceImage : referenceImages) {
-            originalImageUrls.add(referenceImage.getOrigin_url());
-            thumbnailImageUrls.add(referenceImage.getThumbnail_url());
-        }
+
+        List<String> originalImageUrls = referenceImages.stream()
+            .map(ReferenceImage::getOrigin_url)
+            .collect(Collectors.toList());
+
+        List<String> thumbnailImageUrls = referenceImages.stream()
+            .map(ReferenceImage::getThumbnail_url)
+            .collect(Collectors.toList());
 
         return ReferenceImageUrls.builder()
             .originalImage(originalImageUrls)

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
@@ -129,11 +129,11 @@ public class PhotographerReservationService {
         List<ReferenceImage> referenceImages = referenceImageRepository.findAllByReservationForm(reservationForm);
 
         List<String> originalImageUrls = referenceImages.stream()
-            .map(ReferenceImage::getOrigin_url)
+            .map(ReferenceImage::getOriginUrl)
             .collect(Collectors.toList());
 
         List<String> thumbnailImageUrls = referenceImages.stream()
-            .map(ReferenceImage::getThumbnail_url)
+            .map(ReferenceImage::getThumbnailUrl)
             .collect(Collectors.toList());
 
         return ReferenceImageUrls.builder()

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
@@ -15,6 +15,7 @@ import com.foru.freebe.reservation.dto.FormComponent;
 import com.foru.freebe.reservation.dto.FormDetailsViewResponse;
 import com.foru.freebe.reservation.dto.FormListViewResponse;
 import com.foru.freebe.reservation.dto.PreferredDate;
+import com.foru.freebe.reservation.dto.ReferenceImageUrls;
 import com.foru.freebe.reservation.dto.StatusHistory;
 import com.foru.freebe.reservation.entity.ReferenceImage;
 import com.foru.freebe.reservation.entity.ReservationForm;
@@ -50,12 +51,13 @@ public class PhotographerReservationService {
         CustomerDetails customerDetails = buildCustomerDetails(reservationForm);
         Map<String, String> shootDetails = reservationForm.getPhotoInfo();
         Map<Integer, PreferredDate> preferredDates = reservationForm.getPreferredDate();
-        List<String> preferredImages = getPreferredImages(reservationForm);
+        ReferenceImageUrls preferredImages = getPreferredImages(reservationForm);
 
         FormDetailsViewResponse formDetailsViewResponse = FormDetailsViewResponse.builder(reservationForm.getId(),
                 reservationForm.getReservationStatus(), statusHistories, reservationForm.getProductTitle(), customerDetails,
                 shootDetails, preferredDates)
-            .preferredImages(preferredImages)
+            .originalImage(preferredImages.getOriginalImage())
+            .thumbnailImage(preferredImages.getThumbnailImage())
             .requestMemo(reservationForm.getCustomerMemo())
             .build();
 
@@ -123,11 +125,18 @@ public class PhotographerReservationService {
             .build();
     }
 
-    private List<String> getPreferredImages(ReservationForm reservationForm) {
-        return referenceImageRepository.findAllByReservationForm(reservationForm)
-            .orElse(List.of())
-            .stream()
-            .map(ReferenceImage::getReferencingImage)
-            .collect(Collectors.toList());
+    private ReferenceImageUrls getPreferredImages(ReservationForm reservationForm) {
+        List<ReferenceImage> referenceImages = referenceImageRepository.findAllByReservationForm(reservationForm);
+        List<String> originalImageUrls = new ArrayList<>();
+        List<String> thumbnailImageUrls = new ArrayList<>();
+        for (ReferenceImage referenceImage : referenceImages) {
+            originalImageUrls.add(referenceImage.getOrigin_url());
+            thumbnailImageUrls.add(referenceImage.getThumbnail_url());
+        }
+
+        return ReferenceImageUrls.builder()
+            .originalImage(originalImageUrls)
+            .thumbnailImage(thumbnailImageUrls)
+            .build();
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -37,6 +37,13 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 10MB
+      max-request-size: 10MB
+
 logging:
   level:
     web: debug


### PR DESCRIPTION
## 체크리스트

- ✅ 불필요한 주석 처리가 없는가?

## 작업 내역
- Thumbnailator를 사용한 이미지 리사이즈 로직 구현
- S3와 연동하여 버킷내에 /origin, /thumbnail 경로에 각각 이미지 업로드 로직 구현
- 위 내용은 신청서 상세보기, 예약신청서 등록, 상품 등록 API에 관련된 코드 리팩터링
    - 해당 API에 대한 API Docs 업데이트, 프론트 개발 시 참고부탁드립니다!
- 기존의 ReferenceImage Entity에 preferredImage 필드를 origin_url, thumbnail_url 필드로 수정하여 리팩터링

## 고민한 사항
- 생각한 것보다 리팩터링 해야 할 부분이 많고 많은 에러들 때문에 PR이 조금 지연되었습니다...ㅠㅠ🙇‍♂️
- 이미지 리사이즈 레퍼런스를 보면서 이미지의 확장자에 대한 validation을 진행하는 코드를 활용하여 작성했을 때 에러가 났고, 해당 에러에 대한 수정이 어려워 지금은 validation을 하지 않고 있습니다. 사실 아직까지는 확장자에 대한 범위를 제한하고 있지 않아서 추후에 사용자 요구사항에 따라 다시 추가할 의향이 있습니다😊
- 이미지 리사이즈 과정에서 (A) **원본 이미지에 대한 이미지 비율에 따른 축소**, (B) **특정 너비, 높이 픽셀을 정한 것에 맞게 이미지를 축소**를 고민하고 있었고, 저희 기획에 따라 (B) 방법을 채택하여 코드 작성을 하였지만 추후에 사용자가 썸네일 이미지에 대한 품질이 낮다고 평가할 우려가 있습니다. 해당 부분 인지하여 추후에 피드백을 받는다면 추가로 품질을 높이는 코드를 추가할 계획입니다.

## 리뷰 요청사항
- 시급도는 중간입니다. (9/3까지만 해주시면 좋을 것 같아요! 이후 연관성 있는 API 개발이 기다리고 있습니다😂)
- S3ImageService, CustomerReservationService, PhotographerReservationService 중점적으로 리뷰 부탁드립니다!
- 추가로 ReferenceImage Entity에 대해 수정한 부분도 확인해주시면 좋을 것 같아요!