### PR TITLE
[FU-202] DTO 필드 유효성 검증 적용

### DIFF
--- a/src/main/java/com/foru/freebe/auth/dto/LoginRequest.java
+++ b/src/main/java/com/foru/freebe/auth/dto/LoginRequest.java
@@ -2,10 +2,15 @@ package com.foru.freebe.auth.dto;
 
 import com.foru.freebe.member.entity.Role;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
 public class LoginRequest {
+    @NotBlank
     private String code;
+
+    @NotNull
     private Role roleType;
 }

--- a/src/main/java/com/foru/freebe/auth/model/KakaoUser.java
+++ b/src/main/java/com/foru/freebe/auth/model/KakaoUser.java
@@ -13,8 +13,10 @@ import lombok.NoArgsConstructor;
 public class KakaoUser {
     @JsonProperty("id")
     private Long kakaoId;
+
     @JsonProperty("connected_at")
     private LocalDateTime connectedAt;
+
     @JsonProperty("kakao_account")
     private Map<String, Object> kakaoAccount;
 

--- a/src/main/java/com/foru/freebe/errors/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/foru/freebe/errors/handler/GlobalExceptionHandler.java
@@ -21,8 +21,6 @@ import com.foru.freebe.errors.response.ErrorResponse;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
-
-    // 우리가 직접 커스텀한 에러 API
     @ExceptionHandler(RestApiException.class)
     public ResponseEntity<Object> handleCustomException(RestApiException e) {
         return handleExceptionInternal(e.getErrorCode());
@@ -33,7 +31,6 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return handleExceptionInternal(e.getErrorCode());
     }
 
-    // 메서드 인자 타입 예외 처리
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Object> handleIllegalArgument(IllegalArgumentException e) {
         ErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
@@ -43,11 +40,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     // 메서드 인자의 유효성 검사가 실패했을 때 발생
     // 주로 Spring의 @Valid, @Validated 애노테이션을 사용한 검증 실패시 발생
     @Override
-    public ResponseEntity<Object> handleMethodArgumentNotValid(
-        MethodArgumentNotValidException e,
-        HttpHeaders headers,
-        HttpStatusCode status,
-        WebRequest request) {
+    public ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e, HttpHeaders headers,
+        HttpStatusCode status, WebRequest request) {
         ErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
         return handleExceptionInternal(e, errorCode);
     }

--- a/src/main/java/com/foru/freebe/errors/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/foru/freebe/errors/handler/GlobalExceptionHandler.java
@@ -49,12 +49,31 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler({Exception.class})
     public ResponseEntity<Object> handleAllException(Exception ex) {
         ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
-        return handleExceptionInternal(errorCode);
+        return handleExceptionInternal(ex, errorCode);
     }
 
     private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode) {
-        return ResponseEntity.status(errorCode.getHttpStatus())
+        return ResponseEntity
+            .status(errorCode.getHttpStatus())
             .body(makeErrorResponse(errorCode));
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode, String message) {
+        return ResponseEntity
+            .status(errorCode.getHttpStatus())
+            .body(makeErrorResponse(errorCode, message));
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(BindException e, ErrorCode errorCode) {
+        return ResponseEntity
+            .status(errorCode.getHttpStatus())
+            .body(makeErrorResponse(e, errorCode));
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorCode errorCode) {
+        return ResponseEntity
+            .status(errorCode.getHttpStatus())
+            .body(makeErrorResponse(errorCode, e.getMessage()));
     }
 
     private ErrorResponse makeErrorResponse(ErrorCode errorCode) {
@@ -64,21 +83,11 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             .build();
     }
 
-    private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode, String message) {
-        return ResponseEntity.status(errorCode.getHttpStatus())
-            .body(makeErrorResponse(errorCode, message));
-    }
-
     private ErrorResponse makeErrorResponse(ErrorCode errorCode, String message) {
         return ErrorResponse.builder()
             .code(errorCode.name())
             .message(message)
             .build();
-    }
-
-    private ResponseEntity<Object> handleExceptionInternal(BindException e, ErrorCode errorCode) {
-        return ResponseEntity.status(errorCode.getHttpStatus())
-            .body(makeErrorResponse(e, errorCode));
     }
 
     private ErrorResponse makeErrorResponse(BindException e, ErrorCode errorCode) {

--- a/src/main/java/com/foru/freebe/member/entity/Member.java
+++ b/src/main/java/com/foru/freebe/member/entity/Member.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -34,13 +35,13 @@ public class Member extends BaseEntity {
     @Column(length = 20, nullable = false)
     private Role role;
 
-    @NotNull
+    @NotBlank
     private String name;
 
-    @NotNull
+    @NotBlank
     private String email;
 
-    @NotNull
+    @NotBlank
     private String phoneNumber;
 
     private Integer birthYear;

--- a/src/main/java/com/foru/freebe/product/controller/PhotographerProductController.java
+++ b/src/main/java/com/foru/freebe/product/controller/PhotographerProductController.java
@@ -42,7 +42,7 @@ public class PhotographerProductController {
     public ApiResponse<List<RegisteredProductResponse>> getRegisteredProductList(
         @AuthenticationPrincipal MemberAdapter memberAdapter) {
         Member photographer = memberAdapter.getMember();
-        return productService.getRegisteredProductList(photographer.getId());
+        return productService.getRegisteredProductList(photographer);
     }
 
     @PutMapping("/product/status")

--- a/src/main/java/com/foru/freebe/product/dto/customer/ProductDetailResponse.java
+++ b/src/main/java/com/foru/freebe/product/dto/customer/ProductDetailResponse.java
@@ -6,6 +6,7 @@ import com.foru.freebe.product.dto.photographer.ProductComponentDto;
 import com.foru.freebe.product.dto.photographer.ProductDiscountDto;
 import com.foru.freebe.product.dto.photographer.ProductOptionDto;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,14 +15,19 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class ProductDetailResponse {
-    @NotNull
+    @NotBlank
     private String productTitle;
+
     private String productDescription;
+
     @NotNull
     private List<String> productImageUrls;
+
     @NotNull
     private List<ProductComponentDto> productComponents;
+
     private List<ProductOptionDto> productOptions;
+
     private List<ProductDiscountDto> productDiscounts;
 
     @Builder

--- a/src/main/java/com/foru/freebe/product/dto/customer/ProductListResponse.java
+++ b/src/main/java/com/foru/freebe/product/dto/customer/ProductListResponse.java
@@ -1,5 +1,7 @@
 package com.foru.freebe.product.dto.customer;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,8 +9,13 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class ProductListResponse {
+    @NotNull
     private Long productId;
+
+    @NotBlank
     private String productTitle;
+
+    @NotBlank
     private String productRepresentativeImageUrl;
 
     @Builder

--- a/src/main/java/com/foru/freebe/product/dto/photographer/ProductComponentDto.java
+++ b/src/main/java/com/foru/freebe/product/dto/photographer/ProductComponentDto.java
@@ -1,6 +1,6 @@
 package com.foru.freebe.product.dto.photographer;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,10 +8,12 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class ProductComponentDto {
-    @NotNull
+    @NotBlank
     private String title;
-    @NotNull
+
+    @NotBlank
     private String content;
+
     private String description;
 
     @Builder

--- a/src/main/java/com/foru/freebe/product/dto/photographer/ProductComponentDto.java
+++ b/src/main/java/com/foru/freebe/product/dto/photographer/ProductComponentDto.java
@@ -1,6 +1,7 @@
 package com.foru.freebe.product.dto.photographer;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,11 +10,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ProductComponentDto {
     @NotBlank
+    @Size(max = 30, message = "Title cannot be longer than 30 characters")
     private String title;
 
     @NotBlank
+    @Size(max = 100, message = "Content cannot be longer than 100 characters")
     private String content;
 
+    @Size(max = 100, message = "Description cannot be longer than 100 characters")
     private String description;
 
     @Builder

--- a/src/main/java/com/foru/freebe/product/dto/photographer/ProductDiscountDto.java
+++ b/src/main/java/com/foru/freebe/product/dto/photographer/ProductDiscountDto.java
@@ -5,6 +5,7 @@ import com.foru.freebe.product.entity.DiscountType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,6 +14,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ProductDiscountDto {
     @NotBlank
+    @Size(max = 30, message = "Title cannot be longer than 30 characters")
     private String title;
 
     @NotNull
@@ -22,6 +24,7 @@ public class ProductDiscountDto {
     @Positive
     private Integer discountValue;
 
+    @Size(max = 100, message = "Description cannot be longer than 100 characters")
     private String description;
 
     @Builder

--- a/src/main/java/com/foru/freebe/product/dto/photographer/ProductDiscountDto.java
+++ b/src/main/java/com/foru/freebe/product/dto/photographer/ProductDiscountDto.java
@@ -2,8 +2,9 @@ package com.foru.freebe.product.dto.photographer;
 
 import com.foru.freebe.product.entity.DiscountType;
 
-import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,13 +12,16 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class ProductDiscountDto {
-    @NotNull
+    @NotBlank
     private String title;
+
     @NotNull
     private DiscountType discountType;
+
     @NotNull
-    @Min(value = 1, message = "상품 할인 값은 0보다 큰 자연수여야 합니다.")
+    @Positive
     private Integer discountValue;
+
     private String description;
 
     @Builder

--- a/src/main/java/com/foru/freebe/product/dto/photographer/ProductOptionDto.java
+++ b/src/main/java/com/foru/freebe/product/dto/photographer/ProductOptionDto.java
@@ -1,7 +1,7 @@
 package com.foru.freebe.product.dto.photographer;
 
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,9 +11,11 @@ import lombok.NoArgsConstructor;
 public class ProductOptionDto {
     @NotNull
     private String title;
+
     @NotNull
-    @Min(value = 1, message = "상품 옵션 가격은 0보다 큰 자연수여야 합니다.")
+    @Positive
     private Integer price;
+
     private String description;
 
     @Builder

--- a/src/main/java/com/foru/freebe/product/dto/photographer/ProductOptionDto.java
+++ b/src/main/java/com/foru/freebe/product/dto/photographer/ProductOptionDto.java
@@ -2,6 +2,7 @@ package com.foru.freebe.product.dto.photographer;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,12 +11,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ProductOptionDto {
     @NotNull
+    @Size(max = 30, message = "Title cannot be longer than 30 characters")
     private String title;
 
     @NotNull
     @Positive
     private Integer price;
 
+    @Size(max = 100, message = "Description cannot be longer than 100 characters")
     private String description;
 
     @Builder

--- a/src/main/java/com/foru/freebe/product/dto/photographer/ProductOptionDto.java
+++ b/src/main/java/com/foru/freebe/product/dto/photographer/ProductOptionDto.java
@@ -1,7 +1,7 @@
 package com.foru.freebe.product.dto.photographer;
 
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,7 +15,7 @@ public class ProductOptionDto {
     private String title;
 
     @NotNull
-    @Positive
+    @PositiveOrZero
     private Integer price;
 
     @Size(max = 100, message = "Description cannot be longer than 100 characters")

--- a/src/main/java/com/foru/freebe/product/dto/photographer/ProductRegisterRequest.java
+++ b/src/main/java/com/foru/freebe/product/dto/photographer/ProductRegisterRequest.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,8 +12,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ProductRegisterRequest {
     @NotBlank
+    @Size(max = 30, message = "Title cannot be longer than 30 characters")
     private String productTitle;
 
+    @Size(max = 100, message = "Description cannot be longer than 100 characters")
     private String productDescription;
 
     @NotNull

--- a/src/main/java/com/foru/freebe/product/dto/photographer/ProductRegisterRequest.java
+++ b/src/main/java/com/foru/freebe/product/dto/photographer/ProductRegisterRequest.java
@@ -2,6 +2,7 @@ package com.foru.freebe.product.dto.photographer;
 
 import java.util.List;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,11 +10,15 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class ProductRegisterRequest {
-    @NotNull
+    @NotBlank
     private String productTitle;
+
     private String productDescription;
+
     @NotNull
     private List<ProductComponentDto> productComponents;
+
     private List<ProductOptionDto> productOptions;
+
     private List<ProductDiscountDto> productDiscounts;
 }

--- a/src/main/java/com/foru/freebe/product/dto/photographer/RegisteredProductResponse.java
+++ b/src/main/java/com/foru/freebe/product/dto/photographer/RegisteredProductResponse.java
@@ -2,6 +2,9 @@ package com.foru.freebe.product.dto.photographer;
 
 import com.foru.freebe.product.entity.ActiveStatus;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,9 +12,16 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class RegisteredProductResponse {
+    @NotNull
     private Long productId;
+
+    @NotBlank
     private String productTitle;
+
+    @PositiveOrZero
     private Integer reservationCount;
+
+    @NotNull
     private ActiveStatus activeStatus;
     //TODO 추후 상품 대표 사진에 대한 로직 처리와 함께 대표사진 경로에 대한 필드 추가
 

--- a/src/main/java/com/foru/freebe/product/dto/photographer/UpdateProductRequest.java
+++ b/src/main/java/com/foru/freebe/product/dto/photographer/UpdateProductRequest.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 public class UpdateProductRequest {
     @NotNull
     private Long productId;
+
     @NotNull
     private ActiveStatus activeStatus;
 }

--- a/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
@@ -86,7 +86,6 @@ public class PhotographerProductService {
                 .productId(product.getId())
                 .productTitle(product.getTitle())
                 .reservationCount(getReservationCount(member.getId(), product.getTitle()))
-                .reservationCount(getReservationCount(member.getId(), product.getTitle()))
                 .activeStatus(product.getActiveStatus())
                 .build())
             .collect(Collectors.toList());

--- a/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
@@ -85,8 +85,8 @@ public class PhotographerProductService {
             .map(product -> RegisteredProductResponse.builder()
                 .productId(product.getId())
                 .productTitle(product.getTitle())
-                .reservationCount(0) // TODO 예약체결 관련 로직 구현 후 추가
-                .reservationCount(getReservationCount(product.getTitle()))
+                .reservationCount(getReservationCount(member.getId(), product.getTitle()))
+                .reservationCount(getReservationCount(member.getId(), product.getTitle()))
                 .activeStatus(product.getActiveStatus())
                 .build())
             .collect(Collectors.toList());
@@ -96,6 +96,12 @@ public class PhotographerProductService {
             .message("Successfully retrieved list of registered products")
             .data(registeredProducts)
             .build();
+    }
+
+    private Integer getReservationCount(Long id, String productTitle) {
+        return (int)reservationFormRepository.findAllByPhotographerIdAndProductTitle(id, productTitle).stream()
+            .filter(form -> form.getReservationStatus() == ReservationStatus.PHOTO_COMPLETED)
+            .count();
     }
 
     @Transactional

--- a/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
@@ -31,6 +31,8 @@ import com.foru.freebe.product.respository.ProductDiscountRepository;
 import com.foru.freebe.product.respository.ProductImageRepository;
 import com.foru.freebe.product.respository.ProductOptionRepository;
 import com.foru.freebe.product.respository.ProductRepository;
+import com.foru.freebe.reservation.entity.ReservationStatus;
+import com.foru.freebe.reservation.repository.ReservationFormRepository;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -44,6 +46,7 @@ public class PhotographerProductService {
     private final ProductOptionRepository productOptionRepository;
     private final ProductDiscountRepository productDiscountRepository;
     private final MemberRepository memberRepository;
+    private final ReservationFormRepository reservationFormRepository;
 
     private final S3ImageService s3ImageService;
 
@@ -74,9 +77,7 @@ public class PhotographerProductService {
             .build();
     }
 
-    public ApiResponse<List<RegisteredProductResponse>> getRegisteredProductList(Long photographerId) {
-        Member member = getMember(photographerId);
-
+    public ApiResponse<List<RegisteredProductResponse>> getRegisteredProductList(Member member) {
         List<Product> registeredProductList = productRepository.findByMember(member)
             .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
 
@@ -85,6 +86,7 @@ public class PhotographerProductService {
                 .productId(product.getId())
                 .productTitle(product.getTitle())
                 .reservationCount(0) // TODO 예약체결 관련 로직 구현 후 추가
+                .reservationCount(getReservationCount(product.getTitle()))
                 .activeStatus(product.getActiveStatus())
                 .build())
             .collect(Collectors.toList());

--- a/src/main/java/com/foru/freebe/reservation/dto/BasicReservationInfoResponse.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/BasicReservationInfoResponse.java
@@ -15,10 +15,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class BasicReservationInfoResponse {
     @NotBlank
-    private String customerName;
+    private String name;
 
     @NotBlank
-    private String customerPhoneNumber;
+    private String phoneNumber;
 
     @NotNull
     private List<ProductComponentDto> productComponentDtoList;
@@ -26,11 +26,11 @@ public class BasicReservationInfoResponse {
     private List<ProductOptionDto> productOptionDtoList;
 
     @Builder
-    public BasicReservationInfoResponse(String customerName, String customerPhoneNumber,
+    public BasicReservationInfoResponse(String name, String phoneNumber,
         List<ProductComponentDto> productComponentDtoList,
         List<ProductOptionDto> productOptionDtoList) {
-        this.customerName = customerName;
-        this.customerPhoneNumber = customerPhoneNumber;
+        this.name = name;
+        this.phoneNumber = phoneNumber;
         this.productComponentDtoList = productComponentDtoList;
         this.productOptionDtoList = productOptionDtoList;
     }

--- a/src/main/java/com/foru/freebe/reservation/dto/BasicReservationInfoResponse.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/BasicReservationInfoResponse.java
@@ -5,6 +5,8 @@ import java.util.List;
 import com.foru.freebe.product.dto.photographer.ProductComponentDto;
 import com.foru.freebe.product.dto.photographer.ProductOptionDto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,17 +14,23 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class BasicReservationInfoResponse {
-    private String name;
-    private String phoneNumber;
+    @NotBlank
+    private String customerName;
+
+    @NotBlank
+    private String customerPhoneNumber;
+
+    @NotNull
     private List<ProductComponentDto> productComponentDtoList;
+
     private List<ProductOptionDto> productOptionDtoList;
 
     @Builder
-    public BasicReservationInfoResponse(String name, String phoneNumber,
+    public BasicReservationInfoResponse(String customerName, String customerPhoneNumber,
         List<ProductComponentDto> productComponentDtoList,
         List<ProductOptionDto> productOptionDtoList) {
-        this.name = name;
-        this.phoneNumber = phoneNumber;
+        this.customerName = customerName;
+        this.customerPhoneNumber = customerPhoneNumber;
         this.productComponentDtoList = productComponentDtoList;
         this.productOptionDtoList = productOptionDtoList;
     }

--- a/src/main/java/com/foru/freebe/reservation/dto/CustomerDetails.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/CustomerDetails.java
@@ -1,18 +1,26 @@
 package com.foru.freebe.reservation.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class CustomerDetails {
-    private String name;
-    private String phoneNumber;
-    private String instagramId;
+    @NotBlank
+    private String customerName;
+
+    @NotBlank
+    private String customerPhoneNumber;
+
+    @NotBlank
+    private String customerInstagramId;
 
     @Builder
-    public CustomerDetails(String name, String phoneNumber, String instagramId) {
-        this.name = name;
-        this.phoneNumber = phoneNumber;
-        this.instagramId = instagramId;
+    public CustomerDetails(String customerName, String customerPhoneNumber, String customerInstagramId) {
+        this.customerName = customerName;
+        this.customerPhoneNumber = customerPhoneNumber;
+        this.customerInstagramId = customerInstagramId;
     }
 }

--- a/src/main/java/com/foru/freebe/reservation/dto/CustomerDetails.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/CustomerDetails.java
@@ -9,18 +9,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CustomerDetails {
     @NotBlank
-    private String customerName;
+    private String name;
 
     @NotBlank
-    private String customerPhoneNumber;
+    private String phoneNumber;
 
     @NotBlank
-    private String customerInstagramId;
+    private String instagramId;
 
     @Builder
-    public CustomerDetails(String customerName, String customerPhoneNumber, String customerInstagramId) {
-        this.customerName = customerName;
-        this.customerPhoneNumber = customerPhoneNumber;
-        this.customerInstagramId = customerInstagramId;
+    public CustomerDetails(String name, String phoneNumber, String instagramId) {
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+        this.instagramId = instagramId;
     }
 }

--- a/src/main/java/com/foru/freebe/reservation/dto/FormComponent.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/FormComponent.java
@@ -4,16 +4,41 @@ import java.time.LocalDate;
 
 import com.foru.freebe.reservation.entity.ReservationStatus;
 
-import lombok.AllArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-@AllArgsConstructor
 @Getter
+@NoArgsConstructor
 public class FormComponent {
+    @NotNull
     private Long reservationId;
+
+    @NotNull
     private LocalDate reservationSubmissionDate;
+
+    @NotNull
     private ReservationStatus reservationStatus;
+
+    @NotBlank
     private String customerName;
+
+    @NotBlank
     private String productTitle;
+
+    @NotNull
     private PreferredDate shootingDate;
+
+    @Builder
+    public FormComponent(Long reservationId, LocalDate reservationSubmissionDate, ReservationStatus reservationStatus,
+        String customerName, String productTitle, PreferredDate shootingDate) {
+        this.reservationId = reservationId;
+        this.reservationSubmissionDate = reservationSubmissionDate;
+        this.reservationStatus = reservationStatus;
+        this.customerName = customerName;
+        this.productTitle = productTitle;
+        this.shootingDate = shootingDate;
+    }
 }

--- a/src/main/java/com/foru/freebe/reservation/dto/FormDetailsViewResponse.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/FormDetailsViewResponse.java
@@ -5,6 +5,8 @@ import java.util.Map;
 
 import com.foru.freebe.reservation.entity.ReservationStatus;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,17 +14,35 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class FormDetailsViewResponse {
+    @NotNull
     private Long reservationNumber;
+
+    @NotNull
     private ReservationStatus currentReservationStatus;
+
+    @NotNull
     private List<StatusHistory> statusHistory;
+
+    @NotBlank
     private String productTitle;
+
+    @NotNull
     private CustomerDetails customerDetails;
+
+    @NotNull
     private Map<String, String> photoInfo;
+
     private Map<Integer, PhotoOption> photoOptions;
+
+    @NotNull
     private Map<Integer, PreferredDate> preferredDates;
+
     private List<String> originalImage;
+
     private List<String> thumbnailImage;
+
     private String requestMemo;
+
     private String photographerMemo;
 
     @Builder

--- a/src/main/java/com/foru/freebe/reservation/dto/FormListViewResponse.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/FormListViewResponse.java
@@ -4,12 +4,16 @@ import java.util.List;
 
 import com.foru.freebe.reservation.entity.ReservationStatus;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class FormListViewResponse {
+    @NotNull
     private ReservationStatus reservationStatus;
+
+    @NotNull
     private List<FormComponent> formComponent;
 }

--- a/src/main/java/com/foru/freebe/reservation/dto/FormRegisterRequest.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/FormRegisterRequest.java
@@ -2,7 +2,9 @@ package com.foru.freebe.reservation.dto;
 
 import java.util.Map;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,10 +14,10 @@ public class FormRegisterRequest {
     @NotNull
     private Long photographerId;
 
-    @NotNull
+    @NotBlank
     private String instagramId;
 
-    @NotNull
+    @NotBlank
     private String productTitle;
 
     private Map<String, String> photoInfo;
@@ -25,6 +27,7 @@ public class FormRegisterRequest {
 
     private Map<Integer, PhotoOption> photoOptions;
 
+    @Size(max = 300, message = "Memo cannot be longer than 300 characters")
     private String customerMemo;
 
     @NotNull

--- a/src/main/java/com/foru/freebe/reservation/dto/FormRegisterRequest.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/FormRegisterRequest.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class FormRegisterRequest {
+    @NotNull
     private Long photographerId;
 
     @NotNull
@@ -19,6 +20,7 @@ public class FormRegisterRequest {
 
     private Map<String, String> photoInfo;
 
+    @NotNull
     private Map<Integer, PreferredDate> preferredDates;
 
     private Map<Integer, PhotoOption> photoOptions;

--- a/src/main/java/com/foru/freebe/reservation/dto/PhotoOption.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/PhotoOption.java
@@ -1,10 +1,14 @@
 package com.foru.freebe.reservation.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class PhotoOption {
+    @NotBlank
     private String title;
+
     private Integer quantity;
+
     private Integer price;
 }

--- a/src/main/java/com/foru/freebe/reservation/dto/PreferredDate.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/PreferredDate.java
@@ -3,11 +3,17 @@ package com.foru.freebe.reservation.dto;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
 public class PreferredDate {
+    @NotNull
     private LocalDate date;
+
+    @NotNull
     private LocalTime startTime;
+
+    @NotNull
     private LocalTime endTime;
 }

--- a/src/main/java/com/foru/freebe/reservation/dto/ReservationInfoResponse.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/ReservationInfoResponse.java
@@ -4,17 +4,29 @@ import java.util.Map;
 
 import com.foru.freebe.reservation.entity.ReservationStatus;
 
-import lombok.AllArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
 public class ReservationInfoResponse {
+    @NotNull
     private ReservationStatus reservationStatus;
+
+    @NotBlank
     private String productTitle;
+
+    @NotNull
     private Map<String, String> photoInfo;
+
+    @NotNull
     private Map<Integer, PreferredDate> preferredDate;
+
     private Map<Integer, PhotoOption> photoOptions;
+
     private String customerMemo;
     private Boolean serviceTermAgreement;
     private Boolean photographerTermAgreement;

--- a/src/main/java/com/foru/freebe/reservation/dto/ReservationInfoResponse.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/ReservationInfoResponse.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 public class ReservationInfoResponse {
     @NotNull
     private ReservationStatus reservationStatus;
@@ -28,6 +28,16 @@ public class ReservationInfoResponse {
     private Map<Integer, PhotoOption> photoOptions;
 
     private String customerMemo;
-    private Boolean serviceTermAgreement;
-    private Boolean photographerTermAgreement;
+
+    @Builder
+    public ReservationInfoResponse(ReservationStatus reservationStatus, String productTitle,
+        Map<String, String> photoInfo, Map<Integer, PreferredDate> preferredDate,
+        Map<Integer, PhotoOption> photoOptions, String customerMemo) {
+        this.reservationStatus = reservationStatus;
+        this.productTitle = productTitle;
+        this.photoInfo = photoInfo;
+        this.preferredDate = preferredDate;
+        this.photoOptions = photoOptions;
+        this.customerMemo = customerMemo;
+    }
 }

--- a/src/main/java/com/foru/freebe/reservation/dto/StatusHistory.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/StatusHistory.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 
 import com.foru.freebe.reservation.entity.ReservationStatus;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,7 +13,10 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class StatusHistory {
+    @NotNull
     ReservationStatus reservationStatus;
+
+    @NotNull
     LocalDate statusUpdateDate;
 
     @Builder

--- a/src/main/java/com/foru/freebe/reservation/entity/ReferenceImage.java
+++ b/src/main/java/com/foru/freebe/reservation/entity/ReferenceImage.java
@@ -8,7 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,10 +26,10 @@ public class ReferenceImage {
     @JoinColumn(name = "reservation_form_id")
     private ReservationForm reservationForm;
 
-    @NotNull
+    @NotBlank
     private String originUrl;
 
-    @NotNull
+    @NotBlank
     private String thumbnailUrl;
 
     private ReferenceImage(String originUrl, String thumbnailUrl, ReservationForm reservationForm) {

--- a/src/main/java/com/foru/freebe/reservation/repository/ReservationFormRepository.java
+++ b/src/main/java/com/foru/freebe/reservation/repository/ReservationFormRepository.java
@@ -11,4 +11,6 @@ public interface ReservationFormRepository extends JpaRepository<ReservationForm
     Optional<List<ReservationForm>> findAllByPhotographerId(Long photographerId);
 
     Optional<ReservationForm> findByPhotographerIdAndId(Long photographerId, Long id);
+
+    List<ReservationForm> findAllByPhotographerIdAndProductTitle(Long photographerId, String productTitle);
 }

--- a/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
@@ -83,8 +83,8 @@ public class CustomerReservationService {
         List<ProductOptionDto> productOptionDtoList = convertProductOptionDtoList(productOptions);
 
         BasicReservationInfoResponse basicReservationInfoResponse = BasicReservationInfoResponse.builder()
-            .name(customer.getName())
-            .phoneNumber(customer.getPhoneNumber())
+            .customerName(customer.getName())
+            .customerPhoneNumber(customer.getPhoneNumber())
             .productComponentDtoList(productComponentDtoList)
             .productOptionDtoList(productOptionDtoList)
             .build();
@@ -102,11 +102,14 @@ public class CustomerReservationService {
 
         validateCustomerAccess(reservationForm, customerId);
 
-        ReservationInfoResponse reservationInfoResponse = new ReservationInfoResponse(
-            reservationForm.getReservationStatus(), reservationForm.getProductTitle(),
-            reservationForm.getPhotoInfo(), reservationForm.getPreferredDate(), reservationForm.getPhotoOption(),
-            reservationForm.getCustomerMemo(), reservationForm.getServiceTermAgreement(),
-            reservationForm.getPhotographerTermAgreement());
+        ReservationInfoResponse reservationInfoResponse = ReservationInfoResponse.builder()
+            .reservationStatus(reservationForm.getReservationStatus())
+            .productTitle(reservationForm.getProductTitle())
+            .photoInfo(reservationForm.getPhotoInfo())
+            .preferredDate(reservationForm.getPreferredDate())
+            .photoOptions(reservationForm.getPhotoOption())
+            .customerMemo(reservationForm.getCustomerMemo())
+            .build();
 
         return ApiResponse.<ReservationInfoResponse>builder()
             .status(200)

--- a/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
@@ -83,8 +83,8 @@ public class CustomerReservationService {
         List<ProductOptionDto> productOptionDtoList = convertProductOptionDtoList(productOptions);
 
         BasicReservationInfoResponse basicReservationInfoResponse = BasicReservationInfoResponse.builder()
-            .customerName(customer.getName())
-            .customerPhoneNumber(customer.getPhoneNumber())
+            .name(customer.getName())
+            .phoneNumber(customer.getPhoneNumber())
             .productComponentDtoList(productComponentDtoList)
             .productOptionDtoList(productOptionDtoList)
             .build();

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationDetails.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationDetails.java
@@ -130,9 +130,9 @@ public class PhotographerReservationDetails {
 
     private CustomerDetails buildCustomerDetails(ReservationForm reservationForm) {
         return CustomerDetails.builder()
-            .name(reservationForm.getCustomer().getName())
-            .phoneNumber(reservationForm.getCustomer().getPhoneNumber())
-            .instagramId(reservationForm.getInstagramId())
+            .customerName(reservationForm.getCustomer().getName())
+            .customerPhoneNumber(reservationForm.getCustomer().getPhoneNumber())
+            .customerInstagramId(reservationForm.getInstagramId())
             .build();
     }
 

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationDetails.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationDetails.java
@@ -130,9 +130,9 @@ public class PhotographerReservationDetails {
 
     private CustomerDetails buildCustomerDetails(ReservationForm reservationForm) {
         return CustomerDetails.builder()
-            .customerName(reservationForm.getCustomer().getName())
-            .customerPhoneNumber(reservationForm.getCustomer().getPhoneNumber())
-            .customerInstagramId(reservationForm.getInstagramId())
+            .name(reservationForm.getCustomer().getName())
+            .phoneNumber(reservationForm.getCustomer().getPhoneNumber())
+            .instagramId(reservationForm.getInstagramId())
             .build();
     }
 

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
@@ -58,14 +58,14 @@ public class PhotographerReservationService {
     }
 
     private FormComponent toFormComponent(ReservationForm reservationForm) {
-        return new FormComponent(
-            reservationForm.getId(),
-            reservationForm.getCreatedAt().toLocalDate(),
-            reservationForm.getReservationStatus(),
-            reservationForm.getCustomer().getName(),
-            reservationForm.getProductTitle(),
-            reservationForm.getShootingDate() == null ? null : reservationForm.getShootingDate()
-        );
+        return FormComponent.builder()
+            .reservationId(reservationForm.getId())
+            .reservationSubmissionDate(reservationForm.getCreatedAt().toLocalDate())
+            .reservationStatus(reservationForm.getReservationStatus())
+            .customerName(reservationForm.getCustomer().getName())
+            .productTitle(reservationForm.getProductTitle())
+            .shootingDate(reservationForm.getShootingDate() == null ? null : reservationForm.getShootingDate())
+            .build();
     }
 
     private List<FormComponent> sortFormComponents(ReservationStatus status, List<FormComponent> formComponents) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         show_sql: true


### PR DESCRIPTION
## 체크리스트

- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
- DTO 필드에 대한 유효성 검증을 추가했습니다. 
- 프론트엔드의 작업 내용에 맞춰(FU-157) Request DTO의 최대 글자수 제한을 적용했습니다.
- 사진작가측 상품목록 조회 시 예약체결 건수를 조회하는 로직을 구현했습니다. (TODO 사항이었는데 구현되지 않고 있었음..)
- 의뢰자측 신청서 조회 ReponseBody에서 약관 동의여부를 삭제했습니다. (기존에 논의했던 내용, [API Docs](https://www.notion.so/yul-lee/customer-reservation-reservationFormI-ed0439b036b14ab582cb675cb57c331a?pvs=4) 참고)

## 고민한 사항
🙅‍♀️

## 리뷰 요청사항
적절하게 검증되고 있는지 확인 부탁드립니다! 시급도는 낮음, 예상 리뷰시간은 5분 미만입니다.