### PR TITLE
[FU-199] 신청서 리스트뷰 조회 API 보완

### DIFF
--- a/src/main/java/com/foru/freebe/constants/SortConstants.java
+++ b/src/main/java/com/foru/freebe/constants/SortConstants.java
@@ -1,0 +1,7 @@
+package com.foru.freebe.constants;
+
+public final class SortConstants {
+    public static final int LESS_THAN = -1;
+    public static final int EQUAL = 0;
+    public static final int GREATER_THAN = 1;
+}

--- a/src/main/java/com/foru/freebe/reservation/dto/FormComponent.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/FormComponent.java
@@ -1,5 +1,7 @@
 package com.foru.freebe.reservation.dto;
 
+import java.time.LocalDate;
+
 import com.foru.freebe.reservation.entity.ReservationStatus;
 
 import lombok.AllArgsConstructor;
@@ -9,6 +11,7 @@ import lombok.Getter;
 @Getter
 public class FormComponent {
     private Long reservationId;
+    private LocalDate reservationSubmissionDate;
     private ReservationStatus reservationStatus;
     private String customerName;
     private String productTitle;

--- a/src/main/java/com/foru/freebe/reservation/dto/FormComponent.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/FormComponent.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class FormComponent {
+    private Long reservationId;
     private ReservationStatus reservationStatus;
     private String customerName;
     private String productTitle;

--- a/src/main/java/com/foru/freebe/reservation/entity/ReservationForm.java
+++ b/src/main/java/com/foru/freebe/reservation/entity/ReservationForm.java
@@ -78,6 +78,10 @@ public class ReservationForm extends BaseEntity {
     private Map<Integer, PreferredDate> preferredDate;
 
     @Type(JsonType.class)
+    @Column(name = "shooting_date", columnDefinition = "longtext")
+    private PreferredDate shootingDate;
+
+    @Type(JsonType.class)
     @Column(name = "photo_option", columnDefinition = "longtext")
     private Map<Integer, PhotoOption> photoOption;
 

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
@@ -71,6 +71,31 @@ public class PhotographerReservationService {
             .orElseGet(ArrayList::new);
 
         Map<ReservationStatus, List<FormComponent>> reservationStatusMap = groupingFormAsStatus(formList);
+        reservationStatusMap.forEach((status, formComponents) -> {
+            formComponents.sort((fc1, fc2) -> {
+                if (fc1.getReservationStatus() == ReservationStatus.NEW
+                    && fc2.getReservationStatus() == ReservationStatus.NEW) {
+                    return fc2.getReservationId().compareTo(fc1.getReservationId());
+                } else if (fc1.getReservationStatus() == ReservationStatus.IN_PROGRESS
+                    && fc2.getReservationStatus() == ReservationStatus.IN_PROGRESS) {
+                    return fc2.getReservationId().compareTo(fc1.getReservationId());
+                } else {
+                    if (fc1.getShootingDate() != null && fc2.getShootingDate() != null) {
+                        int dateComparison = fc1.getShootingDate().getDate().compareTo(fc2.getShootingDate().getDate());
+                        if (dateComparison != 0) {
+                            return dateComparison; // 날짜가 다르면 날짜로 정렬
+                        }
+                        // 날짜가 같은 경우, 시작 시간 비교
+                        return fc1.getShootingDate().getStartTime().compareTo(fc2.getShootingDate().getStartTime());
+                    } else if (fc1.getShootingDate() != null) {
+                        return -1; // fc1은 날짜가 있지만 fc2는 없는 경우 fc1이 우선
+                    } else if (fc2.getShootingDate() != null) {
+                        return 1; // fc2는 날짜가 있지만 fc1은 없는 경우 fc2가 우선
+                    }
+                    return 0; // 둘 다 null인 경우 정렬 순서 없음
+                }
+            });
+        });
 
         return reservationStatusMap.entrySet().stream()
             .map(entry -> new FormListViewResponse(entry.getKey(), entry.getValue()))
@@ -90,9 +115,7 @@ public class PhotographerReservationService {
             reservationForm.getReservationStatus(),
             reservationForm.getCustomer().getName(),
             reservationForm.getProductTitle(),
-            reservationForm.getReservationStatus() == ReservationStatus.NEW ? null :
-                reservationForm.getPreferredDate().values().stream().findFirst().orElse(null)
-            //ToDo: 임의로 희망 촬영일정의 첫번째 값을 반환하였음. 추후 신청서 상태 변경 로직이 추가되면 확정된 촬영일자로 변경해주어야 함
+            reservationForm.getShootingDate() == null ? null : reservationForm.getShootingDate()
         );
     }
 

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
 import com.foru.freebe.common.dto.ApiResponse;
+import com.foru.freebe.constants.SortConstants;
 import com.foru.freebe.errors.errorcode.CommonErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
 import com.foru.freebe.reservation.dto.CustomerDetails;
@@ -88,16 +89,16 @@ public class PhotographerReservationService {
             formComponents.sort((fc1, fc2) -> {
                 if (fc1.getShootingDate() != null && fc2.getShootingDate() != null) {
                     int dateComparison = fc1.getShootingDate().getDate().compareTo(fc2.getShootingDate().getDate());
-                    if (dateComparison != 0) {
-                        return dateComparison; // 날짜로 정렬
+                    if (dateComparison == SortConstants.EQUAL) {
+                        return fc1.getShootingDate().getStartTime().compareTo(fc2.getShootingDate().getStartTime());
                     }
-                    return fc1.getShootingDate().getStartTime().compareTo(fc2.getShootingDate().getStartTime());
+                    return dateComparison;
                 } else if (fc1.getShootingDate() != null) {
-                    return -1; // fc1은 날짜가 있지만 fc2는 없는 경우 fc1이 우선
+                    return SortConstants.LESS_THAN;
                 } else if (fc2.getShootingDate() != null) {
-                    return 1; // fc2는 날짜가 있지만 fc1은 없는 경우 fc2가 우선
+                    return SortConstants.GREATER_THAN;
                 }
-                return 0;
+                return SortConstants.EQUAL;
             });
             return formComponents;
         }

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
@@ -114,6 +114,7 @@ public class PhotographerReservationService {
     private FormComponent toFormComponent(ReservationForm reservationForm) {
         return new FormComponent(
             reservationForm.getId(),
+            reservationForm.getCreatedAt().toLocalDate(),
             reservationForm.getReservationStatus(),
             reservationForm.getCustomer().getName(),
             reservationForm.getProductTitle(),

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
@@ -86,6 +86,7 @@ public class PhotographerReservationService {
 
     private FormComponent toFormComponent(ReservationForm reservationForm) {
         return new FormComponent(
+            reservationForm.getId(),
             reservationForm.getReservationStatus(),
             reservationForm.getCustomer().getName(),
             reservationForm.getProductTitle(),


### PR DESCRIPTION
## 체크리스트

- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
- 신청서 리스트뷰 조회 시, 각 신청서 컴포넌트마다 `reservationID`도 함께 반환하여 이후 신청서상세보기 페이지와 연결이 가능하도록 수정
- 신청서 리스트뷰 조회 시, 신청서 상태 별로 정렬이 이뤄진 상태에서 응답하도록 수정
```
{
    "status": 200,
    "message": "Successfully get reservation list",
    "data": [
        {
            "reservationStatus": "WAITING_FOR_PHOTO",
            "formComponent": [
                {
                    "reservationId": 17,
                    "reservationSubmissionDate": "2024-09-04",
                    "reservationStatus": "WAITING_FOR_PHOTO",
                    "customerName": "이유리",
                    "productTitle": "웨딩스냅1",
                    "shootingDate": {
                        "date": "2024-08-30",
                        "startTime": "15:00:00",
                        "endTime": "17:00:00"
                    }
                },
                {
                    "reservationId": 18,
                    "reservationSubmissionDate": "2024-09-04",
                    "reservationStatus": "WAITING_FOR_PHOTO",
                    "customerName": "이유리",
                    "productTitle": "웨딩스냅1",
                    "shootingDate": {
                        "date": "2024-09-01",
                        "startTime": "14:00:00",
                        "endTime": "17:00:00"
                    }
                },
                {
                    "reservationId": 14,
                    "reservationSubmissionDate": "2024-09-04",
                    "reservationStatus": "WAITING_FOR_PHOTO",
                    "customerName": "이유리",
                    "productTitle": "웨딩스냅1",
                    "shootingDate": {
                        "date": "2024-09-01",
                        "startTime": "15:00:00",
                        "endTime": "17:00:00"
                    }
                },
                {
                    "reservationId": 16,
                    "reservationSubmissionDate": "2024-09-04",
                    "reservationStatus": "WAITING_FOR_PHOTO",
                    "customerName": "이유리",
                    "productTitle": "웨딩스냅1",
                    "shootingDate": {
                        "date": "2024-09-03",
                        "startTime": "15:00:00",
                        "endTime": "17:00:00"
                    }
                }
            ]
        },
        {
            "reservationStatus": "NEW",
            "formComponent": [
                {
                    "reservationId": 21,
                    "reservationSubmissionDate": "2024-09-04",
                    "reservationStatus": "NEW",
                    "customerName": "이유리",
                    "productTitle": "웨딩스냅1",
                    "shootingDate": null
                },
                {
                    "reservationId": 20,
                    "reservationSubmissionDate": "2024-09-04",
                    "reservationStatus": "NEW",
                    "customerName": "이유리",
                    "productTitle": "웨딩스냅1",
                    "shootingDate": null
                }
            ]
        }
    ]
}
```

## 고민한 사항
- `NEW`, `IN_PROGRESS`: 가장 최근에 들어온 신청서 기준으로 내림차순 정렬
- `WAITING_FOR_DEPOSIT`, `WAITING_FOR_PHOTO`: 확정 일정 기준으로 내림차순 정렬

## 리뷰 요청사항
figma 디자인 상에서는 `NEW`상태일때 오래된 신청서가 맨 위로 가도록 정렬해뒀는데, 오래된 신청서를 빨리 처리하게끔 유도하는 것보다 새로 들어온 신청서를 더 쉽게 확인할 수 있어야되는게 우선시되는 것 같아 위와 같은 정렬기준을 설정했습니다!
정렬 기준에 대한 다른 의견이 있다면 알려주세요 ~ :) 

## 시급도
(보통) 오늘 안에 리뷰되었으면 합니다-!