### PR TITLE
[FU-179] 사진작가 회원가입 API 개발

### DIFF
--- a/.github/workflows/cd_workflow_dev.yml
+++ b/.github/workflows/cd_workflow_dev.yml
@@ -20,20 +20,27 @@ jobs:
 
       - name: env 설정
         run: |
-          echo "SPRING_DATASOURCE_URL=${{ secrets.SPRING_DATASOURCE_URL }}" >> .env
-          echo "SPRING_DATASOURCE_USERNAME=${{ secrets.SPRING_DATASOURCE_USERNAME }}" >> .env
-          echo "SPRING_DATASOURCE_PASSWORD=${{ secrets.SPRING_DATASOURCE_PASSWORD }}" >> .env
-          echo "AWS_REGION=${{ secrets.AWS_REGION }}" >> .env
-          echo "AWS_CODE_DEPLOY_APPLICATION=${{ secrets.AWS_CODE_DEPLOY_APPLICATION }}" >> .env
-          echo "AWS_CODE_DEPLOY_GROUP=${{ secrets.AWS_CODE_DEPLOY_GROUP }}" >> .env
-          echo "AWS_S3_BUCKET=${{ secrets.AWS_S3_BUCKET }}" >> .env
-          echo "AWS_ACCESS_KEY=${{ secrets.CICD_ACCESS_KEY }}" >> .env
-          echo "AWS_SECRET_KEY=${{ secrets.CICD_SECRET_KEY }}" >> .env
-          echo "FREEBE_BASE_URL=${{ secrets.FREEBE_BASE_URL }}" >> .env
           echo "KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }}" >> .env
           echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}" >> .env
           echo "KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }}" >> .env
+          echo "SPRING_DATASOURCE_URL=${{ secrets.SPRING_DATASOURCE_URL }}" >> .env
+          echo "SPRING_DATASOURCE_USERNAME=${{ secrets.SPRING_DATASOURCE_USERNAME }}" >> .env
+          echo "SPRING_DATASOURCE_PASSWORD=${{ secrets.SPRING_DATASOURCE_PASSWORD }}" >> .env
+          echo "FREEBE_BASE_URL=${{ secrets.FREEBE_BASE_URL }}" >> .env
           echo "JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}" >> .env
+          echo "AWS_REGION=${{ secrets.AWS_REGION }}" >> .env
+          echo "AWS_ACCESS_KEY=${{ secrets.CICD_ACCESS_KEY }}" >> .env
+          echo "AWS_SECRET_KEY=${{ secrets.CICD_SECRET_KEY }}" >> .env
+          echo "AWS_S3_BUCKET=${{ secrets.AWS_S3_BUCKET }}" >> .env
+          echo "AWS_S3_ORIGINAL_PATH=${{ secrets.AWS_S3_ORIGINAL_PATH }}" >> .env
+          echo "AWS_S3_THUMBNAIL_PATH=${{ secrets.AWS_S3_THUMBNAIL_PATH }}" >> .env
+          echo "AWS_S3_PHOTOGRAPHER_PATH=${{ secrets.AWS_S3_PHOTOGRAPHER_PATH }}" >> .env
+          echo "AWS_S3_CUSTOMER_PATH=${{ secrets.AWS_S3_CUSTOMER_PATH }}" >> .env
+          echo "AWS_S3_PRODUCT_PATH=${{ secrets.AWS_S3_PRODUCT_PATH }}" >> .env
+          echo "AWS_S3_PROFILE_PATH=${{ secrets.AWS_S3_PROFILE_PATH }}" >> .env
+          echo "AWS_S3_RESERVATION_PATH=${{ secrets.AWS_S3_RESERVATION_PATH }}" >> .env
+          echo "AWS_CODE_DEPLOY_APPLICATION=${{ secrets.AWS_CODE_DEPLOY_APPLICATION }}" >> .env
+          echo "AWS_CODE_DEPLOY_GROUP=${{ secrets.AWS_CODE_DEPLOY_GROUP }}" >> .env
 
       - name: gradlew에 실행 권한 부여
         run: chmod +x ./gradlew

--- a/src/main/java/com/foru/freebe/common/service/S3ImageService.java
+++ b/src/main/java/com/foru/freebe/common/service/S3ImageService.java
@@ -38,10 +38,15 @@ public class S3ImageService {
     @Value("${AWS_S3_BUCKET}")
     private String bucketName;
 
-    public List<String> uploadOriginalImage(List<MultipartFile> images) throws IOException {
+    @Value("${AWS_S3_ORIGIN_PATH}")
+    private String originPath;
+
+    @Value("${AWS_S3_THUMBNAIL_PATH}")
+    private String thumbnailPath;
+
         List<String> originalImageUrls = new ArrayList<>();
         for (MultipartFile image : images) {
-            String originKey = "origin/" + image.getOriginalFilename();
+            String originKey = originPath + image.getOriginalFilename();
 
             ObjectMetadata metadata = new ObjectMetadata();
             metadata.setContentLength(image.getSize());
@@ -56,7 +61,7 @@ public class S3ImageService {
     public List<String> uploadThumbnailImage(List<MultipartFile> images) throws IOException {
         List<String> thumbnailImageUrls = new ArrayList<>();
         for (MultipartFile image : images) {
-            String thumbnailKey = "thumbnail/" + image.getOriginalFilename();
+            String thumbnailKey = thumbnailPath + image.getOriginalFilename();
             InputStream originalImageStream = image.getInputStream();
 
             ByteArrayOutputStream thumbnailOutputStream = new ByteArrayOutputStream();

--- a/src/main/java/com/foru/freebe/config/S3Config.java
+++ b/src/main/java/com/foru/freebe/config/S3Config.java
@@ -12,11 +12,11 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 
 @Configuration
 public class S3Config {
-    @Value("${AWS_ACCESS_KEY}")
+    @Value("${cloud.aws.credentials.access-key}")
     private String accessKey;
-    @Value("${AWS_SECRET_KEY}")
+    @Value("${cloud.aws.credentials.secret-key}")
     private String secretKey;
-    @Value("${AWS_REGION}")
+    @Value("${cloud.aws.region.static}")
     private String region;
 
     @Bean

--- a/src/main/java/com/foru/freebe/member/controller/JoinController.java
+++ b/src/main/java/com/foru/freebe/member/controller/JoinController.java
@@ -1,9 +1,12 @@
 package com.foru.freebe.member.controller;
 
+import java.io.IOException;
+
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.foru.freebe.auth.model.MemberAdapter;
 import com.foru.freebe.common.dto.ApiResponse;
@@ -11,7 +14,6 @@ import com.foru.freebe.member.dto.PhotographerJoinRequest;
 import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.member.service.MemberService;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -21,8 +23,10 @@ public class JoinController {
 
     @PostMapping("/photographer/join")
     public ApiResponse<String> joinPhotographer(@AuthenticationPrincipal MemberAdapter memberAdapter,
-        @Valid @RequestBody PhotographerJoinRequest request) {
+        @RequestPart(value = "request") PhotographerJoinRequest request,
+        @RequestPart(value = "image", required = false) MultipartFile image) throws IOException {
+
         Member member = memberAdapter.getMember();
-        return memberService.joinPhotographer(member, request);
+        return memberService.joinPhotographer(member, request, image);
     }
 }

--- a/src/main/java/com/foru/freebe/member/service/MemberService.java
+++ b/src/main/java/com/foru/freebe/member/service/MemberService.java
@@ -1,12 +1,21 @@
 package com.foru.freebe.member.service;
 
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.foru.freebe.auth.model.KakaoUser;
 import com.foru.freebe.common.dto.ApiResponse;
+import com.foru.freebe.common.service.S3ImageService;
+import com.foru.freebe.errors.errorcode.CommonErrorCode;
+import com.foru.freebe.errors.exception.RestApiException;
 import com.foru.freebe.jwt.model.JwtTokenModel;
 import com.foru.freebe.jwt.service.JwtService;
 import com.foru.freebe.member.dto.PhotographerJoinRequest;
@@ -15,6 +24,10 @@ import com.foru.freebe.member.entity.MemberTermAgreement;
 import com.foru.freebe.member.entity.Role;
 import com.foru.freebe.member.repository.MemberRepository;
 import com.foru.freebe.member.repository.MemberTermAgreementRepository;
+import com.foru.freebe.profile.entity.Profile;
+import com.foru.freebe.profile.entity.ProfileImage;
+import com.foru.freebe.profile.repository.ProfileImageRepository;
+import com.foru.freebe.profile.repository.ProfileRepository;
 import com.foru.freebe.profile.service.ProfileService;
 
 import jakarta.transaction.Transactional;
@@ -25,8 +38,15 @@ import lombok.RequiredArgsConstructor;
 public class MemberService {
     private final ProfileService profileService;
     private final JwtService jwtService;
+    private final S3ImageService s3ImageService;
     private final MemberRepository memberRepository;
     private final MemberTermAgreementRepository memberTermAgreementRepository;
+    private static final int PROFILE_THUMBNAIL_SIZE = 100;
+    private final ProfileRepository profileRepository;
+    private final ProfileImageRepository profileImageRepository;
+
+    @Value("${AWS_S3_PROFILE_IMAGE_PATH}")
+    private String AWS_S3_PROFILE_IMAGE_PATH;
 
     @Transactional
     public ResponseEntity<ApiResponse<?>> findOrRegisterMember(KakaoUser kakaoUser, Role role) {
@@ -47,16 +67,39 @@ public class MemberService {
     }
 
     @Transactional
-    public ApiResponse<String> joinPhotographer(Member member, PhotographerJoinRequest request) {
+    public ApiResponse<String> joinPhotographer(Member member, PhotographerJoinRequest request,
+        MultipartFile profileImage) throws IOException {
         Member photographer = completePhotographerSignup(member, request.getInstagramId());
         savePhotographerAgreements(photographer, request);
 
         String url = profileService.getUniqueUrl(member.getId());
+        saveProfileImage(photographer, profileImage);
         return ApiResponse.<String>builder()
             .status(HttpStatus.OK.value())
             .data(url)
             .message("Successfully joined")
             .build();
+    }
+
+    private void saveProfileImage(Member photographer, MultipartFile profileImage) throws IOException {
+        List<MultipartFile> profileImages = Collections.singletonList(profileImage);
+
+        List<String> originalImageUrls = s3ImageService.uploadOriginalImages(profileImages, AWS_S3_PROFILE_IMAGE_PATH);
+        List<String> thumbnailImageUrls = s3ImageService.uploadThumbnailImages(profileImages, AWS_S3_PROFILE_IMAGE_PATH,
+            PROFILE_THUMBNAIL_SIZE);
+
+        String originalImageUrl = originalImageUrls.get(0);
+        String thumbnailImageUrl = thumbnailImageUrls.get(0);
+
+        Profile profile = profileRepository.findByMember(photographer)
+            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+
+        ProfileImage image = ProfileImage.builder()
+            .profile(profile)
+            .originUrl(originalImageUrl)
+            .thumbnailUrl(thumbnailImageUrl)
+            .build();
+        profileImageRepository.save(image);
     }
 
     private Member registerNewMember(KakaoUser kakaoUser, Role role) {

--- a/src/main/java/com/foru/freebe/member/service/MemberService.java
+++ b/src/main/java/com/foru/freebe/member/service/MemberService.java
@@ -1,10 +1,7 @@
 package com.foru.freebe.member.service;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,8 +11,6 @@ import org.springframework.web.multipart.MultipartFile;
 import com.foru.freebe.auth.model.KakaoUser;
 import com.foru.freebe.common.dto.ApiResponse;
 import com.foru.freebe.common.service.S3ImageService;
-import com.foru.freebe.errors.errorcode.CommonErrorCode;
-import com.foru.freebe.errors.exception.RestApiException;
 import com.foru.freebe.jwt.model.JwtTokenModel;
 import com.foru.freebe.jwt.service.JwtService;
 import com.foru.freebe.member.dto.PhotographerJoinRequest;
@@ -24,8 +19,6 @@ import com.foru.freebe.member.entity.MemberTermAgreement;
 import com.foru.freebe.member.entity.Role;
 import com.foru.freebe.member.repository.MemberRepository;
 import com.foru.freebe.member.repository.MemberTermAgreementRepository;
-import com.foru.freebe.profile.entity.Profile;
-import com.foru.freebe.profile.entity.ProfileImage;
 import com.foru.freebe.profile.repository.ProfileImageRepository;
 import com.foru.freebe.profile.repository.ProfileRepository;
 import com.foru.freebe.profile.service.ProfileService;
@@ -41,12 +34,8 @@ public class MemberService {
     private final S3ImageService s3ImageService;
     private final MemberRepository memberRepository;
     private final MemberTermAgreementRepository memberTermAgreementRepository;
-    private static final int PROFILE_THUMBNAIL_SIZE = 100;
     private final ProfileRepository profileRepository;
     private final ProfileImageRepository profileImageRepository;
-
-    @Value("${AWS_S3_PROFILE_IMAGE_PATH}")
-    private String AWS_S3_PROFILE_IMAGE_PATH;
 
     @Transactional
     public ResponseEntity<ApiResponse<?>> findOrRegisterMember(KakaoUser kakaoUser, Role role) {
@@ -70,36 +59,17 @@ public class MemberService {
     public ApiResponse<String> joinPhotographer(Member member, PhotographerJoinRequest request,
         MultipartFile profileImage) throws IOException {
         Member photographer = completePhotographerSignup(member, request.getInstagramId());
+
         savePhotographerAgreements(photographer, request);
+        profileService.initialProfileSetting(photographer, profileImage);
 
         String url = profileService.getUniqueUrl(member.getId());
-        saveProfileImage(photographer, profileImage);
+
         return ApiResponse.<String>builder()
             .status(HttpStatus.OK.value())
             .data(url)
             .message("Successfully joined")
             .build();
-    }
-
-    private void saveProfileImage(Member photographer, MultipartFile profileImage) throws IOException {
-        List<MultipartFile> profileImages = Collections.singletonList(profileImage);
-
-        List<String> originalImageUrls = s3ImageService.uploadOriginalImages(profileImages, AWS_S3_PROFILE_IMAGE_PATH);
-        List<String> thumbnailImageUrls = s3ImageService.uploadThumbnailImages(profileImages, AWS_S3_PROFILE_IMAGE_PATH,
-            PROFILE_THUMBNAIL_SIZE);
-
-        String originalImageUrl = originalImageUrls.get(0);
-        String thumbnailImageUrl = thumbnailImageUrls.get(0);
-
-        Profile profile = profileRepository.findByMember(photographer)
-            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
-
-        ProfileImage image = ProfileImage.builder()
-            .profile(profile)
-            .originUrl(originalImageUrl)
-            .thumbnailUrl(thumbnailImageUrl)
-            .build();
-        profileImageRepository.save(image);
     }
 
     private Member registerNewMember(KakaoUser kakaoUser, Role role) {

--- a/src/main/java/com/foru/freebe/member/service/MemberService.java
+++ b/src/main/java/com/foru/freebe/member/service/MemberService.java
@@ -10,7 +10,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.foru.freebe.auth.model.KakaoUser;
 import com.foru.freebe.common.dto.ApiResponse;
-import com.foru.freebe.common.service.S3ImageService;
 import com.foru.freebe.jwt.model.JwtTokenModel;
 import com.foru.freebe.jwt.service.JwtService;
 import com.foru.freebe.member.dto.PhotographerJoinRequest;
@@ -22,6 +21,7 @@ import com.foru.freebe.member.repository.MemberTermAgreementRepository;
 import com.foru.freebe.profile.repository.ProfileImageRepository;
 import com.foru.freebe.profile.repository.ProfileRepository;
 import com.foru.freebe.profile.service.ProfileService;
+import com.foru.freebe.s3.S3ImageService;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/foru/freebe/profile/entity/Profile.java
+++ b/src/main/java/com/foru/freebe/profile/entity/Profile.java
@@ -35,8 +35,6 @@ public class Profile extends BaseEntity {
 
     private String introductionContent;
 
-    private String profileImageUrl;
-
     private String bannerImageUrl;
 
     public void assignUniqueUrl(String uniqueUrl) {
@@ -48,7 +46,6 @@ public class Profile extends BaseEntity {
         Member member) {
         this.uniqueUrl = uniqueUrl;
         this.introductionContent = introductionContent;
-        this.profileImageUrl = profileImageUrl;
         this.bannerImageUrl = bannerImageUrl;
         this.member = member;
     }

--- a/src/main/java/com/foru/freebe/profile/entity/Profile.java
+++ b/src/main/java/com/foru/freebe/profile/entity/Profile.java
@@ -37,10 +37,6 @@ public class Profile extends BaseEntity {
 
     private String bannerImageUrl;
 
-    public void assignUniqueUrl(String uniqueUrl) {
-        this.uniqueUrl = uniqueUrl;
-    }
-
     @Builder
     public Profile(String uniqueUrl, String introductionContent, String profileImageUrl, String bannerImageUrl,
         Member member) {

--- a/src/main/java/com/foru/freebe/profile/entity/ProfileImage.java
+++ b/src/main/java/com/foru/freebe/profile/entity/ProfileImage.java
@@ -1,0 +1,42 @@
+package com.foru.freebe.profile.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProfileImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "profile_image_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "profile_id")
+    private Profile profile;
+
+    @NotNull
+    private String thumbnailUrl;
+
+    @NotNull
+    private String originUrl;
+
+    @Builder
+    public ProfileImage(Profile profile, String thumbnailUrl, String originUrl) {
+        this.profile = profile;
+        this.thumbnailUrl = thumbnailUrl;
+        this.originUrl = originUrl;
+    }
+}

--- a/src/main/java/com/foru/freebe/profile/repository/ProfileImageRepository.java
+++ b/src/main/java/com/foru/freebe/profile/repository/ProfileImageRepository.java
@@ -2,7 +2,13 @@ package com.foru.freebe.profile.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.foru.freebe.profile.entity.Profile;
 import com.foru.freebe.profile.entity.ProfileImage;
 
 public interface ProfileImageRepository extends JpaRepository<ProfileImage, Long> {
+    Boolean existsByProfile(Profile profile);
+
+    ProfileImage findByProfile(Profile profile);
+
+    Void deleteByProfile(Profile profile);
 }

--- a/src/main/java/com/foru/freebe/profile/repository/ProfileImageRepository.java
+++ b/src/main/java/com/foru/freebe/profile/repository/ProfileImageRepository.java
@@ -1,0 +1,8 @@
+package com.foru.freebe.profile.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.foru.freebe.profile.entity.ProfileImage;
+
+public interface ProfileImageRepository extends JpaRepository<ProfileImage, Long> {
+}

--- a/src/main/java/com/foru/freebe/profile/repository/ProfileRepository.java
+++ b/src/main/java/com/foru/freebe/profile/repository/ProfileRepository.java
@@ -8,6 +8,8 @@ import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.profile.entity.Profile;
 
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
+    Boolean existsByMemberId(Long memberId);
+
     Optional<Profile> findByMember(Member member);
 
     Optional<Profile> findByUniqueUrl(String uniqueUrl);

--- a/src/main/java/com/foru/freebe/profile/service/ProfileService.java
+++ b/src/main/java/com/foru/freebe/profile/service/ProfileService.java
@@ -82,7 +82,9 @@ public class ProfileService {
         }
 
         Profile profile = createMemberProfile(photographer);
-        saveProfileImage(profile, profileImage, photographer.getId());
+        if (profileImage != null) {
+            saveProfileImage(profile, profileImage, photographer.getId());
+        }
     }
 
     private Profile createMemberProfile(Member member) {

--- a/src/main/java/com/foru/freebe/profile/service/ProfileService.java
+++ b/src/main/java/com/foru/freebe/profile/service/ProfileService.java
@@ -1,12 +1,16 @@
 package com.foru.freebe.profile.service;
 
+import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import com.foru.freebe.common.service.S3ImageService;
 import com.foru.freebe.errors.errorcode.CommonErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
 import com.foru.freebe.member.entity.Member;
@@ -15,31 +19,37 @@ import com.foru.freebe.profile.dto.LinkInfo;
 import com.foru.freebe.profile.dto.ProfileResponse;
 import com.foru.freebe.profile.entity.Link;
 import com.foru.freebe.profile.entity.Profile;
+import com.foru.freebe.profile.entity.ProfileImage;
 import com.foru.freebe.profile.repository.LinkRepository;
+import com.foru.freebe.profile.repository.ProfileImageRepository;
 import com.foru.freebe.profile.repository.ProfileRepository;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class ProfileService {
+    private static final int PROFILE_THUMBNAIL_SIZE = 100;
+
     private final MemberRepository memberRepository;
     private final ProfileRepository profileRepository;
     private final LinkRepository linkRepository;
+    private final ProfileImageRepository profileImageRepository;
+    private final S3ImageService s3ImageService;
 
     @Value("${FREEBE_BASE_URL}")
     private String freebeBaseUrl;
+
+    @Value("${AWS_S3_PROFILE_IMAGE_PATH}")
+    private String awsS3ProfileImagePath;
 
     public String getUniqueUrl(Long id) {
         Member member = memberRepository.findById(id)
             .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
 
         Profile profile = profileRepository.findByMember(member)
-            .orElseGet(() -> createMemberProfile(member));
-
-        if (profile.getUniqueUrl() == null) {
-            saveUniqueUrl(profile);
-        }
+            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
 
         return profile.getUniqueUrl();
     }
@@ -56,31 +66,68 @@ public class ProfileService {
             .map(link -> new LinkInfo(link.getTitle(), link.getUrl()))
             .collect(Collectors.toList());
 
+        ProfileImage profileImage = profileImageRepository.findByProfile(photographerProfile);
+
         return new ProfileResponse(
             photographerProfile.getBannerImageUrl(),
-            photographerProfile.getProfileImageUrl(),
+            profileImage.getThumbnailUrl(),
             photographer.getInstagramId(),
             photographerProfile.getIntroductionContent(),
             linkInfos);
     }
 
+    @Transactional
+    public void initialProfileSetting(Member photographer, MultipartFile profileImage) throws IOException {
+        Boolean isProfileExists = profileRepository.existsByMemberId(photographer.getId());
+        if (isProfileExists) {
+            throw new RestApiException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+        }
+
+        Profile profile = createMemberProfile(photographer);
+        saveProfileImage(profile, profileImage);
+    }
+
     private Profile createMemberProfile(Member member) {
-        return Profile.builder()
-            .uniqueUrl(null)
+        String uniqueUrl = createUniqueUrl();
+
+        Profile profile = Profile.builder()
+            .uniqueUrl(uniqueUrl)
             .introductionContent(null)
             .bannerImageUrl(null)
             .member(member)
             .build();
+
+        return profileRepository.save(profile);
     }
 
-    private void saveUniqueUrl(Profile profile) {
-        String uniqueUrl = generateUniqueUrl();
-        profile.assignUniqueUrl(uniqueUrl);
-        profileRepository.save(profile);
-    }
-
-    private String generateUniqueUrl() {
+    private String createUniqueUrl() {
         String uniqueId = UUID.randomUUID().toString();
         return freebeBaseUrl + "/photographer/" + uniqueId;
+    }
+
+    private void saveProfileImage(Profile profile, MultipartFile profileImage) throws IOException {
+        deleteProfileImageIfExists(profile);
+
+        List<MultipartFile> profileImages = Collections.singletonList(profileImage);
+        List<String> originalImageUrls = s3ImageService.uploadOriginalImages(profileImages, awsS3ProfileImagePath);
+        List<String> thumbnailImageUrls = s3ImageService.uploadThumbnailImages(profileImages, awsS3ProfileImagePath,
+            PROFILE_THUMBNAIL_SIZE);
+
+        String originalImageUrl = originalImageUrls.get(0);
+        String thumbnailImageUrl = thumbnailImageUrls.get(0);
+
+        ProfileImage image = ProfileImage.builder()
+            .profile(profile)
+            .originUrl(originalImageUrl)
+            .thumbnailUrl(thumbnailImageUrl)
+            .build();
+        profileImageRepository.save(image);
+    }
+
+    private void deleteProfileImageIfExists(Profile profile) {
+        Boolean isProfileExists = profileImageRepository.existsByProfile(profile);
+        if (isProfileExists) {
+            profileImageRepository.deleteByProfile(profile);
+        }
     }
 }

--- a/src/main/java/com/foru/freebe/reservation/controller/CustomerReservationController.java
+++ b/src/main/java/com/foru/freebe/reservation/controller/CustomerReservationController.java
@@ -15,12 +15,12 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.foru.freebe.auth.model.MemberAdapter;
 import com.foru.freebe.common.dto.ApiResponse;
-import com.foru.freebe.common.service.S3ImageService;
 import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.reservation.dto.BasicReservationInfoResponse;
 import com.foru.freebe.reservation.dto.FormRegisterRequest;
 import com.foru.freebe.reservation.dto.ReservationInfoResponse;
 import com.foru.freebe.reservation.service.CustomerReservationService;
+import com.foru.freebe.s3.S3ImageService;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/foru/freebe/s3/S3ImageService.java
+++ b/src/main/java/com/foru/freebe/s3/S3ImageService.java
@@ -1,15 +1,16 @@
-package com.foru.freebe.common.service;
+package com.foru.freebe.s3;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -33,19 +34,36 @@ import lombok.RequiredArgsConstructor;
 public class S3ImageService {
     private final AmazonS3 amazonS3;
 
-    @Value("${AWS_S3_BUCKET}")
+    @Value("${cloud.aws.s3.bucket}")
     private String bucketName;
 
-    @Value("${AWS_S3_ORIGIN_PATH}")
+    @Value("${cloud.aws.s3.base-path.original}")
     private String originPath;
 
-    @Value("${AWS_S3_THUMBNAIL_PATH}")
+    @Value("${cloud.aws.s3.base-path.thumbnail}")
     private String thumbnailPath;
 
-    public List<String> uploadOriginalImages(List<MultipartFile> images, String folderPath) throws IOException {
+    @Value("${cloud.aws.s3.base-path.photographer}")
+    private String photographerPath;
+
+    @Value("${cloud.aws.s3.base-path.customer}")
+    private String customerPath;
+
+    @Value("${cloud.aws.s3.base-path.product}")
+    private String productPath;
+
+    @Value("${cloud.aws.s3.base-path.profile}")
+    private String profilePath;
+
+    @Value("${cloud.aws.s3.base-path.reservation}")
+    private String reservationPath;
+
+    public List<String> uploadOriginalImages(List<MultipartFile> images, S3ImageType s3ImageType, Long memberId) throws
+        IOException {
+
         List<String> originalImageUrls = new ArrayList<>();
         for (MultipartFile image : images) {
-            String originKey = originPath + folderPath + image.getOriginalFilename();
+            String originKey = generateImagePath(image, s3ImageType, memberId, true);
 
             ObjectMetadata metadata = new ObjectMetadata();
             metadata.setContentLength(image.getSize());
@@ -57,11 +75,12 @@ public class S3ImageService {
         return originalImageUrls;
     }
 
-    public List<String> uploadThumbnailImages(List<MultipartFile> images, String folderPath, int thumbnailSize) throws
-        IOException {
+    public List<String> uploadThumbnailImages(List<MultipartFile> images, S3ImageType s3ImageType, Long memberId,
+        int thumbnailSize) throws IOException {
+
         List<String> thumbnailImageUrls = new ArrayList<>();
         for (MultipartFile image : images) {
-            String thumbnailKey = thumbnailPath + folderPath + image.getOriginalFilename();
+            String thumbnailKey = generateImagePath(image, s3ImageType, memberId, false);
             InputStream originalImageStream = image.getInputStream();
 
             ByteArrayOutputStream thumbnailOutputStream = new ByteArrayOutputStream();
@@ -78,6 +97,36 @@ public class S3ImageService {
             addImageUrlFromS3(thumbnailKey, thumbnailImageUrls);
         }
         return thumbnailImageUrls;
+    }
+
+    // TODO 추후 수정 및 삭제 API 티켓에서 사용할 예정
+    public void deleteImageFromS3(String imageAddress) {
+        String key = getKeyFromImageAddress(imageAddress);
+        try {
+            amazonS3.deleteObject(new DeleteObjectRequest(bucketName, key));
+        } catch (AmazonS3Exception e) {
+            throw new RestApiException(AwsErrorCode.AMAZON_S3_EXCEPTION);
+        } catch (AmazonServiceException e) {
+            throw new RestApiException(AwsErrorCode.AMAZON_SERVICE_EXCEPTION);
+        } catch (Exception e) {
+            throw new RestApiException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private String generateImagePath(MultipartFile image, S3ImageType s3ImageType, Long memberId, Boolean isOrigin) {
+        String fileName = image.getOriginalFilename();
+        String uniqueId = UUID.randomUUID().toString();
+        String imageType = isOrigin ? originPath : thumbnailPath;
+
+        String basePath;
+        switch (s3ImageType) {
+            case PRODUCT -> basePath = photographerPath + memberId + productPath;
+            case PROFILE -> basePath = photographerPath + memberId + profilePath;
+            case RESERVATION -> basePath = customerPath + memberId + reservationPath;
+            default -> throw new RestApiException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+        }
+
+        return basePath + imageType + uniqueId + fileName;
     }
 
     private void uploadToS3(String key, InputStream imageInputStream, ObjectMetadata metadata) {
@@ -97,26 +146,12 @@ public class S3ImageService {
         originalImageUrls.add(imageUrl);
     }
 
-    // TODO 추후 수정 및 삭제 API 티켓에서 사용할 예정
-    public void deleteImageFromS3(String imageAddress) {
-        String key = getKeyFromImageAddress(imageAddress);
-        try {
-            amazonS3.deleteObject(new DeleteObjectRequest(bucketName, key));
-        } catch (AmazonS3Exception e) {
-            throw new RestApiException(AwsErrorCode.AMAZON_S3_EXCEPTION);
-        } catch (AmazonServiceException e) {
-            throw new RestApiException(AwsErrorCode.AMAZON_SERVICE_EXCEPTION);
-        } catch (Exception e) {
-            throw new RestApiException(CommonErrorCode.INTERNAL_SERVER_ERROR);
-        }
-    }
-
     private String getKeyFromImageAddress(String imageAddress) {
         try {
             URL url = new URL(imageAddress);
-            String decodingKey = URLDecoder.decode(url.getPath(), "UTF-8");
+            String decodingKey = URLDecoder.decode(url.getPath(), StandardCharsets.UTF_8);
             return decodingKey.substring(1); // 맨 앞의 '/' 제거
-        } catch (MalformedURLException | UnsupportedEncodingException e) {
+        } catch (MalformedURLException e) {
             throw new RestApiException(CommonErrorCode.IO_EXCEPTION);
         }
     }

--- a/src/main/java/com/foru/freebe/s3/S3ImageType.java
+++ b/src/main/java/com/foru/freebe/s3/S3ImageType.java
@@ -1,0 +1,7 @@
+package com.foru.freebe.s3;
+
+public enum S3ImageType {
+    PROFILE,
+    PRODUCT,
+    RESERVATION,
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         show_sql: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         show_sql: true
@@ -43,6 +43,24 @@ spring:
       enabled: true
       max-file-size: 10MB
       max-request-size: 10MB
+
+cloud:
+  aws:
+    credentials:
+      secret-key: ${AWS_SECRET_KEY}
+      access-key: ${AWS_ACCESS_KEY}
+    region:
+      static: ${AWS_REGION}
+    s3:
+      bucket: ${AWS_S3_BUCKET}
+      base-path:
+        original: ${AWS_S3_ORIGINAL_PATH}
+        thumbnail: ${AWS_S3_THUMBNAIL_PATH}
+        photographer: ${AWS_S3_PHOTOGRAPHER_PATH}
+        customer: ${AWS_S3_CUSTOMER_PATH}
+        product: ${AWS_S3_PRODUCT_PATH}
+        profile: ${AWS_S3_PROFILE_PATH}
+        reservation: ${AWS_S3_RESERVATION_PATH}
 
 logging:
   level:


### PR DESCRIPTION
## 체크리스트

- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
- 사진작가 회원가입 페이지에서 필요한 API 개발을 완료했습니다.
- 프로필 이미지 등록하는 로직을 구현했습니다. ProfileImage 테이블이 새로 추가되었습니다.
- S3 이미지 업로드 경로를 구체화했습니다.
1. 상품사진 등록: photograpers/{photographerId}/products/{파일명}
2. 프로필사진 등록: photographers/{photographerId}/profile/{파일명}
3. 레퍼런스 이미지 등록: customers/{customerId}/reservations/{파일명}

- 코드 상에서 @Value 어노테이션을 사용해 환경변수를 읽어올 때 기존에는 .properties에 등록된 환경변수를 참조했지만, AWS 관련 환경변수가 많아지고 계층을 나눌 필요성이 있다고 판단해 .yml파일의 계층적 구조를 사용하기로 했습니다. 

## 고민한 사항
- S3에 서로 다른 이미지를 업로드할 때 만약 파일명이 중복된다면 덮어쓰기 되면서 기존의 파일을 잃게되거나, 혹은 업로드 시 에러가 날 수 있음을 고려했습니다. 따라서 이미지 업로드 시에 고유한 파일명을 보장하기 위해 `랜덤스트링+파일명`으로 저장되게끔 구현했습니다. 
- 로그인 버그픽스 티켓의 시급도가 높아 해당 티켓의 테스트코드 작성은 FU-124에서 함께 처리할 예정입니다.
- @yuseok0215 가독성 문제로 인해 cd_workflow_dev.yml파일에 환경변수 등록 시, .properties파일과 환경변수 위치를 맞추는게 어떨까 하는 생각이 들었습니당 🙇‍♀️

## 리뷰 요청사항
시급도 (보통)
작성한 코드가 많지는 않아서 전반적으로 검토 부탁드립니다 :)