### PR TITLE
[FU-228] CodeDeploy 배포 자동화 오류 분석 및 문제해결을 위한 스크립트 개선

### DIFF
--- a/.github/workflows/cd_workflow_dev.yml
+++ b/.github/workflows/cd_workflow_dev.yml
@@ -3,6 +3,8 @@ name: Backend Dev Server CD
 on:
   push:
     branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
 
 jobs:
   build:

--- a/.github/workflows/cd_workflow_dev.yml
+++ b/.github/workflows/cd_workflow_dev.yml
@@ -3,9 +3,7 @@ name: Backend Dev Server CD
 on:
   push:
     branches: [ "develop" ]
-  pull_request:
-    branches: [ "develop" ]
-
+    
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -13,7 +13,7 @@ APP_LOG="$ROOT_PATH/application.log"
 ERROR_LOG="$ROOT_PATH/error.log"
 START_LOG="$ROOT_PATH/start.log"
 
-NOW=$(date +%c)
+NOW=$(date "+%Y %b %d %a %H:%M:%S")
 
 # JAR 파일 복사
 echo "[$NOW] $JAR 복사 중..." >> $START_LOG

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -12,8 +12,9 @@ JAR="$ROOT_PATH/application.jar"
 APP_LOG="$ROOT_PATH/application.log"
 ERROR_LOG="$ROOT_PATH/error.log"
 START_LOG="$ROOT_PATH/start.log"
-
 NOW=$(date "+%Y %b %d %a %H:%M:%S")
+
+echo "--------------------------------------------------" >> $START_LOG
 
 # JAR 파일 복사
 echo "[$NOW] $JAR 복사 중..." >> $START_LOG

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
+# 환경 변수 로드
 set -o allexport
 source /home/ubuntu/freebe-backend/.env
 set +o allexport
 
+# 경로 및 파일 설정
 ROOT_PATH="/home/ubuntu/freebe-backend"
 JAR="$ROOT_PATH/application.jar"
 
@@ -13,11 +15,24 @@ START_LOG="$ROOT_PATH/start.log"
 
 NOW=$(date +%c)
 
-echo "[$NOW] $JAR 복사" >> $START_LOG
-cp $ROOT_PATH/build/libs/freebe-0.0.1-SNAPSHOT.jar $JAR
+# JAR 파일 복사
+echo "[$NOW] $JAR 복사 중..." >> $START_LOG
+if cp $ROOT_PATH/build/libs/freebe-0.0.1-SNAPSHOT.jar $JAR; then
+  echo "[$NOW] JAR 파일 복사 완료" >> $START_LOG
+else
+  echo "[$NOW] JAR 파일 복사 실패" >> $START_LOG
+  exit 1
+fi
 
+# 애플리케이션 실행
 echo "[$NOW] > $JAR 실행" >> $START_LOG
 nohup java -jar $JAR > $APP_LOG 2> $ERROR_LOG &
 
-SERVICE_PID=$(pgrep -f $JAR)
-echo "[$NOW] > 서비스 PID: $SERVICE_PID" >> $START_LOG
+# 실행된 프로세스의 PID 확인
+NEW_SERVICE_PID=$(pgrep -f $JAR)
+if [ ! -z "$NEW_SERVICE_PID" ]; then
+  echo "[$NOW] > 새로운 서비스 PID: $NEW_SERVICE_PID" >> $START_LOG
+else
+  echo "[$NOW] > 서비스 시작 실패" >> $START_LOG
+  exit 1
+fi

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -14,6 +14,7 @@ else
   echo "[$NOW] 기존 프로세스 종료 시도: PID $SERVICE_PIDS" >> $STOP_LOG
 
   for PID in $SERVICE_PIDS; do
+    echo "[$NOW] kill $PID 실행 중" >> $STOP_LOG
     kill "$PID"
     sleep 1
 

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -6,7 +6,7 @@ STOP_LOG="$ROOT_PATH/stop.log"
 NOW=$(date "+%Y %b %d %a %H:%M:%S")
 
 # 실행 중인 모든 프로세스의 PID를 가져옴
-SERVICE_PIDS=$(pgrep -f $JAR)
+SERVICE_PIDS=$(pgrep -f $JAR | tr '\n' ' ')
 
 if [ -z "$SERVICE_PIDS" ]; then
   echo "[$NOW] 실행 중인 기존 프로세스 없음" >> $STOP_LOG

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -3,11 +3,25 @@
 ROOT_PATH="/home/ubuntu/freebe-backend"
 JAR="$ROOT_PATH/application.jar"
 STOP_LOG="$ROOT_PATH/stop.log"
-SERVICE_PID=$(pgrep -f $JAR)
+NOW=$(date +%c)
 
-if [ -z "$SERVICE_PID" ]; then
-  echo "서비스 NouFound" >> $STOP_LOG
+# 실행 중인 모든 프로세스의 PID를 가져옴
+SERVICE_PIDS=$(pgrep -f $JAR)
+
+if [ -z "$SERVICE_PIDS" ]; then
+  echo "[$NOW] 실행 중인 기존 프로세스 없음" >> $STOP_LOG
 else
-  echo "서비스 종료 " >> $STOP_LOG
-  kill "$SERVICE_PID"
+  echo "[$NOW] 기존 프로세스 종료 시도: PID $SERVICE_PIDS" >> $STOP_LOG
+
+  for PID in $SERVICE_PIDS; do
+    kill "$PID"
+    sleep 1
+
+    if kill -0 "$PID" 2>/dev/null; then
+      echo "[$NOW] 프로세스 강제 종료 시도: PID $PID" >> $STOP_LOG
+      kill -9 "$PID"
+    else
+      echo "[$NOW] 프로세스가 성공적으로 종료됨: PID $PID" >> $STOP_LOG
+    fi
+  done
 fi

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -3,7 +3,7 @@
 ROOT_PATH="/home/ubuntu/freebe-backend"
 JAR="$ROOT_PATH/application.jar"
 STOP_LOG="$ROOT_PATH/stop.log"
-NOW=$(date +%c)
+NOW=$(date "+%Y %b %d %a %H:%M:%S")
 
 # 실행 중인 모든 프로세스의 PID를 가져옴
 SERVICE_PIDS=$(pgrep -f $JAR)
@@ -21,6 +21,7 @@ else
     if kill -0 "$PID" 2>/dev/null; then
       echo "[$NOW] 프로세스 강제 종료 시도: PID $PID" >> $STOP_LOG
       kill -9 "$PID"
+      echo "[$NOW] 프로세스 강제 종료됨: PID $PID" >> $STOP_LOG
     else
       echo "[$NOW] 프로세스가 성공적으로 종료됨: PID $PID" >> $STOP_LOG
     fi

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -5,8 +5,10 @@ JAR="$ROOT_PATH/application.jar"
 STOP_LOG="$ROOT_PATH/stop.log"
 NOW=$(date "+%Y %b %d %a %H:%M:%S")
 
+echo "--------------------------------------------------" >> $STOP_LOG
+
 # 실행 중인 모든 프로세스의 PID를 가져옴
-SERVICE_PIDS=$(pgrep -f $JAR | tr '\n' ' ')
+SERVICE_PIDS=$(pgrep -f $JAR)
 
 if [ -z "$SERVICE_PIDS" ]; then
   echo "[$NOW] 실행 중인 기존 프로세스 없음" >> $STOP_LOG

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         show_sql: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         show_sql: true


### PR DESCRIPTION
### 1. 현상 파악
Code Deploy를 통한 배포 자동화가 제대로 이루어지지 않는 문제가 빈번하게 발생하고 있음.
<img width="1096" alt="image" src="https://github.com/user-attachments/assets/ed3e8586-6025-4c16-996c-f5ecccd7bbb8">

</br>

**배포 실패 로그**
The overall deployment failed because too many individual instances failed deployment, too few healthy instances are available for deployment, or some instances in your deployment group are experiencing problems.

**상세 로그**
scripts/stop.sh
Script at specified location: scripts/stop.sh run as user root failed with exit code 1

<br>

### 2. 분석하기
Aws CodeDeploy에서 Event Hook에 대한 로그를 확인해 봤을때, 전체 라이프 사이클 중 `After Install` 단계에서 배포가 실패하고 있음을 확인할 수 있다.
<img width="1167" alt="image" src="https://github.com/user-attachments/assets/4f2a9388-ecd6-4b06-87ca-12614c79e415">
<img width="1072" alt="image" src="https://github.com/user-attachments/assets/76c81cd6-e02a-4b99-8d5d-b22daf11a3dc">


</br>

`After Install` 단계는 이번 배포에 해당하는 어플리케이션을 실행하기 직전에 이뤄지며, appspec.yml을 살펴보면 우리 서비스에서는 stop.sh을 실행하는 단계에 해당한다. Code Deploy의 상세 로그에서도 stop.sh을 실행하는 중에 배포가 실패했음을 알려주고 있다. 
```
hooks:
  AfterInstall:
    - location: scripts/stop.sh
      timeout: 60
      runas : root
```

</br>
stop.sh 스크립트는 아래와 같고, 새 어플리케이션을 실행시키기 전에 기존에 배포되어 실행중인 어플리케이션이 있다면 이를 종료시켜주는 역할을 하고 있다. 여기서 오류가 발생하는 원인을 두 가지로 가정해보았다. 

```
ROOT_PATH="/home/ubuntu/freebe-backend"
JAR="$ROOT_PATH/application.jar"
STOP_LOG="$ROOT_PATH/stop.log"
SERVICE_PID=$(pgrep -f $JAR)

if [ -z "$SERVICE_PID" ]; then
  echo "서비스 NouFound" >> $STOP_LOG
else
  echo "서비스 종료 " >> $STOP_LOG
  kill "$SERVICE_PID"
fi
```

1. pgrep -f 명령어를 통해 실행중인 프로세스 아이디를 제대로 찾지 못함
2. 실행중인 프로세스를 kill할 권한이 없음


1을 검증하기 위해 터미널에서 직접 pgrep -f application.jar 명령어로 실행중인 프로세스를 출력해보았는데, 예상치 못하게 프로세스 아이디 두 개가 출력되었다. ps -p {pid} -o lstart으로 두 프로세스가 시작된 시간을 확인해보니 9월 12일에 20분 간격을 두고 실행된 것을 확인할 수 있었는데, 두번째 프로그램이 배포된 이후부터 동작중인 프로세스가 두 개가 되었고 stop.sh이 여러 개의 프로세스를 처리하지 못하면서 그 이후 배포는 모두 실패한게 아닌가 라는 추측을 해보았다. 왜냐하면 기존 stop.sh은 실행중인 프로세스가 하나인 경우를 가정하고 이미 존재하는 하나의 프로세스를 종료시키도록 스크립트가 작성되어 있기 때문이다. 
그렇지만 실행중인 프로세스가 여러개일 때 스크립트가 기존 의도대로(= 새 프로그램 실행 전에 기존에 실행중인 모든 프로세스 죽이기)는 동작하지 않겠지만 스크립트 자체가 실패하는 것은 이해가 가지 않았던 것이, 실행중인 프로세스가 여러개일 때 service_pid에 기존에 실행중인 여러개의 프로세스 아이디가 공백으로 구분되어 저장되므로(ex: kill 186470 192838) `kill "$SERVICE_PID"`를 실행했을 때 가장 맨 앞에있는 프로세스 한개는 kill 되게끔 동작할 것이기 때문에 스크립트 실행 자체가 실패할 이유는 없다고 생각되었다. 
(물론 이 경우에 kill 명령어에 대한 argument가 올바르지 않아 문제가 되었을 가능성도 있을 수 있다.)

<br>
2의 경우에는 https://ksha0628.tistory.com/84를 읽다가 code deploy 에이전트가 프로세스를 kill할 권한이 없어서 스크립트가 실패할 수도 있겠다는 생각으로 이어졌다. 하지만 현재 실행중인 PID 186470에 대해 ps -p 186470 -o user= 명령어를 확인해봤을때 해당 프로세스가 root 권한으로 실행된 것을 확인했으며 code deploy agent 또한 root 권한으로 실행되기 때문에 kill 권한이 문제되진 않을 것 같다는 판단이다. 
<img width="721" alt="image" src="https://github.com/user-attachments/assets/6da3597e-0b30-4238-bbf3-6840f5521398">


### 3. 조치하기
배포 실패 원인을 가정하고 이를 검증하고자 했지만 현재로써는 실패원인을 명확하게 파악하지 못했다. 따라서 뚜렷한 조치는 취하지 못한 상황이다.
다만, 기존 stop.sh 스크립트에 로그가 부족해 이를 보완하고 여러 개의 프로세스가 동작중일 때 동작중인 프로세스를 모두 kill할 수 있도록 for문을 돌게끔 스크립트를 수정하였다. 만약 기존 스크립트로는 실행중인 프로세스가 여러개일때 kill 명령어가 제대로 동작하지 않아 배포가 실패했었던 거라면 이번 수정을 통해 bug fix가 가능할 것이고, 그게 아니라면 보완된 로그를 확인해가며 구체적인 원인을 더 파악할 수 있을 것 같다.


### 4. 검증하기
해당 PR 머지시키면서 예상된 문제가 맞았는지 검증해보고, 검증이 틀렸다면 이번 PR에서 보완한 start.log, stop.log 기록을 보며 다시 방법을 찾아야 할 것 같습니다 😵‍💫

(update) 09.22 
이번 PR에서 수정한 스크립트로 CodeDeploy 실행한 결과 다시 배포가 정상적으로 이뤄지는 것을 확인하였음
```
[Sun Sep 22 16:39:48 2024] 기존 프로세스 종료 시도: PID 186470
260650
[Sun Sep 22 16:39:48 2024] kill 186470 실행 중
[Sun Sep 22 16:39:48 2024] 프로세스 강제 종료 시도: PID 186470
[Sun Sep 22 16:39:48 2024] kill 260650 실행 중
[Sun Sep 22 16:39:48 2024] 프로세스가 성공적으로 종료됨: PID 260650
```
stop.sh에 찍힌 위 로그로 봤을 때 두개의 프로세스가 실행중일때 PID가 186470 이후에 개행이 이뤄져 저장된 것을 알 수 있었는데, kill 186470 260650 으로 킬 명령이 동작할 것이라 예상했지만 실제로는 kill 186470/n 260650 으로 실행되었기 때문에 `arguments must be process or job IDs` 오류가 나면서 그동안 배포가 실패했을 것이라고 예상된다. 다만 이번 스크립트 수정 이후에는 for문을 돌면서 pid를 꺼내와 하나의 프로세스만 죽이기 때문에 kill 명령어를 수행할 때 개행 이슈가 발생하지 않아 오류가 해결된 것 같다! 