### PR TITLE
[FU-133] 로그아웃 로직 구현

### DIFF
--- a/src/main/java/com/foru/freebe/config/CustomLogoutHandler.java
+++ b/src/main/java/com/foru/freebe/config/CustomLogoutHandler.java
@@ -6,8 +6,10 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.stereotype.Component;
 
+import com.foru.freebe.errors.errorcode.CommonErrorCode;
 import com.foru.freebe.errors.errorcode.JwtErrorCode;
 import com.foru.freebe.errors.exception.JwtTokenException;
+import com.foru.freebe.errors.exception.RestApiException;
 import com.foru.freebe.jwt.service.JwtService;
 import com.foru.freebe.member.entity.Role;
 
@@ -41,7 +43,7 @@ public class CustomLogoutHandler implements LogoutHandler {
         } catch (JwtException e) {
             throw new JwtException(e.getMessage(), e);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new RestApiException(CommonErrorCode.IO_EXCEPTION);
         }
     }
 }

--- a/src/main/java/com/foru/freebe/config/CustomLogoutHandler.java
+++ b/src/main/java/com/foru/freebe/config/CustomLogoutHandler.java
@@ -1,0 +1,47 @@
+package com.foru.freebe.config;
+
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.stereotype.Component;
+
+import com.foru.freebe.errors.errorcode.JwtErrorCode;
+import com.foru.freebe.errors.exception.JwtTokenException;
+import com.foru.freebe.jwt.service.JwtService;
+import com.foru.freebe.member.entity.Role;
+
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CustomLogoutHandler implements LogoutHandler {
+    private final JwtService jwtService;
+
+    @Override
+    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        try {
+            String refreshToken = request.getHeader("refreshToken");
+            if (refreshToken == null) {
+                throw new JwtTokenException(JwtErrorCode.INVALID_TOKEN);
+            }
+            Role role = jwtService.getMemberRole(refreshToken);
+            jwtService.revokeToken(refreshToken);
+
+            switch (role) {
+                case CUSTOMER -> response.sendRedirect("/login/customer");
+                case PHOTOGRAPHER, PHOTOGRAPHER_PENDING -> response.sendRedirect("/login/photographer");
+                default -> response.sendRedirect("/login");
+            }
+        } catch (JwtTokenException e) {
+            throw new JwtTokenException(e.getErrorCode());
+        } catch (JwtException e) {
+            throw new JwtException(e.getMessage(), e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/foru/freebe/config/CustomLogoutHandler.java
+++ b/src/main/java/com/foru/freebe/config/CustomLogoutHandler.java
@@ -25,7 +25,7 @@ public class CustomLogoutHandler implements LogoutHandler {
     public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
         try {
             String refreshToken = request.getHeader("refreshToken");
-            if (refreshToken == null) {
+            if (refreshToken == null || refreshToken.isEmpty()) {
                 throw new JwtTokenException(JwtErrorCode.INVALID_TOKEN);
             }
             Role role = jwtService.getMemberRole(refreshToken);

--- a/src/main/java/com/foru/freebe/config/SecurityConfig.java
+++ b/src/main/java/com/foru/freebe/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
 
 import com.foru.freebe.jwt.filter.JwtAuthenticationFilter;
 import com.foru.freebe.jwt.filter.JwtExceptionFilter;
@@ -21,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 @EnableWebSecurity
 public class SecurityConfig {
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final CustomLogoutHandler customLogoutHandler;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtExceptionFilter jwtExceptionFilter;
 
@@ -30,6 +32,9 @@ public class SecurityConfig {
             .csrf(AbstractHttpConfigurer::disable)
             .cors(withDefaults())
             .sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+            .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class)
+            .addFilterBefore(jwtExceptionFilter, LogoutFilter.class)
 
             .authorizeHttpRequests((request) -> request
                 .requestMatchers("/photographer/join").hasAnyRole("PHOTOGRAPHER_PENDING")
@@ -38,11 +43,14 @@ public class SecurityConfig {
                 .requestMatchers("/customer/**").hasAnyRole("CUSTOMER")
                 .requestMatchers("/admin/**").hasAnyRole("ADMIN")
                 .anyRequest().permitAll())
-            .exceptionHandling((handler) -> handler
-                .accessDeniedHandler(customAccessDeniedHandler))
 
-            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-            .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
+            .logout((logout) -> logout
+                .logoutUrl("/logout")
+                .addLogoutHandler(customLogoutHandler))
+
+            .exceptionHandling((handler) -> handler
+                .accessDeniedHandler(customAccessDeniedHandler));
+
         return http.build();
     }
 }

--- a/src/main/java/com/foru/freebe/config/SecurityConfig.java
+++ b/src/main/java/com/foru/freebe/config/SecurityConfig.java
@@ -32,8 +32,8 @@ public class SecurityConfig {
             .csrf(AbstractHttpConfigurer::disable)
             .cors(withDefaults())
             .sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .addFilterBefore(jwtExceptionFilter, UsernamePasswordAuthenticationFilter.class)
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-            .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class)
             .addFilterBefore(jwtExceptionFilter, LogoutFilter.class)
 
             .authorizeHttpRequests((request) -> request

--- a/src/main/java/com/foru/freebe/errors/errorcode/CommonErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/CommonErrorCode.java
@@ -9,7 +9,8 @@ public enum CommonErrorCode implements ErrorCode {
 
     INVALID_PARAMETER(400, "Invalid parameter included"),
     RESOURCE_NOT_FOUND(404, "Resource not exists"),
-    INTERNAL_SERVER_ERROR(500, "Internal server error");
+    INTERNAL_SERVER_ERROR(500, "Internal server error"),
+    IO_EXCEPTION(500, "IoException occurred");
 
     private final int httpStatus;
     private final String message;

--- a/src/main/java/com/foru/freebe/errors/errorcode/JwtErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/JwtErrorCode.java
@@ -6,8 +6,10 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum JwtErrorCode implements ErrorCode {
+    INVALID_TOKEN(400, "Invalid token"),
     EXPIRED_TOKEN(401, "Expired token"),
-    INVALID_TOKEN(400, "Invalid token");
+    REVOKED_TOKEN(403, "Revoked token"),
+    TOKEN_NOT_FOUND(404, "Token not found");
 
     private final int httpStatus;
     private final String message;

--- a/src/main/java/com/foru/freebe/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/foru/freebe/jwt/filter/JwtAuthenticationFilter.java
@@ -14,6 +14,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import com.foru.freebe.errors.errorcode.JwtErrorCode;
 import com.foru.freebe.errors.exception.JwtTokenException;
 import com.foru.freebe.jwt.service.JwtService;
+import com.foru.freebe.jwt.service.JwtVerifier;
 
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -26,6 +27,7 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtVerifier jwtVerifier;
     private final JwtService jwtService;
 
     @Override
@@ -51,7 +53,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
 
             accessToken = accessToken.substring(7);
-            if (jwtService.isAccessTokenValid(accessToken)) {
+            if (jwtVerifier.isAccessTokenValid(accessToken)) {
                 Authentication auth = jwtService.getAuthentication(accessToken);
                 SecurityContextHolder.getContext().setAuthentication(auth);
             }

--- a/src/main/java/com/foru/freebe/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/foru/freebe/jwt/filter/JwtAuthenticationFilter.java
@@ -13,7 +13,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.foru.freebe.errors.errorcode.JwtErrorCode;
 import com.foru.freebe.errors.exception.JwtTokenException;
-import com.foru.freebe.jwt.service.JwtProvider;
+import com.foru.freebe.jwt.service.JwtService;
 
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -26,7 +26,7 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-    private final JwtProvider jwtProvider;
+    private final JwtService jwtService;
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
@@ -51,8 +51,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
 
             accessToken = accessToken.substring(7);
-            if (jwtProvider.isTokenValidate(accessToken)) {
-                Authentication auth = jwtProvider.getAuthentication(accessToken);
+            if (jwtService.isAccessTokenValid(accessToken)) {
+                Authentication auth = jwtService.getAuthentication(accessToken);
                 SecurityContextHolder.getContext().setAuthentication(auth);
             }
         } catch (ExpiredJwtException e) {

--- a/src/main/java/com/foru/freebe/jwt/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/foru/freebe/jwt/filter/JwtExceptionFilter.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.foru.freebe.errors.exception.JwtTokenException;
+import com.foru.freebe.errors.exception.RestApiException;
 
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
@@ -34,6 +35,13 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
             response.getWriter()
                 .write(
                     "{\"message\":\"" + e.getMessage() + "\"}");
+        } catch (RestApiException e) {
+            response.setStatus(e.getErrorCode().getHttpStatus());
+            response.setContentType("application/json");
+            response.getWriter()
+                .write(
+                    "{\"message\":\"" + e.getMessage() + "\"}"
+                );
         }
     }
 }

--- a/src/main/java/com/foru/freebe/jwt/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/foru/freebe/jwt/filter/JwtExceptionFilter.java
@@ -25,11 +25,15 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
         } catch (JwtTokenException e) {
             response.setStatus(e.getHttpStatus());
             response.setContentType("application/json");
-            response.getWriter().write(e.getMessage());
+            response.getWriter()
+                .write(
+                    "{\"message\":\"" + e.getMessage() + "\"}");
         } catch (JwtException e) {
             response.setStatus(400);
             response.setContentType("application/json");
-            response.getWriter().write(e.getMessage());
+            response.getWriter()
+                .write(
+                    "{\"message\":\"" + e.getMessage() + "\"}");
         }
     }
 }

--- a/src/main/java/com/foru/freebe/jwt/model/JwtToken.java
+++ b/src/main/java/com/foru/freebe/jwt/model/JwtToken.java
@@ -39,6 +39,10 @@ public class JwtToken {
     @NotNull
     private Boolean isRevoked;
 
+    public void revokeToken() {
+        isRevoked = true;
+    }
+
     @Builder
     private JwtToken(Long memberId, String refreshToken, LocalDateTime expiresAt) {
         this.memberId = memberId;

--- a/src/main/java/com/foru/freebe/jwt/model/JwtToken.java
+++ b/src/main/java/com/foru/freebe/jwt/model/JwtToken.java
@@ -10,12 +10,14 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class JwtToken {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,14 +31,20 @@ public class JwtToken {
     private String refreshToken;
 
     @CreationTimestamp
-    private LocalDateTime createdAt;
+    private LocalDateTime issuedAt;
 
-    private JwtToken(Long memberId, String refreshToken) {
+    @NotNull
+    private LocalDateTime expiresAt;
+
+    @NotNull
+    private Boolean isRevoked;
+
+    @Builder
+    private JwtToken(Long memberId, String refreshToken, LocalDateTime expiresAt) {
         this.memberId = memberId;
         this.refreshToken = refreshToken;
-    }
-
-    public static JwtToken createJwtToken(Long memberId, String refreshToken) {
-        return new JwtToken(memberId, refreshToken);
+        this.issuedAt = LocalDateTime.now();
+        this.expiresAt = expiresAt;
+        this.isRevoked = false;
     }
 }

--- a/src/main/java/com/foru/freebe/jwt/repository/JwtTokenRepository.java
+++ b/src/main/java/com/foru/freebe/jwt/repository/JwtTokenRepository.java
@@ -1,6 +1,5 @@
 package com.foru.freebe.jwt.repository;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,7 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.foru.freebe.jwt.model.JwtToken;
 
 public interface JwtTokenRepository extends JpaRepository<JwtToken, Long> {
-    Optional<List<JwtToken>> findByMemberId(Long memberId);
-
-    Optional<JwtToken> findByRefreshToken(String refreshToken);
+    Optional<JwtToken> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/foru/freebe/jwt/repository/JwtTokenRepository.java
+++ b/src/main/java/com/foru/freebe/jwt/repository/JwtTokenRepository.java
@@ -10,4 +10,6 @@ public interface JwtTokenRepository extends JpaRepository<JwtToken, Long> {
     Optional<JwtToken> findByMemberId(Long memberId);
 
     Optional<JwtToken> findByRefreshToken(String refreshToken);
+
+    Void deleteByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/foru/freebe/jwt/repository/JwtTokenRepository.java
+++ b/src/main/java/com/foru/freebe/jwt/repository/JwtTokenRepository.java
@@ -8,4 +8,6 @@ import com.foru.freebe.jwt.model.JwtToken;
 
 public interface JwtTokenRepository extends JpaRepository<JwtToken, Long> {
     Optional<JwtToken> findByMemberId(Long memberId);
+
+    Optional<JwtToken> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/foru/freebe/jwt/service/JwtProvider.java
+++ b/src/main/java/com/foru/freebe/jwt/service/JwtProvider.java
@@ -1,5 +1,7 @@
 package com.foru.freebe.jwt.service;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 
 import javax.crypto.SecretKey;
@@ -64,13 +66,6 @@ public class JwtProvider {
             .compact();
     }
 
-    private Jws<Claims> parseClaims(String token) {
-        return Jwts.parser()
-            .verifyWith(secretKey)
-            .build()
-            .parseSignedClaims(token);
-    }
-
     public boolean isTokenValidate(String token) {
         Jws<Claims> claims = parseClaims(token);
         return true;
@@ -83,4 +78,18 @@ public class JwtProvider {
 
         return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
     }
+
+    public LocalDateTime getExpiration(String token) {
+        Jws<Claims> claims = parseClaims(token);
+        Date expiration = claims.getPayload().getExpiration();
+        return expiration.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
+    }
+
+    private Jws<Claims> parseClaims(String token) {
+        return Jwts.parser()
+            .verifyWith(secretKey)
+            .build()
+            .parseSignedClaims(token);
+    }
+
 }

--- a/src/main/java/com/foru/freebe/jwt/service/JwtProvider.java
+++ b/src/main/java/com/foru/freebe/jwt/service/JwtProvider.java
@@ -31,6 +31,10 @@ public class JwtProvider {
         this.secretKey = Keys.hmacShaKeyFor(jwtSecretKey.getBytes());
     }
 
+    public Long getMemberIdFromToken(String token) {
+        return Long.valueOf(parseClaims(token).getPayload().get("memberId", String.class));
+    }
+
     public String generateAccessToken(Long id) {
         Claims claims = Jwts.claims()
             .issuer(String.valueOf(id))

--- a/src/main/java/com/foru/freebe/jwt/service/JwtService.java
+++ b/src/main/java/com/foru/freebe/jwt/service/JwtService.java
@@ -1,8 +1,5 @@
 package com.foru.freebe.jwt.service;
 
-import java.util.List;
-import java.util.Optional;
-
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 
@@ -49,9 +46,13 @@ public class JwtService {
     }
 
     private void saveRefreshToken(Long id, String refreshToken) {
-        Optional<List<JwtToken>> jwtToken = jwtTokenRepository.findByMemberId(id);
-        jwtToken.ifPresent(jwtTokenRepository::deleteAll);
-        JwtToken newToken = JwtToken.createJwtToken(id, refreshToken);
+        jwtTokenRepository.findByMemberId(id).ifPresent(jwtTokenRepository::deleteAll);
+
+        JwtToken newToken = JwtToken.builder()
+            .memberId(id)
+            .refreshToken(refreshToken)
+            .expiresAt(jwtProvider.getExpiration(refreshToken))
+            .build();
         jwtTokenRepository.save(newToken);
     }
 

--- a/src/main/java/com/foru/freebe/jwt/service/JwtVerifier.java
+++ b/src/main/java/com/foru/freebe/jwt/service/JwtVerifier.java
@@ -1,0 +1,47 @@
+package com.foru.freebe.jwt.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+
+import com.foru.freebe.errors.errorcode.JwtErrorCode;
+import com.foru.freebe.errors.exception.JwtTokenException;
+import com.foru.freebe.jwt.model.JwtToken;
+import com.foru.freebe.jwt.repository.JwtTokenRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class JwtVerifier {
+    private final JwtProvider jwtProvider;
+    private final JwtTokenRepository jwtTokenRepository;
+
+    private void validateTokenExpiration(String token) {
+        if (jwtProvider.getExpiration(token).isBefore(LocalDateTime.now())) {
+            throw new JwtTokenException(JwtErrorCode.EXPIRED_TOKEN);
+        }
+    }
+
+    private void validateRefreshTokenRevocation(JwtToken refreshToken) {
+        if (refreshToken.getIsRevoked()) {
+            throw new JwtTokenException(JwtErrorCode.REVOKED_TOKEN);
+        }
+    }
+
+    public void validateRefreshToken(JwtToken refreshToken) {
+        validateTokenExpiration(refreshToken.getRefreshToken());
+        validateRefreshTokenRevocation(refreshToken);
+    }
+
+    public boolean isAccessTokenValid(String accessToken) {
+        validateTokenExpiration(accessToken);
+
+        Long memberId = jwtProvider.getMemberIdFromToken(accessToken);
+        JwtToken refreshToken = jwtTokenRepository.findByMemberId(memberId)
+            .orElseThrow(() -> new JwtTokenException(JwtErrorCode.TOKEN_NOT_FOUND));
+
+        validateRefreshToken(refreshToken);
+        return true;
+    }
+}


### PR DESCRIPTION
## 체크리스트

- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
1. 로그아웃 요청 시, 요청헤더에 실려온 리프레시 토큰을 무효화시키는 로직을 구현했습니다.
2. 토큰의 무효화 여부를 기록할 수 있도록 DB의 리프레시토큰 저장소에 isRevoked 컬럼을 추가했습니다.
3. 매 API 요청 마다 엑세스토큰을 검증하는 로직에 아래 절차가 추가되었습니다.
-> 요청헤더에 실려온 엑세스토큰의 페이로드에 담긴 정보를 통해 DB에서 동일한 사용자의 리프레시 토큰을 조회하고, 리프레시 토큰의 무효화 여부를 검증합니다.


## 고민한 사항
- 토큰의 무효화 로직 구현방식을 고민했습니다. 
1. 토큰 저장소에 무효화 여부를 기록하기 위한 컬럼을 추가
2. 무효화된 토큰을 저장하기 위한 Black List 테이블을 추가로 설계
3. Redis를 사용해서 블랙리스트를 관리
우선 (3)의 경우 사용자가 많지 않은 초기단계에 Redis를 사용하면서 얻는 이점보다는 관리 측면의 오버헤드가 늘어나는 단점이 더 크다고 판단해 배제하였습니다. 추후에 성능 개선의 뚜렷한 이유가 생길때 도입을 검토해보면 좋을 것 같습니다 :)
그리고 리프레시토큰 저장소 이외에 블랙리스트를 저장하기 위한 테이블을 추가로 설계하는 방식 (2)의 경우, 토큰이 만료되면 배치잡을 통해 리프레시토큰 저장소와 블랙리스트 양측에서 만료된 토큰을 제거해야하기 때문에 큰 이점을 느끼지 못했습니다. 따라서 첫번째 방식으로 컬럼을 통해 토큰 무효화 여부를 기록하고자 합니다~! 이 경우에도 배치잡으로 만료된토큰을 주기적으로 제거해줘야해서 배치 작업용 코드가 필요할 것 같네요 .. (쓰다보니 생각남😅)

<br>

- jwtProvider, jwtService 클래스의 책임 분리가 모호해져서 나름대로 역할 정의가 필요할 것 같다는 생각을 했습니다.
**JwtProvider**는 JWT의 생성과 파싱에 집중
**JwtService**는 비즈니스 로직에 집중하여 JWT의 유효성을 검사, 사용자 인증 및 토큰 관리 작업을 수행
으로 구분하고자 합니다-!

(0905)
-  정원용 멘토님과 코드리뷰 시간 이후에 클래스명 리팩토링만으로도 책임분리를 좀 더 잘할 수 있게 된다는 점을 배웠습니다 🫡
JwtProvider: jwt 라이프사이클에 관여
JwtService: jwt 비즈니스 로직 처리
JwtVerifier: jwt 검증 및 유효성 검사
=> 로 수정되었습니다 

- 만료된 토큰은 스케줄러를 이용해 주기적으로 제거하기보다 우선은 만료된 토큰을 검증하는 로직에서 삭제되게끔 구현해두었습니다-!

## 리뷰 요청사항
`/config/CustomerLogoutHandler`, `/jwt/service/JwtService` 코드를 집중적으로 봐주시면 될 거 같습니당
그리고 로그아웃 이후에 클라이언트 측에서도 쿠키/로컬스토리지에서 토큰 제거해주는게 필요해서 참고해주면 좋겠습니다!