### PR TITLE
[FU-201] ResponseEntity<ResponseBody<T>>으로 responseType 변경

### DIFF
--- a/src/main/java/com/foru/freebe/auth/controller/AuthController.java
+++ b/src/main/java/com/foru/freebe/auth/controller/AuthController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.foru.freebe.auth.dto.LoginRequest;
 import com.foru.freebe.auth.model.KakaoUser;
 import com.foru.freebe.auth.service.AuthService;
-import com.foru.freebe.common.dto.ApiResponse;
+import com.foru.freebe.common.dto.ResponseBody;
 import com.foru.freebe.jwt.model.JwtTokenModel;
 import com.foru.freebe.jwt.service.JwtService;
 import com.foru.freebe.member.service.MemberService;
@@ -32,11 +32,13 @@ public class AuthController {
         JwtTokenModel token = jwtService.reissueToken(refreshToken);
         HttpHeaders headers = jwtService.setTokenHeaders(token);
 
-        return new ResponseEntity<>(headers, HttpStatus.OK);
+        return ResponseEntity.status(HttpStatus.OK.value())
+            .headers(headers)
+            .body(null);
     }
 
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<?>> login(@RequestBody LoginRequest loginRequest) {
+    public ResponseEntity<ResponseBody<?>> login(@RequestBody LoginRequest loginRequest) {
         String accessToken = authService.getToken(loginRequest.getCode());
         KakaoUser kakaoUser = authService.getUserInfo(accessToken);
 

--- a/src/main/java/com/foru/freebe/auth/dto/LoginResponse.java
+++ b/src/main/java/com/foru/freebe/auth/dto/LoginResponse.java
@@ -1,0 +1,22 @@
+package com.foru.freebe.auth.dto;
+
+import com.foru.freebe.jwt.model.JwtTokenModel;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginResponse {
+    private JwtTokenModel token;
+    private String uniqueUrl;
+    private String message;
+
+    @Builder
+    public LoginResponse(JwtTokenModel token, String uniqueUrl, String message) {
+        this.token = token;
+        this.uniqueUrl = uniqueUrl;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/foru/freebe/common/dto/ResponseBody.java
+++ b/src/main/java/com/foru/freebe/common/dto/ResponseBody.java
@@ -12,8 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
-public class ApiResponse<T> {
-    private int status;
+public class ResponseBody<T> {
     private String message;
     private T data;
 }

--- a/src/main/java/com/foru/freebe/config/SecurityConfig.java
+++ b/src/main/java/com/foru/freebe/config/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
                 .requestMatchers("/photographer/join").hasAnyRole("PHOTOGRAPHER_PENDING")
                 .requestMatchers("/photographer/**").hasAnyRole("PHOTOGRAPHER")
                 .requestMatchers("/customer/product/**").permitAll()
+                .requestMatchers("/customer/profile/**").permitAll()
                 .requestMatchers("/customer/**").hasAnyRole("CUSTOMER")
                 .requestMatchers("/admin/**").hasAnyRole("ADMIN")
                 .anyRequest().permitAll())

--- a/src/main/java/com/foru/freebe/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/foru/freebe/jwt/filter/JwtAuthenticationFilter.java
@@ -34,6 +34,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         List<RequestMatcher> matchers = new ArrayList<>();
         matchers.add(new AntPathRequestMatcher("/customer/product/**"));
+        matchers.add(new AntPathRequestMatcher("/customer/profile/**"));
         matchers.add(new AntPathRequestMatcher("/login/**"));
         matchers.add(new AntPathRequestMatcher("/reissue"));
 

--- a/src/main/java/com/foru/freebe/member/controller/JoinController.java
+++ b/src/main/java/com/foru/freebe/member/controller/JoinController.java
@@ -2,6 +2,8 @@ package com.foru.freebe.member.controller;
 
 import java.io.IOException;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -9,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.foru.freebe.auth.model.MemberAdapter;
-import com.foru.freebe.common.dto.ApiResponse;
+import com.foru.freebe.common.dto.ResponseBody;
 import com.foru.freebe.member.dto.PhotographerJoinRequest;
 import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.member.service.MemberService;
@@ -22,11 +24,19 @@ public class JoinController {
     private final MemberService memberService;
 
     @PostMapping("/photographer/join")
-    public ApiResponse<String> joinPhotographer(@AuthenticationPrincipal MemberAdapter memberAdapter,
+    public ResponseEntity<ResponseBody<String>> joinPhotographer(@AuthenticationPrincipal MemberAdapter memberAdapter,
         @RequestPart(value = "request") PhotographerJoinRequest request,
         @RequestPart(value = "image", required = false) MultipartFile image) throws IOException {
 
         Member member = memberAdapter.getMember();
-        return memberService.joinPhotographer(member, request, image);
+        String uniqueUrl = memberService.joinPhotographer(member, request, image);
+
+        ResponseBody<String> responseBody = ResponseBody.<String>builder()
+            .data(uniqueUrl)
+            .message("Successfully joined")
+            .build();
+
+        return ResponseEntity.status(HttpStatus.CREATED.value())
+            .body(responseBody);
     }
 }

--- a/src/main/java/com/foru/freebe/product/controller/CustomerProductController.java
+++ b/src/main/java/com/foru/freebe/product/controller/CustomerProductController.java
@@ -2,12 +2,14 @@ package com.foru.freebe.product.controller;
 
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.foru.freebe.common.dto.ApiResponse;
+import com.foru.freebe.common.dto.ResponseBody;
 import com.foru.freebe.product.dto.customer.ProductDetailResponse;
 import com.foru.freebe.product.dto.customer.ProductListResponse;
 import com.foru.freebe.product.service.CustomerProductService;
@@ -21,18 +23,47 @@ public class CustomerProductController {
     private final CustomerProductService customerProductService;
 
     @GetMapping("/product/list/{photographerId}")
-    public ApiResponse<List<ProductListResponse>> getProductList(
+    public ResponseEntity<ResponseBody<List<ProductListResponse>>> getProductList(
         @PathVariable("photographerId") Long photographerId) {
-        return customerProductService.getProductList(photographerId);
+
+        List<ProductListResponse> responseData = customerProductService.getProductList(photographerId);
+
+        ResponseBody<List<ProductListResponse>> responseBody = ResponseBody.<List<ProductListResponse>>builder()
+            .message("Good Request")
+            .data(responseData)
+            .build();
+
+        return ResponseEntity.status(HttpStatus.OK.value())
+            .body(responseBody);
     }
 
     @GetMapping("/product/details/{productId}")
-    public ApiResponse<ProductDetailResponse> getProductDetails(@PathVariable("productId") Long productId) {
-        return customerProductService.getDetailedInfoOfProduct(productId);
+    public ResponseEntity<ResponseBody<ProductDetailResponse>> getProductDetails(
+        @PathVariable("productId") Long productId) {
+
+        ProductDetailResponse responseData = customerProductService.getDetailedInfoOfProduct(productId);
+
+        ResponseBody<ProductDetailResponse> responseBody = ResponseBody.<ProductDetailResponse>builder()
+            .message("Good Response")
+            .data(responseData)
+            .build();
+
+        return ResponseEntity.status(HttpStatus.OK.value())
+            .body(responseBody);
     }
 
     @GetMapping("/product/images/{photographerId}")
-    public ApiResponse<List<String>> getReferenceImages(@PathVariable("photographerId") Long photographerId) {
-        return customerProductService.getReferenceImages(photographerId);
+    public ResponseEntity<ResponseBody<List<String>>> getReferenceImages(
+        @PathVariable("photographerId") Long photographerId) {
+
+        List<String> responseData = customerProductService.getReferenceImages(photographerId);
+
+        ResponseBody<List<String>> responseBody = ResponseBody.<List<String>>builder()
+            .message("Good Response")
+            .data(responseData)
+            .build();
+
+        return ResponseEntity.status(HttpStatus.OK.value())
+            .body(responseBody);
     }
 }

--- a/src/main/java/com/foru/freebe/product/controller/CustomerProductController.java
+++ b/src/main/java/com/foru/freebe/product/controller/CustomerProductController.java
@@ -52,11 +52,11 @@ public class CustomerProductController {
             .body(responseBody);
     }
 
-    @GetMapping("/product/images/{photographerId}")
+    @GetMapping("/product/images/{productId}")
     public ResponseEntity<ResponseBody<List<String>>> getReferenceImages(
-        @PathVariable("photographerId") Long photographerId) {
+        @PathVariable("productId") Long productId) {
 
-        List<String> responseData = customerProductService.getReferenceImages(photographerId);
+        List<String> responseData = customerProductService.getReferenceImages(productId);
 
         ResponseBody<List<String>> responseBody = ResponseBody.<List<String>>builder()
             .message("Good Response")

--- a/src/main/java/com/foru/freebe/product/controller/PhotographerProductController.java
+++ b/src/main/java/com/foru/freebe/product/controller/PhotographerProductController.java
@@ -3,6 +3,8 @@ package com.foru.freebe.product.controller;
 import java.io.IOException;
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.foru.freebe.auth.model.MemberAdapter;
-import com.foru.freebe.common.dto.ApiResponse;
+import com.foru.freebe.common.dto.ResponseBody;
 import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.product.dto.photographer.ProductRegisterRequest;
 import com.foru.freebe.product.dto.photographer.RegisteredProductResponse;
@@ -31,22 +33,51 @@ public class PhotographerProductController {
     private final PhotographerProductService productService;
 
     @PostMapping("/product")
-    public ApiResponse<Void> registerProduct(@AuthenticationPrincipal MemberAdapter memberAdapter,
+    public ResponseEntity<ResponseBody<Void>> registerProduct(@AuthenticationPrincipal MemberAdapter memberAdapter,
         @RequestPart(value = "request") ProductRegisterRequest request,
         @RequestPart(value = "images", required = false) List<MultipartFile> images) throws IOException {
+
         Member photographer = memberAdapter.getMember();
-        return productService.registerProduct(request, images, photographer.getId());
+        productService.registerProduct(request, images, photographer.getId());
+
+        ResponseBody<Void> responseBody = ResponseBody.<Void>builder()
+            .message("Successfully added")
+            .data(null)
+            .build();
+
+        return ResponseEntity.status(HttpStatus.CREATED.value())
+            .body(responseBody);
     }
 
     @GetMapping("/product/list")
-    public ApiResponse<List<RegisteredProductResponse>> getRegisteredProductList(
+    public ResponseEntity<ResponseBody<List<RegisteredProductResponse>>> getRegisteredProductList(
         @AuthenticationPrincipal MemberAdapter memberAdapter) {
+
         Member photographer = memberAdapter.getMember();
-        return productService.getRegisteredProductList(photographer);
+        List<RegisteredProductResponse> responseData = productService.getRegisteredProductList(photographer);
+
+        ResponseBody<List<RegisteredProductResponse>> responseBody = ResponseBody
+            .<List<RegisteredProductResponse>>builder()
+            .message("Successfully retrieved list of registered products")
+            .data(responseData)
+            .build();
+
+        return ResponseEntity.status(HttpStatus.OK.value())
+            .body(responseBody);
     }
 
     @PutMapping("/product/status")
-    public ApiResponse<Void> updateProductActiveStatus(@Valid @RequestBody UpdateProductRequest updateProductRequest) {
-        return productService.updateProductActiveStatus(updateProductRequest);
+    public ResponseEntity<ResponseBody<Void>> updateProductActiveStatus(
+        @Valid @RequestBody UpdateProductRequest updateProductRequest) {
+
+        productService.updateProductActiveStatus(updateProductRequest);
+
+        ResponseBody<Void> responseBody = ResponseBody.<Void>builder()
+            .message("Successfully updated product active status")
+            .data(null)
+            .build();
+
+        return ResponseEntity.status(HttpStatus.OK.value())
+            .body(responseBody);
     }
 }

--- a/src/main/java/com/foru/freebe/product/respository/ProductRepository.java
+++ b/src/main/java/com/foru/freebe/product/respository/ProductRepository.java
@@ -11,7 +11,7 @@ import com.foru.freebe.product.entity.Product;
 public interface ProductRepository extends JpaRepository<Product, Long> {
     Optional<List<Product>> findByMember(Member member);
 
-    Boolean existsByTitle(String title);
+    Boolean existsByTitleAndMember(String title, Member member);
 
-    Product findByTitle(String title);
+    Product findByTitleAndMember(String title, Member member);
 }

--- a/src/main/java/com/foru/freebe/product/service/CustomerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/CustomerProductService.java
@@ -37,8 +37,8 @@ public class CustomerProductService {
     private final ProductOptionRepository productOptionRepository;
     private final ProductDiscountRepository productDiscountRepository;
 
-    public List<String> getReferenceImages(Long photographerId) {
-        List<ProductImage> productImages = productImageRepository.findByProductId(photographerId);
+    public List<String> getReferenceImages(Long productId) {
+        List<ProductImage> productImages = productImageRepository.findByProductId(productId);
 
         List<String> referenceImages = new ArrayList<>();
         for (ProductImage productImage : productImages) {

--- a/src/main/java/com/foru/freebe/product/service/CustomerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/CustomerProductService.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
-import com.foru.freebe.common.dto.ApiResponse;
 import com.foru.freebe.errors.errorcode.CommonErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
 import com.foru.freebe.member.entity.Member;
@@ -38,7 +37,7 @@ public class CustomerProductService {
     private final ProductOptionRepository productOptionRepository;
     private final ProductDiscountRepository productDiscountRepository;
 
-    public ApiResponse<List<String>> getReferenceImages(Long photographerId) {
+    public List<String> getReferenceImages(Long photographerId) {
         List<ProductImage> productImages = productImageRepository.findByProductId(photographerId);
 
         List<String> referenceImages = new ArrayList<>();
@@ -46,14 +45,10 @@ public class CustomerProductService {
             referenceImages.add(productImage.getOriginUrl());
         }
 
-        return ApiResponse.<List<String>>builder()
-            .status(200)
-            .message("Good Response")
-            .data(referenceImages)
-            .build();
+        return referenceImages;
     }
 
-    public ApiResponse<ProductDetailResponse> getDetailedInfoOfProduct(Long productId) {
+    public ProductDetailResponse getDetailedInfoOfProduct(Long productId) {
         Product product = productRepository.findById(productId)
             .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
 
@@ -62,7 +57,7 @@ public class CustomerProductService {
         List<ProductOptionDto> productOptions = getProductOptions(product);
         List<ProductDiscountDto> productDiscounts = getProductDiscounts(product);
 
-        ProductDetailResponse productDetailResponse = ProductDetailResponse.builder()
+        return ProductDetailResponse.builder()
             .productTitle(product.getTitle())
             .productDescription(product.getDescription())
             .productImageUrls(productImageUrls)
@@ -70,15 +65,9 @@ public class CustomerProductService {
             .productOptions(productOptions)
             .productDiscounts(productDiscounts)
             .build();
-
-        return ApiResponse.<ProductDetailResponse>builder()
-            .status(200)
-            .message("Good Response")
-            .data(productDetailResponse)
-            .build();
     }
 
-    public ApiResponse<List<ProductListResponse>> getProductList(Long photographerId) {
+    public List<ProductListResponse> getProductList(Long photographerId) {
         Member photographer = memberRepository.findById(photographerId)
             .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
 
@@ -97,11 +86,8 @@ public class CustomerProductService {
 
             productListResponseList.add(productListResponse);
         }
-        return ApiResponse.<List<ProductListResponse>>builder()
-            .status(200)
-            .message("Good Request")
-            .data(productListResponseList)
-            .build();
+
+        return productListResponseList;
     }
 
     private List<ProductDiscountDto> getProductDiscounts(Product product) {

--- a/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
@@ -8,7 +8,6 @@ import java.util.stream.IntStream;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.foru.freebe.common.dto.ApiResponse;
 import com.foru.freebe.errors.errorcode.CommonErrorCode;
 import com.foru.freebe.errors.errorcode.ProductErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
@@ -52,7 +51,7 @@ public class PhotographerProductService {
     private final ReservationFormRepository reservationFormRepository;
     private final S3ImageService s3ImageService;
 
-    public ApiResponse<Void> registerProduct(ProductRegisterRequest productRegisterRequestDto,
+    public void registerProduct(ProductRegisterRequest productRegisterRequestDto,
         List<MultipartFile> images, Long photographerId) throws IOException {
         Member member = getMember(photographerId);
 
@@ -71,19 +70,13 @@ public class PhotographerProductService {
         if (productRegisterRequestDto.getProductDiscounts() != null) {
             registerDiscount(productRegisterRequestDto.getProductDiscounts(), productAsActive);
         }
-
-        return ApiResponse.<Void>builder()
-            .status(200)
-            .message("Successfully added")
-            .data(null)
-            .build();
     }
 
-    public ApiResponse<List<RegisteredProductResponse>> getRegisteredProductList(Member member) {
+    public List<RegisteredProductResponse> getRegisteredProductList(Member member) {
         List<Product> registeredProductList = productRepository.findByMember(member)
             .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
 
-        List<RegisteredProductResponse> registeredProducts = registeredProductList.stream()
+        return registeredProductList.stream()
             .map(product -> RegisteredProductResponse.builder()
                 .productId(product.getId())
                 .productTitle(product.getTitle())
@@ -91,12 +84,6 @@ public class PhotographerProductService {
                 .activeStatus(product.getActiveStatus())
                 .build())
             .collect(Collectors.toList());
-
-        return ApiResponse.<List<RegisteredProductResponse>>builder()
-            .status(200)
-            .message("Successfully retrieved list of registered products")
-            .data(registeredProducts)
-            .build();
     }
 
     private Integer getReservationCount(Long id, String productTitle) {
@@ -106,16 +93,10 @@ public class PhotographerProductService {
     }
 
     @Transactional
-    public ApiResponse<Void> updateProductActiveStatus(UpdateProductRequest requestDto) {
+    public void updateProductActiveStatus(UpdateProductRequest requestDto) {
         Product product = productRepository.findById(requestDto.getProductId())
             .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
         product.updateProductActiveStatus(requestDto.getActiveStatus());
-
-        return ApiResponse.<Void>builder()
-            .status(200)
-            .message("Successfully updated product active status")
-            .data(null)
-            .build();
     }
 
     private Product registerActiveProduct(ProductRegisterRequest productRegisterRequestDto, Member member) {

--- a/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
@@ -53,13 +53,13 @@ public class PhotographerProductService {
 
     public void registerProduct(ProductRegisterRequest productRegisterRequestDto,
         List<MultipartFile> images, Long photographerId) throws IOException {
-        Member member = getMember(photographerId);
+        Member photographer = getMember(photographerId);
 
         if (images.isEmpty()) {
             throw new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND);
         }
 
-        Product productAsActive = registerActiveProduct(productRegisterRequestDto, member);
+        Product productAsActive = registerActiveProduct(productRegisterRequestDto, photographer);
         registerProductImage(images, productAsActive, photographerId);
         registerProductComponent(productRegisterRequestDto.getProductComponents(), productAsActive);
 
@@ -99,23 +99,23 @@ public class PhotographerProductService {
         product.updateProductActiveStatus(requestDto.getActiveStatus());
     }
 
-    private Product registerActiveProduct(ProductRegisterRequest productRegisterRequestDto, Member member) {
+    private Product registerActiveProduct(ProductRegisterRequest productRegisterRequestDto, Member photographer) {
         String productTitle = productRegisterRequestDto.getProductTitle();
         String productDescription = productRegisterRequestDto.getProductDescription();
 
         Product productAsActive;
         if (productDescription != null) {
-            productAsActive = Product.createProductAsActive(productTitle, productDescription, member);
+            productAsActive = Product.createProductAsActive(productTitle, productDescription, photographer);
         } else {
-            productAsActive = Product.createProductAsActiveWithoutDescription(productTitle, member);
+            productAsActive = Product.createProductAsActiveWithoutDescription(productTitle, photographer);
         }
 
-        validateProductTitle(productTitle);
+        validateProductTitle(productTitle, photographer);
         return productRepository.save(productAsActive);
     }
 
-    private void validateProductTitle(String productTitle) {
-        Product product = productRepository.findByTitle(productTitle);
+    private void validateProductTitle(String productTitle, Member photographer) {
+        Product product = productRepository.findByTitleAndMember(productTitle, photographer);
         if (product != null) {
             throw new RestApiException(ProductErrorCode.PRODUCT_ALREADY_EXISTS);
         }

--- a/src/main/java/com/foru/freebe/profile/Controller/CustomerProfileController.java
+++ b/src/main/java/com/foru/freebe/profile/Controller/CustomerProfileController.java
@@ -1,11 +1,13 @@
 package com.foru.freebe.profile.Controller;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.foru.freebe.common.dto.ApiResponse;
+import com.foru.freebe.common.dto.ResponseBody;
 import com.foru.freebe.profile.dto.ProfileResponse;
 import com.foru.freebe.profile.service.ProfileService;
 
@@ -19,14 +21,17 @@ public class CustomerProfileController {
     private final ProfileService profileService;
 
     @GetMapping("/profile/{uniqueUrl}")
-    public ApiResponse<ProfileResponse> getPhotographerProfile(
+    public ResponseEntity<ResponseBody<ProfileResponse>> getPhotographerProfile(
         @Valid @PathVariable("uniqueUrl") String uniqueUrl) {
-        ProfileResponse profileResponse = profileService.getPhotographerProfile(uniqueUrl);
 
-        return ApiResponse.<ProfileResponse>builder()
-            .status(200)
+        ProfileResponse responseData = profileService.getPhotographerProfile(uniqueUrl);
+
+        ResponseBody<ProfileResponse> responseBody = ResponseBody.<ProfileResponse>builder()
             .message("Good Response")
-            .data(profileResponse)
+            .data(responseData)
             .build();
+
+        return ResponseEntity.status(HttpStatus.OK.value())
+            .body(responseBody);
     }
 }

--- a/src/main/java/com/foru/freebe/profile/Controller/PhotographerProfileController.java
+++ b/src/main/java/com/foru/freebe/profile/Controller/PhotographerProfileController.java
@@ -2,6 +2,8 @@ package com.foru.freebe.profile.Controller;
 
 import java.io.IOException;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -11,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.foru.freebe.auth.model.MemberAdapter;
-import com.foru.freebe.common.dto.ApiResponse;
+import com.foru.freebe.common.dto.ResponseBody;
 import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.profile.dto.ProfileResponse;
 import com.foru.freebe.profile.dto.UpdateProfileRequest;
@@ -26,16 +28,34 @@ public class PhotographerProfileController {
     private final ProfileService profileService;
 
     @GetMapping("/profile")
-    public ApiResponse<ProfileResponse> getCurrentProfile(@AuthenticationPrincipal MemberAdapter memberAdapter) {
+    public ResponseEntity<ResponseBody<ProfileResponse>> getCurrentProfile(
+        @AuthenticationPrincipal MemberAdapter memberAdapter) {
+
         Member photographer = memberAdapter.getMember();
-        return profileService.getCurrentProfile(photographer);
+        ProfileResponse responseData = profileService.getCurrentProfile(photographer);
+
+        ResponseBody<ProfileResponse> responseBody = ResponseBody.<ProfileResponse>builder()
+            .message("Good Response")
+            .data(responseData).build();
+
+        return ResponseEntity.status(HttpStatus.OK.value())
+            .body(responseBody);
     }
 
     @PutMapping("/profile")
-    public ApiResponse<Void> updateProfile(@RequestPart(value = "request") UpdateProfileRequest updateRequest,
+    public ResponseEntity<ResponseBody<Void>> updateProfile(
+        @RequestPart(value = "request") UpdateProfileRequest updateRequest,
         @RequestPart(value = "image", required = false) MultipartFile profileImage,
         @AuthenticationPrincipal MemberAdapter memberAdapter) throws IOException {
+
         Member photographer = memberAdapter.getMember();
-        return profileService.updateProfile(updateRequest, photographer, profileImage);
+        profileService.updateProfile(updateRequest, photographer, profileImage);
+
+        ResponseBody<Void> responseBody = ResponseBody.<Void>builder()
+            .message("Updated successfully")
+            .data(null).build();
+
+        return ResponseEntity.status(HttpStatus.OK.value())
+            .body(responseBody);
     }
 }

--- a/src/main/java/com/foru/freebe/profile/dto/UpdateProfileRequest.java
+++ b/src/main/java/com/foru/freebe/profile/dto/UpdateProfileRequest.java
@@ -10,12 +10,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class UpdateProfileRequest {
     private String bannerImageUrl;
+    private String instagramId;
     private String introductionContent;
     private List<LinkInfo> linkInfos;
 
     @Builder
-    public UpdateProfileRequest(String bannerImageUrl, String introductionContent, List<LinkInfo> linkInfos) {
+    public UpdateProfileRequest(String bannerImageUrl, String instagramId, String introductionContent,
+        List<LinkInfo> linkInfos) {
         this.bannerImageUrl = bannerImageUrl;
+        this.instagramId = instagramId;
         this.introductionContent = introductionContent;
         this.linkInfos = linkInfos;
     }

--- a/src/main/java/com/foru/freebe/profile/repository/ProfileImageRepository.java
+++ b/src/main/java/com/foru/freebe/profile/repository/ProfileImageRepository.java
@@ -1,5 +1,7 @@
 package com.foru.freebe.profile.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.foru.freebe.profile.entity.Profile;
@@ -8,7 +10,7 @@ import com.foru.freebe.profile.entity.ProfileImage;
 public interface ProfileImageRepository extends JpaRepository<ProfileImage, Long> {
     Boolean existsByProfile(Profile profile);
 
-    ProfileImage findByProfile(Profile profile);
+    Optional<ProfileImage> findByProfile(Profile profile);
 
     void deleteByProfile(Profile profile);
 }

--- a/src/main/java/com/foru/freebe/reservation/controller/CustomerReservationController.java
+++ b/src/main/java/com/foru/freebe/reservation/controller/CustomerReservationController.java
@@ -3,7 +3,9 @@ package com.foru.freebe.reservation.controller;
 import java.io.IOException;
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -14,13 +16,12 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.foru.freebe.auth.model.MemberAdapter;
-import com.foru.freebe.common.dto.ApiResponse;
+import com.foru.freebe.common.dto.ResponseBody;
 import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.reservation.dto.BasicReservationInfoResponse;
 import com.foru.freebe.reservation.dto.FormRegisterRequest;
 import com.foru.freebe.reservation.dto.ReservationInfoResponse;
 import com.foru.freebe.reservation.service.CustomerReservationService;
-import com.foru.freebe.s3.S3ImageService;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -30,29 +31,58 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/customer")
 public class CustomerReservationController {
     private final CustomerReservationService customerReservationService;
-    private final S3ImageService s3ImageService;
 
     @PostMapping(value = "/reservation", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE,
         MediaType.APPLICATION_JSON_VALUE})
-    public ApiResponse<Long> registerReservationForm(@RequestPart("request") FormRegisterRequest request,
+    public ResponseEntity<ResponseBody<Long>> registerReservationForm(
+        @RequestPart("request") FormRegisterRequest request,
         @AuthenticationPrincipal MemberAdapter memberAdapter,
         @RequestPart(value = "images", required = false) List<MultipartFile> images) throws IOException {
+
         Member customer = memberAdapter.getMember();
-        return customerReservationService.registerReservationForm(customer.getId(), request, images);
+        Long responseData = customerReservationService.registerReservationForm(customer.getId(), request, images);
+
+        ResponseBody<Long> responseBody = ResponseBody.<Long>builder()
+            .message("Good Request")
+            .data(responseData)
+            .build();
+
+        return ResponseEntity.status(HttpStatus.OK.value())
+            .body(responseBody);
     }
 
     @GetMapping("/reservation/form/{productId}")
-    public ApiResponse<BasicReservationInfoResponse> getBasicReservationForm(
+    public ResponseEntity<ResponseBody<BasicReservationInfoResponse>> getBasicReservationForm(
         @AuthenticationPrincipal MemberAdapter memberAdapter, @Valid @PathVariable("productId") Long productId) {
+
         Member customer = memberAdapter.getMember();
-        return customerReservationService.getBasicReservationForm(customer.getId(), productId);
+        BasicReservationInfoResponse responseData = customerReservationService.getBasicReservationForm(
+            customer.getId(), productId);
+
+        ResponseBody<BasicReservationInfoResponse> responseBody = ResponseBody.<BasicReservationInfoResponse>builder()
+            .message("Good Response")
+            .data(responseData)
+            .build();
+
+        return ResponseEntity.status(HttpStatus.OK.value())
+            .body(responseBody);
     }
 
     @GetMapping("/reservation/{reservationFormId}")
-    public ApiResponse<ReservationInfoResponse> getReservationInfo(
+    public ResponseEntity<ResponseBody<ReservationInfoResponse>> getReservationInfo(
         @AuthenticationPrincipal MemberAdapter memberAdapter,
         @Valid @PathVariable("reservationFormId") Long reservationFormId) {
+
         Member customer = memberAdapter.getMember();
-        return customerReservationService.getReservationInfo(reservationFormId, customer.getId());
+        ReservationInfoResponse responseData = customerReservationService.getReservationInfo(reservationFormId,
+            customer.getId());
+
+        ResponseBody<ReservationInfoResponse> responseBody = ResponseBody.<ReservationInfoResponse>builder()
+            .message("Good Response")
+            .data(responseData)
+            .build();
+
+        return ResponseEntity.status(HttpStatus.OK.value())
+            .body(responseBody);
     }
 }

--- a/src/main/java/com/foru/freebe/reservation/controller/PhotographerReservationController.java
+++ b/src/main/java/com/foru/freebe/reservation/controller/PhotographerReservationController.java
@@ -2,6 +2,8 @@ package com.foru.freebe.reservation.controller;
 
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -11,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.foru.freebe.auth.model.MemberAdapter;
-import com.foru.freebe.common.dto.ApiResponse;
+import com.foru.freebe.common.dto.ResponseBody;
 import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.reservation.dto.FormDetailsViewResponse;
 import com.foru.freebe.reservation.dto.FormListViewResponse;
@@ -30,27 +32,51 @@ public class PhotographerReservationController {
     private final PhotographerReservationDetails photographerReservationDetails;
 
     @GetMapping("/reservation/list")
-    public ApiResponse<List<FormListViewResponse>> getReservationList(
+    public ResponseEntity<ResponseBody<List<FormListViewResponse>>> getReservationList(
         @AuthenticationPrincipal MemberAdapter memberAdapter) {
 
         Member member = memberAdapter.getMember();
-        return photographerReservationService.getReservationList(member.getId());
+        List<FormListViewResponse> responseData = photographerReservationService.getReservationList(member.getId());
+
+        ResponseBody<List<FormListViewResponse>> responseBody = ResponseBody.<List<FormListViewResponse>>builder()
+            .message("Successfully get reservation list")
+            .data(responseData)
+            .build();
+
+        return ResponseEntity.status(HttpStatus.OK.value())
+            .body(responseBody);
     }
 
     @GetMapping("/reservation/details/{formId}")
-    public ApiResponse<FormDetailsViewResponse> getReservationFormDetails(
+    public ResponseEntity<ResponseBody<FormDetailsViewResponse>> getReservationFormDetails(
         @AuthenticationPrincipal MemberAdapter memberAdapter, @PathVariable("formId") Long formId) {
 
         Member member = memberAdapter.getMember();
-        return photographerReservationDetails.getReservationFormDetails(member.getId(), formId);
+        FormDetailsViewResponse responseData = photographerReservationDetails.getReservationFormDetails(
+            member.getId(), formId);
+
+        ResponseBody<FormDetailsViewResponse> responseBody = ResponseBody.<FormDetailsViewResponse>builder()
+            .message("Successfully get reservation list")
+            .data(responseData)
+            .build();
+
+        return ResponseEntity.status(HttpStatus.OK.value())
+            .body(responseBody);
     }
 
     @PutMapping("/reservation/details/{formId}")
-    public ApiResponse<Void> updateReservationFormDetails(
+    public ResponseEntity<ResponseBody<Void>> updateReservationFormDetails(
         @AuthenticationPrincipal MemberAdapter memberAdapter, @PathVariable("formId") Long formId,
         @Valid @RequestBody ReservationStatusUpdateRequest request) {
 
         Member member = memberAdapter.getMember();
-        return photographerReservationDetails.updateReservationStatus(member.getId(), formId, request);
+        photographerReservationDetails.updateReservationStatus(member.getId(), formId, request);
+
+        ResponseBody<Void> responseBody = ResponseBody.<Void>builder()
+            .message("Successfully update reservation status")
+            .build();
+
+        return ResponseEntity.status(HttpStatus.OK.value())
+            .body(responseBody);
     }
 }

--- a/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
@@ -8,7 +8,6 @@ import java.util.stream.IntStream;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.foru.freebe.common.dto.ApiResponse;
 import com.foru.freebe.errors.errorcode.CommonErrorCode;
 import com.foru.freebe.errors.errorcode.ProductErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
@@ -52,7 +51,7 @@ public class CustomerReservationService {
     private final ReferenceImageRepository referenceImageRepository;
     private final S3ImageService s3ImageService;
 
-    public ApiResponse<Long> registerReservationForm(Long id, FormRegisterRequest formRegisterRequest,
+    public Long registerReservationForm(Long id, FormRegisterRequest formRegisterRequest,
         List<MultipartFile> images) throws IOException {
         Member customer = findMember(id);
         Member photographer = findMember(formRegisterRequest.getPhotographerId());
@@ -65,15 +64,11 @@ public class CustomerReservationService {
             REFERENCE_THUMBNAIL_SIZE);
         saveReservationForm(originalImageUrls, thumbnailImageUrls, reservationForm);
 
-        return ApiResponse.<Long>builder()
-            .status(200)
-            .message("Good Request")
-            .data(reservationForm.getId())
-            .build();
+        return reservationForm.getId();
     }
 
     // TODO 추후 사진작가의 촬영 오픈일정 관련 로직이 추가되면 예약신청서 작성할 때 사진작가의 일정 조회 로직이 필요함
-    public ApiResponse<BasicReservationInfoResponse> getBasicReservationForm(Long customerId, Long productId) {
+    public BasicReservationInfoResponse getBasicReservationForm(Long customerId, Long productId) {
         Member customer = findMember(customerId);
 
         Product product = productRepository.findById(productId)
@@ -86,39 +81,27 @@ public class CustomerReservationService {
         List<ProductOption> productOptions = productOptionRepository.findByProduct(product);
         List<ProductOptionDto> productOptionDtoList = convertProductOptionDtoList(productOptions);
 
-        BasicReservationInfoResponse basicReservationInfoResponse = BasicReservationInfoResponse.builder()
+        return BasicReservationInfoResponse.builder()
             .name(customer.getName())
             .phoneNumber(customer.getPhoneNumber())
             .productComponentDtoList(productComponentDtoList)
             .productOptionDtoList(productOptionDtoList)
             .build();
-
-        return ApiResponse.<BasicReservationInfoResponse>builder()
-            .status(200)
-            .message("Good Response")
-            .data(basicReservationInfoResponse)
-            .build();
     }
 
-    public ApiResponse<ReservationInfoResponse> getReservationInfo(Long reservationFormId, Long customerId) {
+    public ReservationInfoResponse getReservationInfo(Long reservationFormId, Long customerId) {
         ReservationForm reservationForm = reservationFormRepository.findById(reservationFormId)
             .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
 
         validateCustomerAccess(reservationForm, customerId);
 
-        ReservationInfoResponse reservationInfoResponse = ReservationInfoResponse.builder()
+        return ReservationInfoResponse.builder()
             .reservationStatus(reservationForm.getReservationStatus())
             .productTitle(reservationForm.getProductTitle())
             .photoInfo(reservationForm.getPhotoInfo())
             .preferredDate(reservationForm.getPreferredDate())
             .photoOptions(reservationForm.getPhotoOption())
             .customerMemo(reservationForm.getCustomerMemo())
-            .build();
-
-        return ApiResponse.<ReservationInfoResponse>builder()
-            .status(200)
-            .message("Good Response")
-            .data(reservationInfoResponse)
             .build();
     }
 

--- a/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
@@ -57,7 +57,7 @@ public class CustomerReservationService {
         Member photographer = findMember(formRegisterRequest.getPhotographerId());
 
         ReservationForm reservationForm = createReservationForm(formRegisterRequest, photographer, customer);
-        validateReservationForm(formRegisterRequest);
+        validateReservationForm(formRegisterRequest, photographer);
 
         List<String> originalImageUrls = s3ImageService.uploadOriginalImages(images, S3ImageType.RESERVATION, id);
         List<String> thumbnailImageUrls = s3ImageService.uploadThumbnailImages(images, S3ImageType.RESERVATION, id,
@@ -139,20 +139,20 @@ public class CustomerReservationService {
         return builder.build();
     }
 
-    private void validateReservationForm(FormRegisterRequest formRegisterRequest) {
-        validateProductTitleExists(formRegisterRequest.getProductTitle());
-        validateProductIsActive(formRegisterRequest.getProductTitle());
+    private void validateReservationForm(FormRegisterRequest formRegisterRequest, Member photographer) {
+        validateProductTitleExists(formRegisterRequest.getProductTitle(), photographer);
+        validateProductIsActive(formRegisterRequest.getProductTitle(), photographer);
     }
 
-    private void validateProductIsActive(String productTitle) {
-        Product product = productRepository.findByTitle(productTitle);
+    private void validateProductIsActive(String productTitle, Member photographer) {
+        Product product = productRepository.findByTitleAndMember(productTitle, photographer);
         if (product.getActiveStatus() != ActiveStatus.ACTIVE) {
             throw new RestApiException(ProductErrorCode.PRODUCT_INACTIVE_STATUS);
         }
     }
 
-    private void validateProductTitleExists(String productTitle) {
-        if (!productRepository.existsByTitle(productTitle)) {
+    private void validateProductTitleExists(String productTitle, Member photographer) {
+        if (!productRepository.existsByTitleAndMember(productTitle, photographer)) {
             throw new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND);
         }
     }

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationDetails.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationDetails.java
@@ -6,7 +6,6 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
-import com.foru.freebe.common.dto.ApiResponse;
 import com.foru.freebe.errors.errorcode.CommonErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
 import com.foru.freebe.reservation.dto.CustomerDetails;
@@ -33,7 +32,7 @@ public class PhotographerReservationDetails {
     private final ReservationHistoryRepository reservationHistoryRepository;
     private final ReferenceImageRepository referenceImageRepository;
 
-    public ApiResponse<FormDetailsViewResponse> getReservationFormDetails(Long photographerId, Long formId) {
+    public FormDetailsViewResponse getReservationFormDetails(Long photographerId, Long formId) {
         ReservationForm reservationForm = findReservationForm(photographerId, formId);
         List<StatusHistory> statusHistories = getStatusHistories(reservationForm);
 
@@ -42,7 +41,7 @@ public class PhotographerReservationDetails {
         Map<Integer, PreferredDate> preferredDates = reservationForm.getPreferredDate();
         ReferenceImageUrls preferredImages = getPreferredImages(reservationForm);
 
-        FormDetailsViewResponse formDetailsViewResponse = FormDetailsViewResponse.builder(reservationForm.getId(),
+        return FormDetailsViewResponse.builder(reservationForm.getId(),
                 reservationForm.getReservationStatus(), statusHistories, reservationForm.getProductTitle(), customerDetails,
                 shootDetails, preferredDates)
             .photoOptions(reservationForm.getPhotoOption())
@@ -51,16 +50,10 @@ public class PhotographerReservationDetails {
             .requestMemo(reservationForm.getCustomerMemo())
             .photographerMemo(reservationForm.getPhotographerMemo())
             .build();
-
-        return ApiResponse.<FormDetailsViewResponse>builder()
-            .message("Successfully get reservation list")
-            .status(200)
-            .data(formDetailsViewResponse)
-            .build();
     }
 
     @Transactional
-    public ApiResponse<Void> updateReservationStatus(Long photographerId, Long formId,
+    public void updateReservationStatus(Long photographerId, Long formId,
         ReservationStatusUpdateRequest request) {
 
         ReservationForm reservationForm = findReservationForm(photographerId, formId);
@@ -71,11 +64,6 @@ public class PhotographerReservationDetails {
 
         reservationFormRepository.save(reservationForm);
         reservationHistoryRepository.save(history);
-
-        return ApiResponse.<Void>builder()
-            .message("Successfully update reservation status")
-            .status(200)
-            .build();
     }
 
     private ReservationHistory getReservationHistory(ReservationStatusUpdateRequest request,

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
@@ -8,7 +8,6 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
-import com.foru.freebe.common.dto.ApiResponse;
 import com.foru.freebe.constants.SortConstants;
 import com.foru.freebe.reservation.dto.FormComponent;
 import com.foru.freebe.reservation.dto.FormListViewResponse;
@@ -23,14 +22,8 @@ import lombok.RequiredArgsConstructor;
 public class PhotographerReservationService {
     private final ReservationFormRepository reservationFormRepository;
 
-    public ApiResponse<List<FormListViewResponse>> getReservationList(Long photographerId) {
-        List<FormListViewResponse> data = getReservationListAsStatus(photographerId);
-
-        return ApiResponse.<List<FormListViewResponse>>builder()
-            .message("Successfully get reservation list")
-            .status(200)
-            .data(data)
-            .build();
+    public List<FormListViewResponse> getReservationList(Long photographerId) {
+        return getReservationListAsStatus(photographerId);
     }
 
     private List<FormListViewResponse> getReservationListAsStatus(Long id) {

--- a/src/test/java/com/foru/freebe/profile/service/ProfileServiceTest.java
+++ b/src/test/java/com/foru/freebe/profile/service/ProfileServiceTest.java
@@ -120,6 +120,7 @@ class ProfileServiceTest {
             "file contents".getBytes());
 
         when(profileRepository.findByMember(photographer)).thenReturn(Optional.of(existingProfile));
+        when(memberRepository.findById(photographer.getId())).thenReturn(Optional.of(photographer));
 
         // When
         profileService.updateProfile(updateRequest, photographer, requestImage);
@@ -161,6 +162,7 @@ class ProfileServiceTest {
 
         when(profileRepository.findByMember(photographer)).thenReturn(Optional.of(existingProfile));
         when(linkRepository.findByProfile(existingProfile)).thenReturn(Arrays.asList(link1, link2));
+        when(memberRepository.findById(photographer.getId())).thenReturn(Optional.of(photographer));
 
         // When
         profileService.updateProfile(updateRequest, photographer, requestImage);

--- a/src/test/java/com/foru/freebe/profile/service/ProfileServiceTest.java
+++ b/src/test/java/com/foru/freebe/profile/service/ProfileServiceTest.java
@@ -77,6 +77,7 @@ class ProfileServiceTest {
 
         // When
         ProfileResponse result = profileService.getCurrentProfile(photographer);
+
         // Then
         assertNotNull(result);
         assertEquals("http://thumbnails.com", result.getProfileImageUrl());
@@ -124,6 +125,8 @@ class ProfileServiceTest {
 
         // When
         profileService.updateProfile(updateRequest, photographer, requestImage);
+
+        // then
         assertEquals("http://originurl.com", profileImage.getOriginUrl());
         assertEquals("changed content", existingProfile.getIntroductionContent());
         assertEquals("banner.jpg", existingProfile.getBannerImageUrl());
@@ -140,6 +143,7 @@ class ProfileServiceTest {
     @DisplayName("사진작가 측 프로필의 외부 링크 업데이트")
     @Test
     void testUpdateLinks() throws IOException {
+        // Given
         Member photographer = createNewMember();
         Profile existingProfile = createProfile(photographer);
 

--- a/src/test/java/com/foru/freebe/profile/service/ProfileServiceTest.java
+++ b/src/test/java/com/foru/freebe/profile/service/ProfileServiceTest.java
@@ -1,170 +1,198 @@
 package com.foru.freebe.profile.service;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockMultipartFile;
+
+import com.foru.freebe.member.entity.Member;
+import com.foru.freebe.member.entity.Role;
+import com.foru.freebe.member.repository.MemberRepository;
+import com.foru.freebe.profile.dto.LinkInfo;
+import com.foru.freebe.profile.dto.ProfileResponse;
+import com.foru.freebe.profile.dto.UpdateProfileRequest;
+import com.foru.freebe.profile.entity.Link;
+import com.foru.freebe.profile.entity.Profile;
+import com.foru.freebe.profile.entity.ProfileImage;
+import com.foru.freebe.profile.repository.LinkRepository;
+import com.foru.freebe.profile.repository.ProfileImageRepository;
+import com.foru.freebe.profile.repository.ProfileRepository;
+import com.foru.freebe.s3.S3ImageService;
+
 class ProfileServiceTest {
 
-    //     private static final String UNIQUE_URL = "unique-url";
-    //
-    //     @Mock
-    //     private MemberRepository memberRepository;
-    //
-    //     @Mock
-    //     private ProfileRepository profileRepository;
-    //
-    //     @Mock
-    //     private ProfileImageRepository profileImageRepository;
-    //
-    //     @Mock
-    //     private LinkRepository linkRepository;
-    //
-    //     @Mock
-    //     private S3ImageService s3ImageService;
-    //
-    //     @InjectMocks
-    //     private ProfileService profileService;
-    //
-    //     @BeforeEach
-    //     void setUp() {
-    //         MockitoAnnotations.openMocks(this);
-    //         profileService = spy(
-    //             new ProfileService(memberRepository, profileRepository, linkRepository, profileImageRepository,
-    //                 s3ImageService));
-    //     }
-    //
-    //     @DisplayName("사진작가 측 현재 프로필 조회")
-    //     @Test
-    //     void testGetCurrentProfile() {
-    //         // Given
-    //         Member photographer = createNewMember();
-    //         Profile profile = createProfile(photographer);
-    //         ProfileImage profileImage = createProfileImage(profile);
-    //
-    //         Link link1 = createLink(profile, "My Portfolio", "http://portfolio.com");
-    //         Link link2 = createLink(profile, "My Blog", "http://blog.com");
-    //
-    //         when(profileRepository.findByMember(photographer)).thenReturn(Optional.of(profile));
-    //         when(linkRepository.findByProfile(profile)).thenReturn(Arrays.asList(link1, link2));
-    //         when(profileImageRepository.findByProfile(profile)).thenReturn(profileImage);
-    //
-    //         // When
-    //         ApiResponse<ProfileResponse> response = profileService.getCurrentProfile(photographer);
-    //         ProfileResponse result = response.getData();
-    //
-    //         // Then
-    //         assertNotNull(result);
-    //         assertEquals("profile.jpg", result.getProfileImageUrl());
-    //         assertEquals("banner.jpg", result.getBannerImageUrl());
-    //         assertEquals("johndoe", result.getInstagramId());
-    //         assertEquals("Welcome to my profile!", result.getIntroductionContent());
-    //
-    //         List<LinkInfo> linkInfos = result.getLinkInfos();
-    //         assertNotNull(linkInfos);
-    //         assertEquals(2, linkInfos.size());
-    //
-    //         LinkInfo linkInfo1 = linkInfos.get(0);
-    //         assertEquals("My Portfolio", linkInfo1.getLinkTitle());
-    //         assertEquals("http://portfolio.com", linkInfo1.getLinkUrl());
-    //
-    //         LinkInfo linkInfo2 = linkInfos.get(1);
-    //         assertEquals("My Blog", linkInfo2.getLinkTitle());
-    //         assertEquals("http://blog.com", linkInfo2.getLinkUrl());
-    //     }
-    //
-    //     @DisplayName("사진작가 측 외부 링크를 제외한 프로필 업데이트")
-    //     @Test
-    //     void testUpdateProfile() throws IOException {
-    //         // Given
-    //         Member photographer = createNewMember();
-    //         Profile existingProfile = createProfile(photographer);
-    //         ProfileImage profileImage = createProfileImage(existingProfile);
-    //
-    //         List<LinkInfo> linkInfos = Arrays.asList(
-    //             new LinkInfo("changed blog", "www.url.com"),
-    //             new LinkInfo("My Portfolio", "www.change.com"),
-    //             new LinkInfo("new info", "nice"));
-    //
-    //         UpdateProfileRequest updateRequest = UpdateProfileRequest.builder()
-    //             .bannerImageUrl("banner.jpg")
-    //             .introductionContent("changed content")
-    //             .linkInfos(linkInfos)
-    //             .build();
-    //
-    //         MockMultipartFile requestImage = new MockMultipartFile("file", "profile_change.jpg", "image/jpeg",
-    //             "file contents".getBytes());
-    //
-    //         // doNothing().when(profileService).updateLinks(any(Profile.class), anyList());
-    //         when(profileRepository.findByMember(photographer)).thenReturn(Optional.of(existingProfile));
-    //
-    //         // When
-    //         profileService.updateProfile(updateRequest, photographer, requestImage);
-    //         assertEquals("profile_change.jpg", profileImage.getOriginUrl());
-    //         assertEquals("changed content", existingProfile.getIntroductionContent());
-    //         assertEquals("banner.jpg", existingProfile.getBannerImageUrl());
-    //     }
-    //
-    //     private ProfileImage createProfileImage(Profile existingProfile) {
-    //         return ProfileImage.builder()
-    //             .profile(existingProfile)
-    //             .thumbnailUrl("http://thumbnails.com")
-    //             .originUrl("http://originurl.com")
-    //             .build();
-    //     }
-    //
-    //     @DisplayName("사진작가 측 프로필의 외부 링크 업데이트")
-    //     @Test
-    //     void testUpdateLinks() throws IOException {
-    //         Member photographer = createNewMember();
-    //         Profile existingProfile = createProfile(photographer);
-    //
-    //         Link link1 = createLink(existingProfile, "Naver Blog", "www.naver.blog");
-    //         Link link2 = createLink(existingProfile, "Pinterest", "www.pinterest.com");
-    //
-    //         List<LinkInfo> linkInfos = Arrays.asList(
-    //             new LinkInfo("changed blog", "www.url.com"),
-    //             new LinkInfo("Naver Blog", "www.change.com"),
-    //             new LinkInfo("new info", "nice"));
-    //
-    //         UpdateProfileRequest updateRequest = UpdateProfileRequest.builder()
-    //             .bannerImageUrl("banner.jpg")
-    //             .introductionContent("Welcome to my profile!")
-    //             .linkInfos(linkInfos)
-    //             .build();
-    //
-    //         MockMultipartFile requestImage = new MockMultipartFile("file", "profile_change.jpg", "image/jpeg",
-    //             "file contents".getBytes());
-    //
-    //         when(linkRepository.findByProfile(existingProfile)).thenReturn(Arrays.asList(link1, link2));
-    //
-    //         // When
-    //         profileService.updateProfile(updateRequest, photographer, requestImage);
-    //
-    //         // Then
-    //         verify(linkRepository).save(argThat(link ->
-    //             "changed blog".equals(link.getTitle()) && "www.url.com".equals(link.getUrl())));
-    //         verify(linkRepository).save(argThat(link ->
-    //             "new info".equals(link.getTitle()) && "nice".equals(link.getUrl())));
-    //
-    //         verify(linkRepository, times(2)).save(any(Link.class));
-    //     }
-    //
-    //     private Member createNewMember() {
-    //         return new Member(1L, Role.PHOTOGRAPHER, "John Doe", "john@example.com",
-    //             "1234567890", 1980, "Male", "johndoe");
-    //     }
-    //
-    //     private Profile createProfile(Member photographer) {
-    //         return Profile.builder()
-    //             .uniqueUrl(UNIQUE_URL)
-    //             .bannerImageUrl("banner.jpg")
-    //             .introductionContent("Welcome to my profile!")
-    //             .member(photographer)
-    //             .build();
-    //     }
-    //
-    //     private Link createLink(Profile profile, String title, String url) {
-    //         return Link.builder()
-    //             .profile(profile)
-    //             .title(title)
-    //             .url(url)
-    //             .build();
-    //     }
+    private static final String UNIQUE_URL = "unique-url";
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private ProfileRepository profileRepository;
+
+    @Mock
+    private ProfileImageRepository profileImageRepository;
+
+    @Mock
+    private LinkRepository linkRepository;
+
+    @Mock
+    private S3ImageService s3ImageService;
+
+    @InjectMocks
+    private ProfileService profileService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        profileService = spy(
+            new ProfileService(memberRepository, profileRepository, linkRepository, profileImageRepository,
+                s3ImageService));
+    }
+
+    @DisplayName("사진작가 측 현재 프로필 조회")
+    @Test
+    void testGetCurrentProfile() {
+        // Given
+        Member photographer = createNewMember();
+        Profile profile = createProfile(photographer);
+        ProfileImage profileImage = createProfileImage(profile);
+
+        Link link1 = createLink(profile, "My Portfolio", "http://portfolio.com");
+        Link link2 = createLink(profile, "My Blog", "http://blog.com");
+
+        when(profileRepository.findByMember(photographer)).thenReturn(Optional.of(profile));
+        when(linkRepository.findByProfile(profile)).thenReturn(Arrays.asList(link1, link2));
+        when(profileImageRepository.findByProfile(profile)).thenReturn(Optional.ofNullable(profileImage));
+
+        // When
+        ProfileResponse result = profileService.getCurrentProfile(photographer);
+        // Then
+        assertNotNull(result);
+        assertEquals("http://thumbnails.com", result.getProfileImageUrl());
+        assertEquals("banner.jpg", result.getBannerImageUrl());
+        assertEquals("johndoe", result.getInstagramId());
+        assertEquals("Welcome to my profile!", result.getIntroductionContent());
+
+        List<LinkInfo> linkInfos = result.getLinkInfos();
+        assertNotNull(linkInfos);
+        assertEquals(2, linkInfos.size());
+
+        LinkInfo linkInfo1 = linkInfos.get(0);
+        assertEquals("My Portfolio", linkInfo1.getLinkTitle());
+        assertEquals("http://portfolio.com", linkInfo1.getLinkUrl());
+
+        LinkInfo linkInfo2 = linkInfos.get(1);
+        assertEquals("My Blog", linkInfo2.getLinkTitle());
+        assertEquals("http://blog.com", linkInfo2.getLinkUrl());
+    }
+
+    @DisplayName("사진작가 측 외부 링크를 제외한 프로필 업데이트")
+    @Test
+    void testUpdateProfile() throws IOException {
+        // Given
+        Member photographer = createNewMember();
+        Profile existingProfile = createProfile(photographer);
+        ProfileImage profileImage = createProfileImage(existingProfile);
+
+        List<LinkInfo> linkInfos = Arrays.asList(
+            new LinkInfo("changed blog", "www.url.com"),
+            new LinkInfo("My Portfolio", "www.change.com"),
+            new LinkInfo("new info", "nice"));
+
+        UpdateProfileRequest updateRequest = UpdateProfileRequest.builder()
+            .bannerImageUrl("banner.jpg")
+            .introductionContent("changed content")
+            .linkInfos(linkInfos)
+            .build();
+
+        MockMultipartFile requestImage = new MockMultipartFile("file", "profile_change.jpg", "image/jpeg",
+            "file contents".getBytes());
+
+        when(profileRepository.findByMember(photographer)).thenReturn(Optional.of(existingProfile));
+
+        // When
+        profileService.updateProfile(updateRequest, photographer, requestImage);
+        assertEquals("http://originurl.com", profileImage.getOriginUrl());
+        assertEquals("changed content", existingProfile.getIntroductionContent());
+        assertEquals("banner.jpg", existingProfile.getBannerImageUrl());
+    }
+
+    private ProfileImage createProfileImage(Profile existingProfile) {
+        return ProfileImage.builder()
+            .profile(existingProfile)
+            .thumbnailUrl("http://thumbnails.com")
+            .originUrl("http://originurl.com")
+            .build();
+    }
+
+    @DisplayName("사진작가 측 프로필의 외부 링크 업데이트")
+    @Test
+    void testUpdateLinks() throws IOException {
+        Member photographer = createNewMember();
+        Profile existingProfile = createProfile(photographer);
+
+        Link link1 = createLink(existingProfile, "Naver Blog", "www.naver.blog");
+        Link link2 = createLink(existingProfile, "Pinterest", "www.pinterest.com");
+
+        List<LinkInfo> linkInfos = Arrays.asList(
+            new LinkInfo("changed blog", "www.url.com"),
+            new LinkInfo("Naver Blog", "www.change.com"),
+            new LinkInfo("new info", "nice"));
+
+        UpdateProfileRequest updateRequest = UpdateProfileRequest.builder()
+            .bannerImageUrl("banner.jpg")
+            .introductionContent("Welcome to my profile!")
+            .linkInfos(linkInfos)
+            .build();
+
+        MockMultipartFile requestImage = new MockMultipartFile("file", "profile_change.jpg", "image/jpeg",
+            "file contents".getBytes());
+
+        when(profileRepository.findByMember(photographer)).thenReturn(Optional.of(existingProfile));
+        when(linkRepository.findByProfile(existingProfile)).thenReturn(Arrays.asList(link1, link2));
+
+        // When
+        profileService.updateProfile(updateRequest, photographer, requestImage);
+
+        // Then
+        verify(linkRepository).save(argThat(link ->
+            "changed blog".equals(link.getTitle()) && "www.url.com".equals(link.getUrl())));
+        verify(linkRepository).save(argThat(link ->
+            "new info".equals(link.getTitle()) && "nice".equals(link.getUrl())));
+
+        verify(linkRepository, times(2)).save(any(Link.class));
+    }
+
+    private Member createNewMember() {
+        return new Member(1L, Role.PHOTOGRAPHER, "John Doe", "john@example.com",
+            "1234567890", 1980, "Male", "johndoe");
+    }
+
+    private Profile createProfile(Member photographer) {
+        return Profile.builder()
+            .uniqueUrl(UNIQUE_URL)
+            .bannerImageUrl("banner.jpg")
+            .introductionContent("Welcome to my profile!")
+            .member(photographer)
+            .build();
+    }
+
+    private Link createLink(Profile profile, String title, String url) {
+        return Link.builder()
+            .profile(profile)
+            .title(title)
+            .url(url)
+            .build();
+    }
 }


### PR DESCRIPTION
## 체크리스트

- ✅ 불필요한 주석 처리가 없는가?

## 작업 내역
- Service Layer에서는 단순히 로직이 수행된 후 결과값을 반환하게 수정했습니다.
  - Service Layer에서 ResponseBody로 반환하지 않는 이유는 비즈니스 로직을 담는 레이어의 역할을 명확하게 하기 위함과 테스트코드 작성 시 불필요한 코드 또한 예방할 수 있습니다.
- Controller Layer에서는 Service Layer에서 수행 후 반환한 값을 ResponseBody에 싣고 ResponseEntity로 감싸서 응답하도록 수정했습니다.  

- 로컬에서의 전체 API 테스트 수행 (모든 API 통과, [API Docs](https://www.notion.so/yul-lee/API-Docs-9db17cb3aa3842a68edcdafa651a347b)에 통과된 API 표시)
- 테스트를 진행하면서 통과하지 못한 테스트를 기준으로 코드 추가 및 리팩터링 수행
  - "/customer/profile/**" 경로에 대한 접근 및 토큰 권한 추가
  - 상품 등록, 예약신청서 등록 시 member(사진작가)에 대한 검증 로직 추가
  - 변경된 코드 또한 리팩터링
  - 부가적인 오류 수정\

## 고민한 사항
- 기존의 memberService.findOrRegisterMember() 내부에 있는 setResponseBody()를 활용해서 Service Layer에서 ResponseBody를 정의하고 있습니다. 만약 현재 변경하고자 하는 방식으로 대입해본다면 memberService.findOrRegisterMember()는 headers와 member의 RoleType을 반환하면 Controller Layer에서 받아서 if문을 통해 ResponseBody를 정의하게 됩니다.
그래서 memberService.findOrRegisterMember() 메서드에서 반환하는 값이 headers, memberRoleType 이도록 하여 Controller Layer에서 ResponseBody를 정의하는 것과 이 메서드의 경우에만 Service Layer에서 반환 타입을 
ResponseEntity<ResponseBody<?>>로 가져가는 게 좋을지 고민이었습니다.

## 리뷰 요청사항
- 시급도는 높음입니다. 적용 후 후속 API 개발에서 적용해야 합니다.
- 위 고민한 사항에 대해서 의견 부탁드려요!