### PR TITLE
[FU-207] 로그인 버그 픽스

### DIFF
--- a/src/main/java/com/foru/freebe/config/CustomLogoutHandler.java
+++ b/src/main/java/com/foru/freebe/config/CustomLogoutHandler.java
@@ -2,6 +2,7 @@ package com.foru.freebe.config;
 
 import java.io.IOException;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.stereotype.Component;
@@ -23,6 +24,9 @@ import lombok.RequiredArgsConstructor;
 public class CustomLogoutHandler implements LogoutHandler {
     private final JwtService jwtService;
 
+    @Value("${FREEBE_BASE_URL}")
+    private String freebeBaseUrl;
+
     @Override
     public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
         try {
@@ -34,9 +38,9 @@ public class CustomLogoutHandler implements LogoutHandler {
             jwtService.revokeToken(refreshToken);
 
             switch (role) {
-                case CUSTOMER -> response.sendRedirect("/login/customer");
-                case PHOTOGRAPHER, PHOTOGRAPHER_PENDING -> response.sendRedirect("/login/photographer");
-                default -> response.sendRedirect("/login");
+                case CUSTOMER -> response.sendRedirect(freebeBaseUrl + "/login/customer");
+                case PHOTOGRAPHER, PHOTOGRAPHER_PENDING -> response.sendRedirect(freebeBaseUrl + "/login/photographer");
+                default -> response.sendRedirect(freebeBaseUrl + "/login");
             }
         } catch (JwtTokenException e) {
             throw new JwtTokenException(e.getErrorCode());

--- a/src/main/java/com/foru/freebe/errors/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/foru/freebe/errors/handler/GlobalExceptionHandler.java
@@ -1,8 +1,10 @@
 package com.foru.freebe.errors.handler;
 
+import java.sql.DataTruncation;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
@@ -35,6 +37,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     public ResponseEntity<Object> handleIllegalArgument(IllegalArgumentException e) {
         ErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
         return handleExceptionInternal(errorCode, e.getMessage());
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<Object> handleDataTruncation(DataTruncation e) {
+        ErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
+        String message = e.getMessage();
+
+        return handleExceptionInternal(errorCode, message);
     }
 
     // 메서드 인자의 유효성 검사가 실패했을 때 발생

--- a/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
@@ -51,13 +51,10 @@ public class PhotographerProductService {
     private final ReservationFormRepository reservationFormRepository;
     private final S3ImageService s3ImageService;
 
+    @Transactional
     public void registerProduct(ProductRegisterRequest productRegisterRequestDto,
         List<MultipartFile> images, Long photographerId) throws IOException {
         Member photographer = getMember(photographerId);
-
-        if (images.isEmpty()) {
-            throw new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND);
-        }
 
         Product productAsActive = registerActiveProduct(productRegisterRequestDto, photographer);
         registerProductImage(images, productAsActive, photographerId);
@@ -128,6 +125,10 @@ public class PhotographerProductService {
 
     private void registerProductImage(List<MultipartFile> images, Product product, Long id) throws
         IOException {
+
+        if (images.isEmpty()) {
+            throw new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND);
+        }
 
         List<String> originalImageUrls = s3ImageService.uploadOriginalImages(images, S3ImageType.PRODUCT, id);
         List<String> thumbnailImageUrls = s3ImageService.uploadThumbnailImages(images, S3ImageType.PRODUCT, id,

--- a/src/main/java/com/foru/freebe/profile/service/ProfileService.java
+++ b/src/main/java/com/foru/freebe/profile/service/ProfileService.java
@@ -212,7 +212,7 @@ public class ProfileService {
 
     private String createUniqueUrl() {
         String uniqueId = UUID.randomUUID().toString();
-        return freebeBaseUrl + "/photographer/" + uniqueId;
+        return freebeBaseUrl + "/" + uniqueId;
     }
 
     private void saveProfileImage(Profile profile, MultipartFile profileImage, Long id) throws IOException {


### PR DESCRIPTION
## 체크리스트

- [ ] 불필요한 주석 처리가 없는가?

</br>

## 작업 내역
- 사진작가 고유 URL 생성 방식을 변경했습니다.
  - 기존: www.freebe.co.kr/photographer/xxxx
  - 변경: www.freebe.co.kr/xxxx

- DB 컬럼 길이제한을 초과하는 데이터 삽입,수정 요청에 대한 예외처리를 추가했습니다.
```
{
    "code": "INVALID_PARAMETER",
    "message": "Data truncation: Data too long for column 'origin_url' at row 1"
}
```  

- 로그아웃 성공 이후에 다시 로그인화면으로 리다이렉트 되는 url을 수정했습니다.
  - 기존: 사진작가 로그아웃 성공 시 http://api.freebe.co.kr/login/photographer로 리다이렉트
  - 변경: 사진작가 로그아웃 성공 시 https://www.freebe.co.kr/login/photographer로 리다이렉트

</br>

## 고민한 사항
- DB 길이제한을 초과하는 데이터 삽입, 수정 요청이 발생했을 때 예외처리 메시지를 어떻게 주는게 좋을지 고민했습니다. "파일명이 길이제한을 초과합니다" 등으로 커스텀한 예외 메시지를 던지려고 했지만, 또 다른 예외 상황의 DataIntegrityViolationException이 발생할 수 있기때문에 에러메시지 원본 자체를 응답에 포함하도록 구성했습니다.

- 배포환경에서 로그아웃 이후에 재로그인을 시도하려고 하면 로그인이 안되는 문제가 있다고 했는데 로컬환경에서는 유사한 문제가 재현되지 않아서 해당 PR이 배포된 이후에 배포환경에서 로그 확인할 예정입니다.

## 리뷰 요청사항
시급도 (높음): 배포환경 테스트가 이어져야합니다.