### PR TITLE
[FU-196] 로그인 과정에서 발생하는 버그 픽스

### DIFF
--- a/src/main/java/com/foru/freebe/config/CorsConfig.java
+++ b/src/main/java/com/foru/freebe/config/CorsConfig.java
@@ -18,6 +18,7 @@ public class CorsConfig {
         configuration.setAllowedOrigins(Arrays.asList("https://www.freebe.co.kr", "http://localhost:3000"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setExposedHeaders(Arrays.asList("accessToken", "refreshToken"));
+        configuration.setAllowedHeaders(Arrays.asList("Content-Type", "Authorization", "refreshToken"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/src/main/java/com/foru/freebe/config/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/foru/freebe/config/CustomAccessDeniedHandler.java
@@ -1,0 +1,26 @@
+package com.foru.freebe.config;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+        AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json");
+        response.getWriter()
+            .write(
+                "{\"status\":" + HttpStatus.FORBIDDEN.value() + ", \"message\":\"" + accessDeniedException.getMessage()
+                    + "\"}");
+    }
+}

--- a/src/main/java/com/foru/freebe/config/SecurityConfig.java
+++ b/src/main/java/com/foru/freebe/config/SecurityConfig.java
@@ -32,9 +32,10 @@ public class SecurityConfig {
 
             .authorizeHttpRequests((request) -> request
                 .requestMatchers("/photographer/join").hasAnyRole("PHOTOGRAPHER_PENDING")
-                .requestMatchers("/photographer").hasAnyRole("PHOTOGRAPHER")
-                .requestMatchers("/customer").hasAnyRole("CUSTOMER")
-                .requestMatchers("/admin").hasAnyRole("ADMIN")
+                .requestMatchers("/photographer/**").hasAnyRole("PHOTOGRAPHER")
+                .requestMatchers("/customer/product/**").permitAll()
+                .requestMatchers("/customer/**").hasAnyRole("CUSTOMER")
+                .requestMatchers("/admin/**").hasAnyRole("ADMIN")
                 .anyRequest().permitAll())
 
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/foru/freebe/config/SecurityConfig.java
+++ b/src/main/java/com/foru/freebe/config/SecurityConfig.java
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @EnableWebSecurity
 public class SecurityConfig {
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtExceptionFilter jwtExceptionFilter;
 
@@ -37,6 +38,8 @@ public class SecurityConfig {
                 .requestMatchers("/customer/**").hasAnyRole("CUSTOMER")
                 .requestMatchers("/admin/**").hasAnyRole("ADMIN")
                 .anyRequest().permitAll())
+            .exceptionHandling((handler) -> handler
+                .accessDeniedHandler(customAccessDeniedHandler))
 
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
             .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);

--- a/src/main/java/com/foru/freebe/errors/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/foru/freebe/errors/handler/GlobalExceptionHandler.java
@@ -30,8 +30,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(JwtTokenException.class)
     public ResponseEntity<Object> handleJwtAuthenticationException(JwtTokenException e) {
-        ErrorCode errorCode = e.getErrorCode();
-        return handleExceptionInternal(errorCode);
+        return handleExceptionInternal(e.getErrorCode());
     }
 
     // 메서드 인자 타입 예외 처리

--- a/src/main/java/com/foru/freebe/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/foru/freebe/jwt/filter/JwtAuthenticationFilter.java
@@ -1,10 +1,13 @@
 package com.foru.freebe.jwt.filter;
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -27,9 +30,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        String path = request.getRequestURI();
-        String[] excludePath = {"/login/redirect", "/login", "/reissue", "/"};
-        return Arrays.asList(excludePath).contains(path);
+        List<RequestMatcher> matchers = new ArrayList<>();
+        matchers.add(new AntPathRequestMatcher("/customer/product/**"));
+        matchers.add(new AntPathRequestMatcher("/login/**"));
+        matchers.add(new AntPathRequestMatcher("/reissue"));
+
+        return matchers.stream()
+            .anyMatch((matcher -> matcher.matches(request)));
     }
 
     @Override

--- a/src/main/java/com/foru/freebe/member/entity/Member.java
+++ b/src/main/java/com/foru/freebe/member/entity/Member.java
@@ -31,6 +31,7 @@ public class Member extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @NotNull
+    @Column(length = 20, nullable = false)
     private Role role;
 
     @NotNull


### PR DESCRIPTION
### 1. 현상 파악
**Issue 1**. SqlExceptionHelper   : Data truncated for column 'role' at row 1
**Issue 2.** 사진의뢰자 측에서 사진작가 상품 목록 및 상품 상세를 조회하고자 할 때 403 에러 반환
<br>

### 2. 분석하기
**Issue 1**. 
Member 테이블의 Role 컬럼에 들어가는 enum 상수명을 PENDING -> PHOTOGRAPHER_PENDING으로 바꾸면서 DB truncation 이슈가 발생했습니다. 기존에 PENDING으로 엔티티를 생성했을 때 설정된 DB 컬럼 길이보다 PHOTOGRAPHER_PENDING의 길이가 더 길어지면서 발생한 이슈로 보입니다. 

**Issue 2.**
사진작가 상품 목록 및 상품 상세 조회는 별다른 권한 없이도 접근이 가능해야 하는데 CUSTOMER 롤을 부여받은 유저만 접근할 수 있도록 설정되어 있었습니다. 또한 Authorization 헤더 없이 요청을 보내게 되므로 jwt authentication filter에서도 제외되어야 하는데 해당 경로가 제외목록에 포함되어있지 않았습니다.

<br>

### 3. 조치하기
**Issue 1.**
Member 테이블의 Role 컬럼 길이를 명시적으로 지정하였습니다. PHOTOGRAPHER_PENDING보다 긴 컬럼명은 앞으로 사용할 일이 없을 것 같아 최대 컬럼 길이는 PHOTOGRAPHER_PENDING에 맞춰 VARCHAR(20)으로 지정하였습니다.

**Issue 2.**
사진작가 상품 목록 및 상품 상세 조회의 경우 로그인이 이뤄지기 전에 접근하는 페이지이므로, 접근권한이 CUSTOMER로 제한되어 있던 것을 해제하고 jwt authentication 필터에서도 제외되도록 설정을 수정하였습니다.
<br>

### 4. 검증하기
Issue 1, 2와 관련된 API 테스트를 로컬 환경에서 포스트맨을 이용해 진행했고, 정상적으로 동작하는 것을 확인했습니다.
배포 환경에서도 이어서 테스트를 진행할 예정입니다!
<br>

### 5. 회고
테이블이 이미 생성된 이후에 테이블이나 컬럼 속성을 바꾸게 될 경우에는 API 테스트를 일괄적으로 수행해보는 것이 필요하고, alter나 drop 등의 명령어를 사용해 DB 테이블을 손볼 일이 생길 수 있다는 점을 한번 더 인식하는 계기가 되었습니다 ~ :) 

