### PR TITLE
[FU-123] 신청서 상태변경 API

### DIFF
--- a/src/main/java/com/foru/freebe/auth/controller/AuthController.java
+++ b/src/main/java/com/foru/freebe/auth/controller/AuthController.java
@@ -40,6 +40,6 @@ public class AuthController {
         String accessToken = authService.getToken(loginRequest.getCode());
         KakaoUser kakaoUser = authService.getUserInfo(accessToken);
 
-        return memberService.findOrRegisterMember(kakaoUser, loginRequest.getRole());
+        return memberService.findOrRegisterMember(kakaoUser, loginRequest.getRoleType());
     }
 }

--- a/src/main/java/com/foru/freebe/auth/dto/LoginRequest.java
+++ b/src/main/java/com/foru/freebe/auth/dto/LoginRequest.java
@@ -7,9 +7,5 @@ import lombok.Getter;
 @Getter
 public class LoginRequest {
     private String code;
-    private String roleType;
-
-    public Role getRole() {
-        return Role.valueOf(roleType.toUpperCase());
-    }
+    private Role roleType;
 }

--- a/src/main/java/com/foru/freebe/member/entity/Role.java
+++ b/src/main/java/com/foru/freebe/member/entity/Role.java
@@ -1,5 +1,7 @@
 package com.foru.freebe.member.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -8,7 +10,9 @@ import lombok.Getter;
 public enum Role {
     ANONYMOUS,
     PHOTOGRAPHER_PENDING,
+    @JsonProperty("PHOTOGRAPHER")
     PHOTOGRAPHER,
+    @JsonProperty("CUSTOMER")
     CUSTOMER,
     ADMIN
 }

--- a/src/main/java/com/foru/freebe/reservation/controller/PhotographerReservationController.java
+++ b/src/main/java/com/foru/freebe/reservation/controller/PhotographerReservationController.java
@@ -13,6 +13,7 @@ import com.foru.freebe.common.dto.ApiResponse;
 import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.reservation.dto.FormDetailsViewResponse;
 import com.foru.freebe.reservation.dto.FormListViewResponse;
+import com.foru.freebe.reservation.service.PhotographerReservationDetails;
 import com.foru.freebe.reservation.service.PhotographerReservationService;
 
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/photographer")
 public class PhotographerReservationController {
     private final PhotographerReservationService photographerReservationService;
+    private final PhotographerReservationDetails photographerReservationDetails;
 
     @GetMapping("/reservation/list")
     public ApiResponse<List<FormListViewResponse>> getReservationList(
@@ -34,6 +36,6 @@ public class PhotographerReservationController {
     public ApiResponse<FormDetailsViewResponse> getReservationFormDetails(
         @AuthenticationPrincipal MemberAdapter memberAdapter, @PathVariable("formId") Long formId) {
         Member member = memberAdapter.getMember();
-        return photographerReservationService.getReservationFormDetails(member.getId(), formId);
+        return photographerReservationDetails.getReservationFormDetails(member.getId(), formId);
     }
 }

--- a/src/main/java/com/foru/freebe/reservation/controller/PhotographerReservationController.java
+++ b/src/main/java/com/foru/freebe/reservation/controller/PhotographerReservationController.java
@@ -5,6 +5,8 @@ import java.util.List;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -13,9 +15,11 @@ import com.foru.freebe.common.dto.ApiResponse;
 import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.reservation.dto.FormDetailsViewResponse;
 import com.foru.freebe.reservation.dto.FormListViewResponse;
+import com.foru.freebe.reservation.dto.ReservationStatusUpdateRequest;
 import com.foru.freebe.reservation.service.PhotographerReservationDetails;
 import com.foru.freebe.reservation.service.PhotographerReservationService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -28,6 +32,7 @@ public class PhotographerReservationController {
     @GetMapping("/reservation/list")
     public ApiResponse<List<FormListViewResponse>> getReservationList(
         @AuthenticationPrincipal MemberAdapter memberAdapter) {
+
         Member member = memberAdapter.getMember();
         return photographerReservationService.getReservationList(member.getId());
     }
@@ -35,7 +40,17 @@ public class PhotographerReservationController {
     @GetMapping("/reservation/details/{formId}")
     public ApiResponse<FormDetailsViewResponse> getReservationFormDetails(
         @AuthenticationPrincipal MemberAdapter memberAdapter, @PathVariable("formId") Long formId) {
+
         Member member = memberAdapter.getMember();
         return photographerReservationDetails.getReservationFormDetails(member.getId(), formId);
+    }
+
+    @PutMapping("/reservation/details/{formId}")
+    public ApiResponse<Void> updateReservationFormDetails(
+        @AuthenticationPrincipal MemberAdapter memberAdapter, @PathVariable("formId") Long formId,
+        @Valid @RequestBody ReservationStatusUpdateRequest request) {
+
+        Member member = memberAdapter.getMember();
+        return photographerReservationDetails.updateReservationStatus(member.getId(), formId, request);
     }
 }

--- a/src/main/java/com/foru/freebe/reservation/dto/FormDetailsViewResponse.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/FormDetailsViewResponse.java
@@ -18,27 +18,31 @@ public class FormDetailsViewResponse {
     private String productTitle;
     private CustomerDetails customerDetails;
     private Map<String, String> photoInfo;
+    private Map<Integer, PhotoOption> photoOptions;
     private Map<Integer, PreferredDate> preferredDates;
     private List<String> originalImage;
     private List<String> thumbnailImage;
     private String requestMemo;
+    private String photographerMemo;
 
     @Builder
     public FormDetailsViewResponse(Long reservationNumber, ReservationStatus currentReservationStatus,
         List<StatusHistory> statusHistory, String productTitle, CustomerDetails customerDetails,
-        Map<String, String> photoInfo, Map<Integer, PreferredDate> preferredDates, List<String> originalImage,
-        List<String> thumbnailImage,
-        String requestMemo) {
+        Map<String, String> photoInfo, Map<Integer, PhotoOption> photoOptions,
+        Map<Integer, PreferredDate> preferredDates, List<String> originalImage,
+        List<String> thumbnailImage, String requestMemo, String photographerMemo) {
         this.reservationNumber = reservationNumber;
         this.currentReservationStatus = currentReservationStatus;
         this.statusHistory = statusHistory;
         this.productTitle = productTitle;
         this.customerDetails = customerDetails;
         this.photoInfo = photoInfo;
+        this.photoOptions = photoOptions;
         this.preferredDates = preferredDates;
         this.originalImage = originalImage;
         this.thumbnailImage = thumbnailImage;
         this.requestMemo = requestMemo;
+        this.photographerMemo = photographerMemo;
     }
 
     public static FormDetailsViewResponseBuilder builder(Long reservationNumber,

--- a/src/main/java/com/foru/freebe/reservation/dto/ReservationStatusUpdateRequest.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/ReservationStatusUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.foru.freebe.reservation.dto;
+
+import com.foru.freebe.reservation.entity.ReservationStatus;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ReservationStatusUpdateRequest {
+    @NotNull
+    private ReservationStatus updateStatus;
+
+    private String cancellationReason;
+}

--- a/src/main/java/com/foru/freebe/reservation/entity/ReservationForm.java
+++ b/src/main/java/com/foru/freebe/reservation/entity/ReservationForm.java
@@ -89,6 +89,10 @@ public class ReservationForm extends BaseEntity {
 
     private String photographerMemo;
 
+    public void updateReservationStatus(ReservationStatus updateStatus) {
+        this.reservationStatus = updateStatus;
+    }
+
     @Builder
     public ReservationForm(Member photographer, Member customer, String instagramId, String productTitle,
         Long totalPrice, Boolean serviceTermAgreement, Boolean photographerTermAgreement,

--- a/src/main/java/com/foru/freebe/reservation/entity/ReservationHistory.java
+++ b/src/main/java/com/foru/freebe/reservation/entity/ReservationHistory.java
@@ -36,6 +36,8 @@ public class ReservationHistory {
     @NotNull(message = "Reservation Status must not be null")
     private ReservationStatus reservationStatus;
 
+    private String cancellationReason;
+
     @CreationTimestamp
     private LocalDateTime statusUpdateDate;
 
@@ -44,8 +46,20 @@ public class ReservationHistory {
         this.reservationStatus = reservationStatus;
     }
 
+    private ReservationHistory(ReservationForm reservationForm, ReservationStatus reservationStatus,
+        String cancellationReason) {
+        this.reservationForm = reservationForm;
+        this.reservationStatus = reservationStatus;
+        this.cancellationReason = cancellationReason;
+    }
+
     public static ReservationHistory createReservationHistory(ReservationForm reservationForm,
         ReservationStatus reservationStatus) {
         return new ReservationHistory(reservationForm, reservationStatus);
+    }
+
+    public static ReservationHistory createCancelledReservationHistory(ReservationForm reservationForm,
+        ReservationStatus reservationStatus, String cancellationReason) {
+        return new ReservationHistory(reservationForm, reservationStatus, cancellationReason);
     }
 }

--- a/src/main/java/com/foru/freebe/reservation/entity/ReservationHistory.java
+++ b/src/main/java/com/foru/freebe/reservation/entity/ReservationHistory.java
@@ -1,6 +1,6 @@
 package com.foru.freebe.reservation.entity;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import org.hibernate.annotations.CreationTimestamp;
 
@@ -37,14 +37,14 @@ public class ReservationHistory {
     private ReservationStatus reservationStatus;
 
     @CreationTimestamp
-    private LocalDate statusUpdateDate;
+    private LocalDateTime statusUpdateDate;
 
     private ReservationHistory(ReservationForm reservationForm, ReservationStatus reservationStatus) {
         this.reservationForm = reservationForm;
         this.reservationStatus = reservationStatus;
     }
 
-    public static ReservationHistory updateReservationStatus(ReservationForm reservationForm,
+    public static ReservationHistory createReservationHistory(ReservationForm reservationForm,
         ReservationStatus reservationStatus) {
         return new ReservationHistory(reservationForm, reservationStatus);
     }

--- a/src/main/java/com/foru/freebe/reservation/entity/ReservationStatus.java
+++ b/src/main/java/com/foru/freebe/reservation/entity/ReservationStatus.java
@@ -1,8 +1,23 @@
 package com.foru.freebe.reservation.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public enum ReservationStatus {
+    @JsonProperty("NEW")
     NEW,
+
+    @JsonProperty("IN_PROGRESS")
     IN_PROGRESS,
+
+    @JsonProperty("WAITING_FOR_DEPOSIT")
     WAITING_FOR_DEPOSIT,
-    WAITING_FOR_PHOTO
+
+    @JsonProperty("WAITING_FOR_PHOTO")
+    WAITING_FOR_PHOTO,
+
+    @JsonProperty("PHOTO_COMPLETED")
+    PHOTO_COMPLETED,
+
+    @JsonProperty("CANCELLED")
+    CANCELLED
 }

--- a/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
@@ -120,7 +120,7 @@ public class CustomerReservationService {
         ReservationForm newReservationForm = reservationFormRepository.save(reservationForm);
 
         reservationHistoryRepository.save(
-            ReservationHistory.updateReservationStatus(newReservationForm, ReservationStatus.NEW));
+            ReservationHistory.createReservationHistory(newReservationForm, ReservationStatus.NEW));
 
         IntStream.range(0, originalImageUrls.size()).forEach(i -> {
             ReferenceImage referenceImage = ReferenceImage.updateReferenceImage(

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationDetails.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationDetails.java
@@ -98,7 +98,7 @@ public class PhotographerReservationDetails {
                 throw new RestApiException(CommonErrorCode.INVALID_PARAMETER);
             }
         } else if (currentStatus == ReservationStatus.WAITING_FOR_DEPOSIT) {
-            if (updateStatus != ReservationStatus.WAITING_FOR_DEPOSIT && updateStatus != ReservationStatus.CANCELLED) {
+            if (updateStatus != ReservationStatus.WAITING_FOR_PHOTO && updateStatus != ReservationStatus.CANCELLED) {
                 throw new RestApiException(CommonErrorCode.INVALID_PARAMETER);
             }
         } else if (currentStatus == ReservationStatus.WAITING_FOR_PHOTO) {

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationDetails.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationDetails.java
@@ -1,0 +1,103 @@
+package com.foru.freebe.reservation.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.foru.freebe.common.dto.ApiResponse;
+import com.foru.freebe.errors.errorcode.CommonErrorCode;
+import com.foru.freebe.errors.exception.RestApiException;
+import com.foru.freebe.reservation.dto.CustomerDetails;
+import com.foru.freebe.reservation.dto.FormDetailsViewResponse;
+import com.foru.freebe.reservation.dto.PreferredDate;
+import com.foru.freebe.reservation.dto.ReferenceImageUrls;
+import com.foru.freebe.reservation.dto.StatusHistory;
+import com.foru.freebe.reservation.entity.ReferenceImage;
+import com.foru.freebe.reservation.entity.ReservationForm;
+import com.foru.freebe.reservation.entity.ReservationHistory;
+import com.foru.freebe.reservation.repository.ReferenceImageRepository;
+import com.foru.freebe.reservation.repository.ReservationFormRepository;
+import com.foru.freebe.reservation.repository.ReservationHistoryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PhotographerReservationDetails {
+    private final ReservationFormRepository reservationFormRepository;
+    private final ReservationHistoryRepository reservationHistoryRepository;
+    private final ReferenceImageRepository referenceImageRepository;
+
+    public ApiResponse<FormDetailsViewResponse> getReservationFormDetails(Long photographerId, Long formId) {
+        ReservationForm reservationForm = findReservationForm(photographerId, formId);
+        List<StatusHistory> statusHistories = getStatusHistories(reservationForm);
+
+        CustomerDetails customerDetails = buildCustomerDetails(reservationForm);
+        Map<String, String> shootDetails = reservationForm.getPhotoInfo();
+        Map<Integer, PreferredDate> preferredDates = reservationForm.getPreferredDate();
+        ReferenceImageUrls preferredImages = getPreferredImages(reservationForm);
+
+        FormDetailsViewResponse formDetailsViewResponse = FormDetailsViewResponse.builder(reservationForm.getId(),
+                reservationForm.getReservationStatus(), statusHistories, reservationForm.getProductTitle(), customerDetails,
+                shootDetails, preferredDates)
+            .photoOptions(reservationForm.getPhotoOption())
+            .originalImage(preferredImages.getOriginalImage())
+            .thumbnailImage(preferredImages.getThumbnailImage())
+            .requestMemo(reservationForm.getCustomerMemo())
+            .photographerMemo(reservationForm.getPhotographerMemo())
+            .build();
+
+        return ApiResponse.<FormDetailsViewResponse>builder()
+            .message("Successfully get reservation list")
+            .status(200)
+            .data(formDetailsViewResponse)
+            .build();
+    }
+
+    private ReservationForm findReservationForm(Long photographerId, Long formId) {
+        return reservationFormRepository.findByPhotographerIdAndId(photographerId, formId)
+            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+    }
+
+    private List<StatusHistory> getStatusHistories(ReservationForm reservationForm) {
+        return reservationHistoryRepository.findAllByReservationForm(reservationForm)
+            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND))
+            .stream()
+            .map(this::toStatusHistory)
+            .collect(Collectors.toList());
+    }
+
+    private StatusHistory toStatusHistory(ReservationHistory reservationHistory) {
+        return StatusHistory.builder()
+            .reservationStatus(reservationHistory.getReservationStatus())
+            .statusUpdateDate(reservationHistory.getStatusUpdateDate())
+            .build();
+    }
+
+    private CustomerDetails buildCustomerDetails(ReservationForm reservationForm) {
+        return CustomerDetails.builder()
+            .name(reservationForm.getCustomer().getName())
+            .phoneNumber(reservationForm.getCustomer().getPhoneNumber())
+            .instagramId(reservationForm.getInstagramId())
+            .build();
+    }
+
+    private ReferenceImageUrls getPreferredImages(ReservationForm reservationForm) {
+        List<ReferenceImage> referenceImages = referenceImageRepository.findAllByReservationForm(reservationForm);
+
+        List<String> originalImageUrls = referenceImages.stream()
+            .map(ReferenceImage::getOriginUrl)
+            .collect(Collectors.toList());
+
+        List<String> thumbnailImageUrls = referenceImages.stream()
+            .map(ReferenceImage::getThumbnailUrl)
+            .collect(Collectors.toList());
+
+        return ReferenceImageUrls.builder()
+            .originalImage(originalImageUrls)
+            .thumbnailImage(thumbnailImageUrls)
+            .build();
+    }
+}

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationDetails.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationDetails.java
@@ -67,8 +67,7 @@ public class PhotographerReservationDetails {
         validateStatusChange(reservationForm.getReservationStatus(), request.getUpdateStatus());
 
         reservationForm.updateReservationStatus(request.getUpdateStatus());
-        ReservationHistory history = ReservationHistory.createReservationHistory(reservationForm,
-            request.getUpdateStatus());
+        ReservationHistory history = getReservationHistory(request, reservationForm);
 
         reservationFormRepository.save(reservationForm);
         reservationHistoryRepository.save(history);
@@ -77,6 +76,16 @@ public class PhotographerReservationDetails {
             .message("Successfully update reservation status")
             .status(200)
             .build();
+    }
+
+    private ReservationHistory getReservationHistory(ReservationStatusUpdateRequest request,
+        ReservationForm reservationForm) {
+        if (request.getCancellationReason() != null) {
+            return ReservationHistory.createCancelledReservationHistory(reservationForm, request.getUpdateStatus(),
+                request.getCancellationReason());
+        } else {
+            return ReservationHistory.createReservationHistory(reservationForm, request.getUpdateStatus());
+        }
     }
 
     private void validateStatusChange(ReservationStatus currentStatus, ReservationStatus updateStatus) {

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
@@ -58,9 +58,11 @@ public class PhotographerReservationService {
         FormDetailsViewResponse formDetailsViewResponse = FormDetailsViewResponse.builder(reservationForm.getId(),
                 reservationForm.getReservationStatus(), statusHistories, reservationForm.getProductTitle(), customerDetails,
                 shootDetails, preferredDates)
+            .photoOptions(reservationForm.getPhotoOption())
             .originalImage(preferredImages.getOriginalImage())
             .thumbnailImage(preferredImages.getThumbnailImage())
             .requestMemo(reservationForm.getCustomerMemo())
+            .photographerMemo(reservationForm.getPhotographerMemo())
             .build();
 
         return ApiResponse.<FormDetailsViewResponse>builder()

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
@@ -10,22 +10,11 @@ import org.springframework.stereotype.Service;
 
 import com.foru.freebe.common.dto.ApiResponse;
 import com.foru.freebe.constants.SortConstants;
-import com.foru.freebe.errors.errorcode.CommonErrorCode;
-import com.foru.freebe.errors.exception.RestApiException;
-import com.foru.freebe.reservation.dto.CustomerDetails;
 import com.foru.freebe.reservation.dto.FormComponent;
-import com.foru.freebe.reservation.dto.FormDetailsViewResponse;
 import com.foru.freebe.reservation.dto.FormListViewResponse;
-import com.foru.freebe.reservation.dto.PreferredDate;
-import com.foru.freebe.reservation.dto.ReferenceImageUrls;
-import com.foru.freebe.reservation.dto.StatusHistory;
-import com.foru.freebe.reservation.entity.ReferenceImage;
 import com.foru.freebe.reservation.entity.ReservationForm;
-import com.foru.freebe.reservation.entity.ReservationHistory;
 import com.foru.freebe.reservation.entity.ReservationStatus;
-import com.foru.freebe.reservation.repository.ReferenceImageRepository;
 import com.foru.freebe.reservation.repository.ReservationFormRepository;
-import com.foru.freebe.reservation.repository.ReservationHistoryRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -33,8 +22,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PhotographerReservationService {
     private final ReservationFormRepository reservationFormRepository;
-    private final ReservationHistoryRepository reservationHistoryRepository;
-    private final ReferenceImageRepository referenceImageRepository;
 
     public ApiResponse<List<FormListViewResponse>> getReservationList(Long photographerId) {
         List<FormListViewResponse> data = getReservationListAsStatus(photographerId);
@@ -43,32 +30,6 @@ public class PhotographerReservationService {
             .message("Successfully get reservation list")
             .status(200)
             .data(data)
-            .build();
-    }
-
-    public ApiResponse<FormDetailsViewResponse> getReservationFormDetails(Long photographerId, Long formId) {
-        ReservationForm reservationForm = findReservationForm(photographerId, formId);
-        List<StatusHistory> statusHistories = getStatusHistories(reservationForm);
-
-        CustomerDetails customerDetails = buildCustomerDetails(reservationForm);
-        Map<String, String> shootDetails = reservationForm.getPhotoInfo();
-        Map<Integer, PreferredDate> preferredDates = reservationForm.getPreferredDate();
-        ReferenceImageUrls preferredImages = getPreferredImages(reservationForm);
-
-        FormDetailsViewResponse formDetailsViewResponse = FormDetailsViewResponse.builder(reservationForm.getId(),
-                reservationForm.getReservationStatus(), statusHistories, reservationForm.getProductTitle(), customerDetails,
-                shootDetails, preferredDates)
-            .photoOptions(reservationForm.getPhotoOption())
-            .originalImage(preferredImages.getOriginalImage())
-            .thumbnailImage(preferredImages.getThumbnailImage())
-            .requestMemo(reservationForm.getCustomerMemo())
-            .photographerMemo(reservationForm.getPhotographerMemo())
-            .build();
-
-        return ApiResponse.<FormDetailsViewResponse>builder()
-            .message("Successfully get reservation list")
-            .status(200)
-            .data(formDetailsViewResponse)
             .build();
     }
 
@@ -124,50 +85,5 @@ public class PhotographerReservationService {
             reservationForm.getProductTitle(),
             reservationForm.getShootingDate() == null ? null : reservationForm.getShootingDate()
         );
-    }
-
-    private ReservationForm findReservationForm(Long photographerId, Long formId) {
-        return reservationFormRepository.findByPhotographerIdAndId(photographerId, formId)
-            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
-    }
-
-    private List<StatusHistory> getStatusHistories(ReservationForm reservationForm) {
-        return reservationHistoryRepository.findAllByReservationForm(reservationForm)
-            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND))
-            .stream()
-            .map(this::toStatusHistory)
-            .collect(Collectors.toList());
-    }
-
-    private StatusHistory toStatusHistory(ReservationHistory reservationHistory) {
-        return StatusHistory.builder()
-            .reservationStatus(reservationHistory.getReservationStatus())
-            .statusUpdateDate(reservationHistory.getStatusUpdateDate())
-            .build();
-    }
-
-    private CustomerDetails buildCustomerDetails(ReservationForm reservationForm) {
-        return CustomerDetails.builder()
-            .name(reservationForm.getCustomer().getName())
-            .phoneNumber(reservationForm.getCustomer().getPhoneNumber())
-            .instagramId(reservationForm.getInstagramId())
-            .build();
-    }
-
-    private ReferenceImageUrls getPreferredImages(ReservationForm reservationForm) {
-        List<ReferenceImage> referenceImages = referenceImageRepository.findAllByReservationForm(reservationForm);
-
-        List<String> originalImageUrls = referenceImages.stream()
-            .map(ReferenceImage::getOriginUrl)
-            .collect(Collectors.toList());
-
-        List<String> thumbnailImageUrls = referenceImages.stream()
-            .map(ReferenceImage::getThumbnailUrl)
-            .collect(Collectors.toList());
-
-        return ReferenceImageUrls.builder()
-            .originalImage(originalImageUrls)
-            .thumbnailImage(thumbnailImageUrls)
-            .build();
     }
 }

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
@@ -45,6 +45,29 @@ public class PhotographerReservationService {
             .collect(Collectors.toList());
     }
 
+    private Map<ReservationStatus, List<FormComponent>> groupingFormAsStatus(
+        List<ReservationForm> reservationFormList) {
+        return reservationFormList.stream()
+            .map(this::toFormComponent)
+            .filter(form -> isPublicStatus(form.getReservationStatus()))
+            .collect(Collectors.groupingBy(FormComponent::getReservationStatus, Collectors.toList()));
+    }
+
+    private boolean isPublicStatus(ReservationStatus status) {
+        return status != ReservationStatus.PHOTO_COMPLETED && status != ReservationStatus.CANCELLED;
+    }
+
+    private FormComponent toFormComponent(ReservationForm reservationForm) {
+        return new FormComponent(
+            reservationForm.getId(),
+            reservationForm.getCreatedAt().toLocalDate(),
+            reservationForm.getReservationStatus(),
+            reservationForm.getCustomer().getName(),
+            reservationForm.getProductTitle(),
+            reservationForm.getShootingDate() == null ? null : reservationForm.getShootingDate()
+        );
+    }
+
     private List<FormComponent> sortFormComponents(ReservationStatus status, List<FormComponent> formComponents) {
         if (status == ReservationStatus.NEW || status == ReservationStatus.IN_PROGRESS) {
             return formComponents.stream()
@@ -67,23 +90,5 @@ public class PhotographerReservationService {
             });
             return formComponents;
         }
-    }
-
-    private Map<ReservationStatus, List<FormComponent>> groupingFormAsStatus(
-        List<ReservationForm> reservationFormList) {
-        return reservationFormList.stream()
-            .map(this::toFormComponent)
-            .collect(Collectors.groupingBy(FormComponent::getReservationStatus, Collectors.toList()));
-    }
-
-    private FormComponent toFormComponent(ReservationForm reservationForm) {
-        return new FormComponent(
-            reservationForm.getId(),
-            reservationForm.getCreatedAt().toLocalDate(),
-            reservationForm.getReservationStatus(),
-            reservationForm.getCustomer().getName(),
-            reservationForm.getProductTitle(),
-            reservationForm.getShootingDate() == null ? null : reservationForm.getShootingDate()
-        );
     }
 }


### PR DESCRIPTION
## 체크리스트

- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
1.  신청서 상태를 변경하기 위한 API 개발
- NEW -> IN_PROGRESS, CANCELLED
- IN_PROGRESS -> WAITING_FOR_DEPOSIT, CANCELLED
- WAITING_FOR_DEPOSIT -> WAITING_FOR_PHOTO, CANCELLED
- WAITING_FOR_PHOTO -> PHOTO_COMPLETED, CANCELLED


2. 사진작가측 신청서 상세보기 페이지 조회 API 보완
-> 신청서 상세조회 시, 사진작가측 메모와 고객이 선택한 옵션 정보를 response body에 포함하였음

## 고민한 사항
새 신청, 상담 중, 입금 대기, 촬영 대기 각각의 상태마다 다음 상태로 넘어가기 위한 로직과 신청서를 드롭할 수 있는 로직의 구현이 필요했습니다. 이때 신청서를 드롭할 수 있는 모든 케이스를 고려하여 `REJECTED`, `FAILED_CONSULTATION`, `DEPOSIT_NOT_RECEIVED`, `NO_SHOW` 등의 상태 변경을 위한 버튼이 모두 필요한지에 대한 고민이 있었는데, 실제 유저 피드백에 따라 상태가 추가/변경될 경우 UI도 함께 수정되어야 하는 불편함이 있을 것이라 생각되었습니다. 따라서 모든 신청서 상태마다 확인/취소 버튼 두개만을 가지고, 신청서 취소를 할때는 취소 사유를 유저가 직접 기입할 수 있도록 해서 이후의 확장성, 변동가능성을 열어두는 방식을 선택했습니다! (같이 의논해줘서 고마워 😇) 

## 리뷰 요청사항
- 시급도 높음: 다른 개발티켓과의 결합도가 높지 않지만, 이번 스프린트 안에는 머지되어야 해서 시급도 높음입니다 .. 🤣

- 취소된 신청서를 다시 new, in_progress, waiting_for_deposit, waiting_for_photo 등의 상태로 바꿀 수 있는지에 대한 논의가 필요합니다! 현재는 취소 상태에서 위 네가지 상태로 변경하는게 가능하게끔 구현되어있는데 논의된 내용에 따라서 추가 로직 구현 예정입니당.

- @eujin-shin  
신청서 상세보기 페이지 상단의 상태바 업데이트가 필요한데 검토해주세요!! 지난 예약/취소된 예약건을 조회한 뒤 신청서 상세보기 페이지로 접근하는 루트도 있을 것 같아서 [촬영 완료], [취소] 등의 상태도 나타낼 수 있어야 할 것 같습니당 🤗
<img width="357" alt="image" src="https://github.com/user-attachments/assets/18309579-e83a-4c4e-9e0a-794e84a589f0">