### PR TITLE
[FU-256] 사진작가 회원가입/프로필 관리 로직 업데이트

### DIFF
--- a/src/main/java/com/foru/freebe/auth/controller/AuthController.java
+++ b/src/main/java/com/foru/freebe/auth/controller/AuthController.java
@@ -49,7 +49,7 @@ public class AuthController {
 
         ResponseBody<?> responseBody = ResponseBody.builder()
             .message(loginResponse.getMessage())
-            .data(loginResponse.getUniqueUrl())
+            .data(loginResponse.getProfileName())
             .build();
 
         HttpHeaders headers = jwtService.setTokenHeaders(loginResponse.getToken());

--- a/src/main/java/com/foru/freebe/auth/dto/LoginResponse.java
+++ b/src/main/java/com/foru/freebe/auth/dto/LoginResponse.java
@@ -10,13 +10,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class LoginResponse {
     private JwtTokenModel token;
-    private String uniqueUrl;
+    private String profileName;
     private String message;
 
     @Builder
-    public LoginResponse(JwtTokenModel token, String uniqueUrl, String message) {
+    public LoginResponse(JwtTokenModel token, String profileName, String message) {
         this.token = token;
-        this.uniqueUrl = uniqueUrl;
+        this.profileName = profileName;
         this.message = message;
     }
 }

--- a/src/main/java/com/foru/freebe/common/dto/ImageLinkSet.java
+++ b/src/main/java/com/foru/freebe/common/dto/ImageLinkSet.java
@@ -1,0 +1,21 @@
+package com.foru.freebe.common.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ImageLinkSet {
+    private List<String> originUrl;
+    private List<String> thumbnailUrl;
+
+    public String getFirstOriginUrl() {
+        return originUrl.get(0);
+    }
+
+    public String getFirstThumbnailUrl() {
+        return thumbnailUrl.get(0);
+    }
+}

--- a/src/main/java/com/foru/freebe/errors/errorcode/ProfileErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/ProfileErrorCode.java
@@ -1,0 +1,13 @@
+package com.foru.freebe.errors.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProfileErrorCode implements ErrorCode {
+    PROFILE_NAME_ALREADY_EXISTS(400, "이미 존재하는 프로필명입니다.");
+
+    private final int httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/foru/freebe/member/controller/JoinController.java
+++ b/src/main/java/com/foru/freebe/member/controller/JoinController.java
@@ -6,9 +6,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.foru.freebe.auth.model.MemberAdapter;
 import com.foru.freebe.common.dto.ResponseBody;
@@ -16,6 +15,7 @@ import com.foru.freebe.member.dto.PhotographerJoinRequest;
 import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.member.service.MemberService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -25,14 +25,13 @@ public class JoinController {
 
     @PostMapping("/photographer/join")
     public ResponseEntity<ResponseBody<String>> joinPhotographer(@AuthenticationPrincipal MemberAdapter memberAdapter,
-        @RequestPart(value = "request") PhotographerJoinRequest request,
-        @RequestPart(value = "image", required = false) MultipartFile image) throws IOException {
+        @Valid @RequestBody PhotographerJoinRequest request) throws IOException {
 
         Member member = memberAdapter.getMember();
-        String uniqueUrl = memberService.joinPhotographer(member, request, image);
+        String profileName = memberService.joinPhotographer(member, request);
 
         ResponseBody<String> responseBody = ResponseBody.<String>builder()
-            .data(uniqueUrl)
+            .data(profileName)
             .message("Successfully joined")
             .build();
 

--- a/src/main/java/com/foru/freebe/member/dto/PhotographerJoinRequest.java
+++ b/src/main/java/com/foru/freebe/member/dto/PhotographerJoinRequest.java
@@ -6,8 +6,8 @@ import lombok.Getter;
 
 @Getter
 public class PhotographerJoinRequest {
-    @NotBlank(message = "Instagram ID must not be blank")
-    private String instagramId;
+    @NotBlank(message = "Profile name must not be blank")
+    private String profileName;
 
     @AssertTrue
     private Boolean termsOfServiceAgreement;

--- a/src/main/java/com/foru/freebe/member/service/MemberService.java
+++ b/src/main/java/com/foru/freebe/member/service/MemberService.java
@@ -54,12 +54,12 @@ public class MemberService {
     }
 
     @Transactional
-    public String joinPhotographer(Member member, PhotographerJoinRequest request,
-        MultipartFile profileImage) throws IOException {
-        Member photographer = completePhotographerSignup(member, request.getInstagramId());
+    public String joinPhotographer(Member member, PhotographerJoinRequest request, MultipartFile profileImage) throws
+        IOException {
+        Member photographer = completePhotographerSignup(member);
 
         savePhotographerAgreements(photographer, request);
-        profileService.initialProfileSetting(photographer, profileImage);
+        profileService.initialProfileSetting(photographer, profileImage, request.getProfileName());
 
         return profileService.getUniqueUrl(member.getId());
     }
@@ -88,9 +88,8 @@ public class MemberService {
         return memberRepository.save(newMember);
     }
 
-    private Member completePhotographerSignup(Member member, String instagramId) {
+    private Member completePhotographerSignup(Member member) {
         member.assignRole(Role.PHOTOGRAPHER);
-        member.assignInstagramId(instagramId);
         return memberRepository.save(member);
     }
 

--- a/src/main/java/com/foru/freebe/member/service/MemberService.java
+++ b/src/main/java/com/foru/freebe/member/service/MemberService.java
@@ -1,9 +1,6 @@
 package com.foru.freebe.member.service;
 
-import java.io.IOException;
-
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.foru.freebe.auth.dto.LoginResponse;
 import com.foru.freebe.auth.model.KakaoUser;
@@ -17,6 +14,7 @@ import com.foru.freebe.member.entity.MemberTermAgreement;
 import com.foru.freebe.member.entity.Role;
 import com.foru.freebe.member.repository.MemberRepository;
 import com.foru.freebe.member.repository.MemberTermAgreementRepository;
+import com.foru.freebe.profile.entity.Profile;
 import com.foru.freebe.profile.service.ProfileService;
 
 import jakarta.transaction.Transactional;
@@ -54,27 +52,26 @@ public class MemberService {
     }
 
     @Transactional
-    public String joinPhotographer(Member member, PhotographerJoinRequest request, MultipartFile profileImage) throws
-        IOException {
+    public String joinPhotographer(Member member, PhotographerJoinRequest request) {
         Member photographer = completePhotographerSignup(member);
 
         savePhotographerAgreements(photographer, request);
-        profileService.initialProfileSetting(photographer, profileImage, request.getProfileName());
+        Profile profile = profileService.initialProfileSetting(photographer, request.getProfileName());
 
-        return profileService.getUniqueUrl(member.getId());
+        return profile.getProfileName();
     }
 
     private LoginResponse.LoginResponseBuilder validateRoleType(LoginResponse.LoginResponseBuilder builder,
         Member member) {
         if (member.getRole() == Role.PHOTOGRAPHER) {
             return builder.message("photographer login")
-                .uniqueUrl(profileService.getUniqueUrl(member.getId()));
+                .profileName(profileService.getProfileName(member.getId()));
         } else if (member.getRole() == Role.PHOTOGRAPHER_PENDING) {
             return builder.message("photographer join")
-                .uniqueUrl(null);
+                .profileName(null);
         } else if (member.getRole() == Role.CUSTOMER) {
             return builder.message("customer login")
-                .uniqueUrl(null);
+                .profileName(null);
         }
         throw new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND);
     }

--- a/src/main/java/com/foru/freebe/product/controller/CustomerProductController.java
+++ b/src/main/java/com/foru/freebe/product/controller/CustomerProductController.java
@@ -22,11 +22,11 @@ import lombok.RequiredArgsConstructor;
 public class CustomerProductController {
     private final CustomerProductService customerProductService;
 
-    @GetMapping("/product/list/{photographerId}")
+    @GetMapping("/product/list/{profileName}")
     public ResponseEntity<ResponseBody<List<ProductListResponse>>> getProductList(
-        @PathVariable("photographerId") Long photographerId) {
+        @PathVariable("profileName") String profileName) {
 
-        List<ProductListResponse> responseData = customerProductService.getProductList(photographerId);
+        List<ProductListResponse> responseData = customerProductService.getProductList(profileName);
 
         ResponseBody<List<ProductListResponse>> responseBody = ResponseBody.<List<ProductListResponse>>builder()
             .message("Good Request")

--- a/src/main/java/com/foru/freebe/product/service/CustomerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/CustomerProductService.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Service;
 import com.foru.freebe.errors.errorcode.CommonErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
 import com.foru.freebe.member.entity.Member;
-import com.foru.freebe.member.repository.MemberRepository;
 import com.foru.freebe.product.dto.customer.ProductDetailResponse;
 import com.foru.freebe.product.dto.customer.ProductListResponse;
 import com.foru.freebe.product.dto.photographer.ProductComponentDto;
@@ -24,13 +23,15 @@ import com.foru.freebe.product.respository.ProductDiscountRepository;
 import com.foru.freebe.product.respository.ProductImageRepository;
 import com.foru.freebe.product.respository.ProductOptionRepository;
 import com.foru.freebe.product.respository.ProductRepository;
+import com.foru.freebe.profile.entity.Profile;
+import com.foru.freebe.profile.repository.ProfileRepository;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class CustomerProductService {
-    private final MemberRepository memberRepository;
+    private final ProfileRepository profileRepository;
     private final ProductRepository productRepository;
     private final ProductImageRepository productImageRepository;
     private final ProductComponentRepository productComponentRepository;
@@ -67,9 +68,11 @@ public class CustomerProductService {
             .build();
     }
 
-    public List<ProductListResponse> getProductList(Long photographerId) {
-        Member photographer = memberRepository.findById(photographerId)
+    public List<ProductListResponse> getProductList(String profileName) {
+        Profile photographerProfile = profileRepository.findByProfileName(profileName)
             .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+
+        Member photographer = photographerProfile.getMember();
 
         List<Product> products = productRepository.findByMember(photographer)
             .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));

--- a/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
@@ -8,6 +8,7 @@ import java.util.stream.IntStream;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.foru.freebe.common.dto.ImageLinkSet;
 import com.foru.freebe.errors.errorcode.CommonErrorCode;
 import com.foru.freebe.errors.errorcode.ProductErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
@@ -129,14 +130,13 @@ public class PhotographerProductService {
             throw new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND);
         }
 
-        List<String> originalImageUrls = s3ImageService.uploadOriginalImages(images, S3ImageType.PRODUCT, id);
-        List<String> thumbnailImageUrls = s3ImageService.uploadThumbnailImages(images, S3ImageType.PRODUCT, id,
+        ImageLinkSet productImageLinkSet = s3ImageService.imageUploadToS3(images, S3ImageType.PRODUCT, product.getId(),
             PRODUCT_THUMBNAIL_SIZE);
 
-        IntStream.range(0, originalImageUrls.size()).forEach(i -> {
+        IntStream.range(0, productImageLinkSet.getOriginUrl().size()).forEach(i -> {
             ProductImage productImage = ProductImage.createProductImage(
-                thumbnailImageUrls.get(i),
-                originalImageUrls.get(i),
+                productImageLinkSet.getThumbnailUrl().get(i),
+                productImageLinkSet.getOriginUrl().get(i),
                 product);
             productImageRepository.save(productImage);
         });

--- a/src/main/java/com/foru/freebe/profile/Controller/CustomerProfileController.java
+++ b/src/main/java/com/foru/freebe/profile/Controller/CustomerProfileController.java
@@ -20,11 +20,11 @@ import lombok.RequiredArgsConstructor;
 public class CustomerProfileController {
     private final ProfileService profileService;
 
-    @GetMapping("/profile/{uniqueUrl}")
+    @GetMapping("/profile/{profileName}")
     public ResponseEntity<ResponseBody<ProfileResponse>> getPhotographerProfile(
-        @Valid @PathVariable("uniqueUrl") String uniqueUrl) {
+        @Valid @PathVariable("profileName") String profileName) {
 
-        ProfileResponse responseData = profileService.getPhotographerProfile(uniqueUrl);
+        ProfileResponse responseData = profileService.getPhotographerProfile(profileName);
 
         ResponseBody<ProfileResponse> responseBody = ResponseBody.<ProfileResponse>builder()
             .message("Good Response")

--- a/src/main/java/com/foru/freebe/profile/Controller/PhotographerProfileController.java
+++ b/src/main/java/com/foru/freebe/profile/Controller/PhotographerProfileController.java
@@ -44,12 +44,13 @@ public class PhotographerProfileController {
 
     @PutMapping("/profile")
     public ResponseEntity<ResponseBody<Void>> updateProfile(
-        @RequestPart(value = "request") UpdateProfileRequest updateRequest,
-        @RequestPart(value = "image", required = false) MultipartFile profileImage,
-        @AuthenticationPrincipal MemberAdapter memberAdapter) throws IOException {
+        @AuthenticationPrincipal MemberAdapter memberAdapter,
+        @RequestPart(value = "request") UpdateProfileRequest request,
+        @RequestPart(value = "bannerImage", required = false) MultipartFile bannerImage,
+        @RequestPart(value = "profileImage", required = false) MultipartFile profileImage) throws IOException {
 
         Member photographer = memberAdapter.getMember();
-        profileService.updateProfile(updateRequest, photographer, profileImage);
+        profileService.updateProfile(photographer, request, bannerImage, profileImage);
 
         ResponseBody<Void> responseBody = ResponseBody.<Void>builder()
             .message("Updated successfully")

--- a/src/main/java/com/foru/freebe/profile/dto/ProfileResponse.java
+++ b/src/main/java/com/foru/freebe/profile/dto/ProfileResponse.java
@@ -11,17 +11,16 @@ import lombok.NoArgsConstructor;
 public class ProfileResponse {
     private String bannerImageUrl;
     private String profileImageUrl;
-    private String instagramId;
+    private String profileName;
     private String introductionContent;
     private List<LinkInfo> linkInfos;
 
     @Builder
-    public ProfileResponse(String bannerImageUrl, String profileImageUrl, String instagramId,
-        String introductionContent,
-        List<LinkInfo> linkInfos) {
+    public ProfileResponse(String bannerImageUrl, String profileImageUrl, String profileName,
+        String introductionContent, List<LinkInfo> linkInfos) {
         this.bannerImageUrl = bannerImageUrl;
         this.profileImageUrl = profileImageUrl;
-        this.instagramId = instagramId;
+        this.profileName = profileName;
         this.introductionContent = introductionContent;
         this.linkInfos = linkInfos;
     }

--- a/src/main/java/com/foru/freebe/profile/dto/UpdateProfileRequest.java
+++ b/src/main/java/com/foru/freebe/profile/dto/UpdateProfileRequest.java
@@ -9,14 +9,11 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class UpdateProfileRequest {
-    private String bannerImageUrl;
     private String introductionContent;
     private List<LinkInfo> linkInfos;
 
     @Builder
-    public UpdateProfileRequest(String bannerImageUrl, String instagramId, String introductionContent,
-        List<LinkInfo> linkInfos) {
-        this.bannerImageUrl = bannerImageUrl;
+    public UpdateProfileRequest(String introductionContent, List<LinkInfo> linkInfos) {
         this.introductionContent = introductionContent;
         this.linkInfos = linkInfos;
     }

--- a/src/main/java/com/foru/freebe/profile/dto/UpdateProfileRequest.java
+++ b/src/main/java/com/foru/freebe/profile/dto/UpdateProfileRequest.java
@@ -10,7 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class UpdateProfileRequest {
     private String bannerImageUrl;
-    private String instagramId;
     private String introductionContent;
     private List<LinkInfo> linkInfos;
 
@@ -18,7 +17,6 @@ public class UpdateProfileRequest {
     public UpdateProfileRequest(String bannerImageUrl, String instagramId, String introductionContent,
         List<LinkInfo> linkInfos) {
         this.bannerImageUrl = bannerImageUrl;
-        this.instagramId = instagramId;
         this.introductionContent = introductionContent;
         this.linkInfos = linkInfos;
     }

--- a/src/main/java/com/foru/freebe/profile/entity/Profile.java
+++ b/src/main/java/com/foru/freebe/profile/entity/Profile.java
@@ -30,8 +30,8 @@ public class Profile extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @NotBlank(message = "Unique url must not be blank")
-    private String uniqueUrl;
+    @NotBlank(message = "Profile name must not be blank")
+    private String profileName;
 
     private String introductionContent;
 
@@ -46,9 +46,9 @@ public class Profile extends BaseEntity {
     }
 
     @Builder
-    public Profile(String uniqueUrl, String introductionContent, String profileImageUrl, String bannerImageUrl,
+    public Profile(String profileName, String introductionContent, String profileImageUrl, String bannerImageUrl,
         Member member) {
-        this.uniqueUrl = uniqueUrl;
+        this.profileName = profileName;
         this.introductionContent = introductionContent;
         this.bannerImageUrl = bannerImageUrl;
         this.member = member;

--- a/src/main/java/com/foru/freebe/profile/entity/Profile.java
+++ b/src/main/java/com/foru/freebe/profile/entity/Profile.java
@@ -35,22 +35,14 @@ public class Profile extends BaseEntity {
 
     private String introductionContent;
 
-    private String bannerImageUrl;
-
-    public void assignBannerImageUrl(String bannerImageUrl) {
-        this.bannerImageUrl = bannerImageUrl;
-    }
-
-    public void assignIntroductionContent(String introductionContent) {
+    public void updateIntroductionContent(String introductionContent) {
         this.introductionContent = introductionContent;
     }
 
     @Builder
-    public Profile(String profileName, String introductionContent, String profileImageUrl, String bannerImageUrl,
-        Member member) {
+    public Profile(String profileName, String introductionContent, Member member) {
         this.profileName = profileName;
         this.introductionContent = introductionContent;
-        this.bannerImageUrl = bannerImageUrl;
         this.member = member;
     }
 }

--- a/src/main/java/com/foru/freebe/profile/entity/ProfileImage.java
+++ b/src/main/java/com/foru/freebe/profile/entity/ProfileImage.java
@@ -8,7 +8,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,16 +26,29 @@ public class ProfileImage {
     @JoinColumn(name = "profile_id")
     private Profile profile;
 
-    @NotNull
-    private String thumbnailUrl;
+    private String bannerOriginUrl;
 
-    @NotNull
-    private String originUrl;
+    private String profileOriginUrl;
+
+    private String profileThumbnailUrl;
+
+    public void assignBannerOriginUrl(String bannerOriginUrl) {
+        this.bannerOriginUrl = bannerOriginUrl;
+    }
+
+    public void assignProfileOriginUrl(String profileOriginUrl) {
+        this.profileOriginUrl = profileOriginUrl;
+    }
+
+    public void assignProfileThumbnailUrl(String profileThumbnailUrl) {
+        this.profileThumbnailUrl = profileThumbnailUrl;
+    }
 
     @Builder
-    public ProfileImage(Profile profile, String thumbnailUrl, String originUrl) {
+    public ProfileImage(Profile profile, String profileThumbnailUrl, String profileOriginUrl, String bannerOriginUrl) {
         this.profile = profile;
-        this.thumbnailUrl = thumbnailUrl;
-        this.originUrl = originUrl;
+        this.profileThumbnailUrl = profileThumbnailUrl;
+        this.profileOriginUrl = profileOriginUrl;
+        this.bannerOriginUrl = bannerOriginUrl;
     }
 }

--- a/src/main/java/com/foru/freebe/profile/repository/ProfileImageRepository.java
+++ b/src/main/java/com/foru/freebe/profile/repository/ProfileImageRepository.java
@@ -8,9 +8,5 @@ import com.foru.freebe.profile.entity.Profile;
 import com.foru.freebe.profile.entity.ProfileImage;
 
 public interface ProfileImageRepository extends JpaRepository<ProfileImage, Long> {
-    Boolean existsByProfile(Profile profile);
-
     Optional<ProfileImage> findByProfile(Profile profile);
-
-    void deleteByProfile(Profile profile);
 }

--- a/src/main/java/com/foru/freebe/profile/repository/ProfileRepository.java
+++ b/src/main/java/com/foru/freebe/profile/repository/ProfileRepository.java
@@ -8,7 +8,9 @@ import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.profile.entity.Profile;
 
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
-    Boolean existsByMemberId(Long memberId);
+    boolean existsByMemberId(Long memberId);
+
+    boolean existsByProfileName(String profileName);
 
     Optional<Profile> findByMember(Member member);
 

--- a/src/main/java/com/foru/freebe/profile/repository/ProfileRepository.java
+++ b/src/main/java/com/foru/freebe/profile/repository/ProfileRepository.java
@@ -12,6 +12,8 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
     boolean existsByProfileName(String profileName);
 
+    Optional<Profile> findByMemberId(Long memberId);
+
     Optional<Profile> findByMember(Member member);
 
     Optional<Profile> findByProfileName(String profileName);

--- a/src/main/java/com/foru/freebe/profile/repository/ProfileRepository.java
+++ b/src/main/java/com/foru/freebe/profile/repository/ProfileRepository.java
@@ -12,5 +12,5 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
     Optional<Profile> findByMember(Member member);
 
-    Optional<Profile> findByUniqueUrl(String uniqueUrl);
+    Optional<Profile> findByProfileName(String profileName);
 }

--- a/src/main/java/com/foru/freebe/profile/service/ProfileService.java
+++ b/src/main/java/com/foru/freebe/profile/service/ProfileService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.foru.freebe.errors.errorcode.CommonErrorCode;
+import com.foru.freebe.errors.errorcode.ProfileErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
 import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.member.repository.MemberRepository;
@@ -184,14 +185,21 @@ public class ProfileService {
     @Transactional
     public void initialProfileSetting(Member photographer, MultipartFile profileImage, String profileName) throws
         IOException {
-        Boolean isProfileExists = profileRepository.existsByMemberId(photographer.getId());
+        boolean isProfileExists = profileRepository.existsByMemberId(photographer.getId());
         if (isProfileExists) {
             throw new RestApiException(CommonErrorCode.INTERNAL_SERVER_ERROR);
         }
 
+        validateProfileNameDuplicate(profileName);
         Profile profile = createMemberProfile(photographer, profileName);
         if (profileImage != null) {
             saveProfileImage(profile, profileImage, photographer.getId());
+        }
+    }
+
+    private void validateProfileNameDuplicate(String profileName) {
+        if (profileRepository.existsByProfileName(profileName)) {
+            throw new RestApiException(ProfileErrorCode.PROFILE_NAME_ALREADY_EXISTS);
         }
     }
 

--- a/src/main/java/com/foru/freebe/profile/service/ProfileService.java
+++ b/src/main/java/com/foru/freebe/profile/service/ProfileService.java
@@ -52,11 +52,11 @@ public class ProfileService {
         Profile profile = profileRepository.findByMember(member)
             .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
 
-        return profile.getUniqueUrl();
+        return profile.getProfileName();
     }
 
-    public ProfileResponse getPhotographerProfile(String uniqueUrl) {
-        Profile photographerProfile = profileRepository.findByUniqueUrl(uniqueUrl)
+    public ProfileResponse getPhotographerProfile(String profileName) {
+        Profile photographerProfile = profileRepository.findByProfileName(profileName)
             .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
 
         Member photographer = photographerProfile.getMember();
@@ -73,14 +73,14 @@ public class ProfileService {
             return new ProfileResponse(
                 photographerProfile.getBannerImageUrl(),
                 profileImage.getThumbnailUrl(),
-                photographer.getInstagramId(),
+                photographerProfile.getProfileName(),
                 photographerProfile.getIntroductionContent(),
                 linkInfos);
         } else {
             return new ProfileResponse(
                 photographerProfile.getBannerImageUrl(),
                 null,
-                photographer.getInstagramId(),
+                photographerProfile.getProfileName(),
                 photographerProfile.getIntroductionContent(),
                 linkInfos);
         }
@@ -103,14 +103,14 @@ public class ProfileService {
             return new ProfileResponse(
                 photographerProfile.getBannerImageUrl(),
                 profileImage.getThumbnailUrl(),
-                photographer.getInstagramId(),
+                photographerProfile.getProfileName(),
                 photographerProfile.getIntroductionContent(),
                 linkInfos);
         } else {
             return new ProfileResponse(
                 photographerProfile.getBannerImageUrl(),
                 null,
-                photographer.getInstagramId(),
+                photographerProfile.getProfileName(),
                 photographerProfile.getIntroductionContent(),
                 linkInfos);
         }
@@ -134,9 +134,6 @@ public class ProfileService {
         // 변경 감지: 필요한 필드만 업데이트
         if (!Objects.equals(photographerProfile.getBannerImageUrl(), updateRequest.getBannerImageUrl())) {
             photographerProfile.assignBannerImageUrl(updateRequest.getBannerImageUrl());
-        }
-        if (!Objects.equals(persistedPhotographer.getInstagramId(), updateRequest.getInstagramId())) {
-            persistedPhotographer.assignInstagramId(updateRequest.getInstagramId());
         }
         if (!Objects.equals(photographerProfile.getIntroductionContent(), updateRequest.getIntroductionContent())) {
             photographerProfile.assignIntroductionContent(updateRequest.getIntroductionContent());
@@ -185,23 +182,22 @@ public class ProfileService {
     }
 
     @Transactional
-    public void initialProfileSetting(Member photographer, MultipartFile profileImage) throws IOException {
+    public void initialProfileSetting(Member photographer, MultipartFile profileImage, String profileName) throws
+        IOException {
         Boolean isProfileExists = profileRepository.existsByMemberId(photographer.getId());
         if (isProfileExists) {
             throw new RestApiException(CommonErrorCode.INTERNAL_SERVER_ERROR);
         }
 
-        Profile profile = createMemberProfile(photographer);
+        Profile profile = createMemberProfile(photographer, profileName);
         if (profileImage != null) {
             saveProfileImage(profile, profileImage, photographer.getId());
         }
     }
 
-    private Profile createMemberProfile(Member member) {
-        String uniqueUrl = createUniqueUrl();
-
+    private Profile createMemberProfile(Member member, String profileName) {
         Profile profile = Profile.builder()
-            .uniqueUrl(uniqueUrl)
+            .profileName(profileName)
             .introductionContent(null)
             .bannerImageUrl(null)
             .member(member)

--- a/src/main/java/com/foru/freebe/profile/service/ProfileService.java
+++ b/src/main/java/com/foru/freebe/profile/service/ProfileService.java
@@ -4,12 +4,12 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.foru.freebe.common.dto.ImageLinkSet;
 import com.foru.freebe.errors.errorcode.CommonErrorCode;
 import com.foru.freebe.errors.errorcode.ProfileErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
@@ -40,92 +40,122 @@ public class ProfileService {
     private final S3ImageService s3ImageService;
 
     public String getProfileName(Long id) {
-        Profile profile = profileRepository.findByMemberId(id)
-            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
-
+        Profile profile = getProfile(id);
         return profile.getProfileName();
     }
 
     public ProfileResponse getPhotographerProfile(String profileName) {
-        Profile photographerProfile = profileRepository.findByProfileName(profileName)
-            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+        Profile profile = getProfile(profileName);
 
-        List<Link> links = linkRepository.findByProfile(photographerProfile);
+        ProfileImage profileImage = profileImageRepository.findByProfile(profile).orElse(null);
 
-        List<LinkInfo> linkInfos = links.stream()
-            .map(link -> new LinkInfo(link.getTitle(), link.getUrl()))
-            .collect(Collectors.toList());
+        List<LinkInfo> linkInfos = getProfileLinkInfos(profile);
 
-        ProfileImage profileImage = profileImageRepository.findByProfile(photographerProfile).orElse(null);
-
-        if (profileImage != null) {
-            return new ProfileResponse(
-                photographerProfile.getBannerImageUrl(),
-                profileImage.getThumbnailUrl(),
-                photographerProfile.getProfileName(),
-                photographerProfile.getIntroductionContent(),
-                linkInfos);
-        } else {
-            return new ProfileResponse(
-                photographerProfile.getBannerImageUrl(),
-                null,
-                photographerProfile.getProfileName(),
-                photographerProfile.getIntroductionContent(),
-                linkInfos);
-        }
-
+        return ProfileResponse.builder()
+            .bannerImageUrl(profileImage != null ? profileImage.getBannerOriginUrl() : null)
+            .profileImageUrl(profileImage != null ? profileImage.getProfileThumbnailUrl() : null)
+            .profileName(profileName)
+            .introductionContent(profile.getIntroductionContent())
+            .linkInfos(linkInfos)
+            .build();
     }
 
     public ProfileResponse getCurrentProfile(Member photographer) {
-        Profile photographerProfile = profileRepository.findByMember(photographer)
-            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+        Profile profile = getProfile(photographer);
+        return getPhotographerProfile(profile.getProfileName());
+    }
 
-        ProfileImage profileImage = profileImageRepository.findByProfile(photographerProfile).orElse(null);
+    @Transactional
+    //ToDO: 기존에 존재하는 이미지는 s3에서 제거.
+    //ToDo: persisten 유지
+    public void updateProfile(Member photographer, UpdateProfileRequest request, MultipartFile bannerImageFile,
+        MultipartFile profileImageFile) throws IOException {
 
-        List<Link> links = linkRepository.findByProfile(photographerProfile);
+        Profile profile = getProfile(photographer);
+        ProfileImage profileImage = createProfileImageIfNotExists(profile);
 
-        List<LinkInfo> linkInfos = links.stream()
-            .map(link -> new LinkInfo(link.getTitle(), link.getUrl()))
-            .collect(Collectors.toList());
+        if (request.getIntroductionContent() != null) {
+            profile.updateIntroductionContent(request.getIntroductionContent());
+        }
 
-        if (profileImage != null) {
-            return new ProfileResponse(
-                photographerProfile.getBannerImageUrl(),
-                profileImage.getThumbnailUrl(),
-                photographerProfile.getProfileName(),
-                photographerProfile.getIntroductionContent(),
-                linkInfos);
-        } else {
-            return new ProfileResponse(
-                photographerProfile.getBannerImageUrl(),
-                null,
-                photographerProfile.getProfileName(),
-                photographerProfile.getIntroductionContent(),
-                linkInfos);
+        updateLinks(profile, request.getLinkInfos());
+
+        if (bannerImageFile != null) {
+            updateBannerImage(profileImage, bannerImageFile, photographer.getId());
+        }
+
+        if (profileImageFile != null) {
+            updateProfileImage(profileImage, profileImageFile, photographer.getId());
         }
     }
 
     @Transactional
-    public void updateProfile(UpdateProfileRequest updateRequest, Member photographer,
-        MultipartFile profileImage) throws IOException {
-        Profile photographerProfile = profileRepository.findByMember(photographer)
+    public Profile initialProfileSetting(Member photographer, String profileName) {
+        boolean isProfileExists = profileRepository.existsByMemberId(photographer.getId());
+        if (isProfileExists) {
+            throw new RestApiException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+        }
+
+        validateProfileNameDuplicate(profileName);
+        return createMemberProfile(photographer, profileName);
+    }
+
+    private void validateProfileNameDuplicate(String profileName) {
+        if (profileRepository.existsByProfileName(profileName)) {
+            throw new RestApiException(ProfileErrorCode.PROFILE_NAME_ALREADY_EXISTS);
+        }
+    }
+
+    private Profile getProfile(Long memberId) {
+        return profileRepository.findByMemberId(memberId)
             .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+    }
 
-        ProfileImage existingProfileImage = profileImageRepository.findByProfile(photographerProfile).orElse(null);
-        if (existingProfileImage != null) {
-            profileImageRepository.delete(existingProfileImage);
-            saveProfileImage(photographerProfile, profileImage, photographer.getId());
-        }
+    private Profile getProfile(Member photographer) {
+        return profileRepository.findByMember(photographer)
+            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+    }
 
-        // 변경 감지: 필요한 필드만 업데이트
-        if (!Objects.equals(photographerProfile.getBannerImageUrl(), updateRequest.getBannerImageUrl())) {
-            photographerProfile.assignBannerImageUrl(updateRequest.getBannerImageUrl());
-        }
-        if (!Objects.equals(photographerProfile.getIntroductionContent(), updateRequest.getIntroductionContent())) {
-            photographerProfile.assignIntroductionContent(updateRequest.getIntroductionContent());
-        }
+    private Profile getProfile(String profileName) {
+        return profileRepository.findByProfileName(profileName)
+            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+    }
 
-        updateLinks(photographerProfile, updateRequest.getLinkInfos());
+    private List<LinkInfo> getProfileLinkInfos(Profile profile) {
+        List<Link> links = linkRepository.findByProfile(profile);
+
+        return links.stream()
+            .map(link -> new LinkInfo(link.getTitle(), link.getUrl()))
+            .collect(Collectors.toList());
+    }
+
+    private ProfileImage createProfileImageIfNotExists(Profile photographerProfile) {
+        return profileImageRepository.findByProfile(photographerProfile)
+            .orElse(ProfileImage.builder().profile(photographerProfile).build());
+    }
+
+    private void updateBannerImage(ProfileImage profileImage, MultipartFile imageFile, Long id) throws IOException {
+        List<MultipartFile> profileImages = Collections.singletonList(imageFile);
+        ImageLinkSet bannerImageLinkSet = s3ImageService.imageUploadToS3(profileImages, S3ImageType.PROFILE, id);
+
+        String newBannerImageUrl = bannerImageLinkSet.getFirstOriginUrl();
+        profileImage.assignBannerOriginUrl(newBannerImageUrl);
+
+        profileImageRepository.save(profileImage);
+    }
+
+    private void updateProfileImage(ProfileImage profileImage, MultipartFile imageFile, Long id) throws IOException {
+        List<MultipartFile> profileImages = Collections.singletonList(imageFile);
+        ImageLinkSet profileImageLinkSet = s3ImageService.imageUploadToS3(profileImages, S3ImageType.PROFILE, id,
+            PROFILE_THUMBNAIL_SIZE);
+
+        String originalImageUrl = profileImageLinkSet.getFirstOriginUrl();
+        String thumbnailImageUrl = profileImageLinkSet.getFirstThumbnailUrl();
+
+        profileImage.assignProfileOriginUrl(originalImageUrl);
+        profileImage.assignProfileThumbnailUrl(thumbnailImageUrl);
+
+        profileImageRepository.save(profileImage);
     }
 
     private void updateLinks(Profile profile, List<LinkInfo> linkInfos) {
@@ -167,62 +197,18 @@ public class ProfileService {
         }
     }
 
-    @Transactional
-    public Profile initialProfileSetting(Member photographer, String profileName) {
-        boolean isProfileExists = profileRepository.existsByMemberId(photographer.getId());
-        if (isProfileExists) {
-            throw new RestApiException(CommonErrorCode.INTERNAL_SERVER_ERROR);
-        }
-
-        validateProfileNameDuplicate(profileName);
-        return createMemberProfile(photographer, profileName);
-    }
-
-    private void validateProfileNameDuplicate(String profileName) {
-        if (profileRepository.existsByProfileName(profileName)) {
-            throw new RestApiException(ProfileErrorCode.PROFILE_NAME_ALREADY_EXISTS);
-        }
-    }
-
     private Profile createMemberProfile(Member member, String profileName) {
         Profile profile = Profile.builder()
             .profileName(profileName)
             .introductionContent(null)
-            .bannerImageUrl(null)
             .member(member)
             .build();
 
         return profileRepository.save(profile);
     }
 
-    private void saveProfileImage(Profile profile, MultipartFile profileImage, Long id) throws IOException {
-        deleteProfileImageIfExists(profile);
-
-        List<MultipartFile> profileImages = Collections.singletonList(profileImage);
-        List<String> originalImageUrls = s3ImageService.uploadOriginalImages(profileImages, S3ImageType.PROFILE, id);
-        List<String> thumbnailImageUrls = s3ImageService.uploadThumbnailImages(profileImages, S3ImageType.PROFILE, id,
-            PROFILE_THUMBNAIL_SIZE);
-
-        String originalImageUrl = originalImageUrls.get(0);
-        String thumbnailImageUrl = thumbnailImageUrls.get(0);
-
-        ProfileImage image = ProfileImage.builder()
-            .profile(profile)
-            .originUrl(originalImageUrl)
-            .thumbnailUrl(thumbnailImageUrl)
-            .build();
-        profileImageRepository.save(image);
-    }
-
-    private void deleteProfileImageIfExists(Profile profile) {
-        Boolean isProfileExists = profileImageRepository.existsByProfile(profile);
-        if (isProfileExists) {
-            profileImageRepository.deleteByProfile(profile);
-        }
-    }
-
     private Boolean isLinkInfoChanged(Link existingLink, LinkInfo linkInfo) {
-        return !existingLink.getUrl().equals(linkInfo.getLinkUrl()) ||
-            !existingLink.getTitle().equals(linkInfo.getLinkTitle());
+        return !existingLink.getUrl().equals(linkInfo.getLinkUrl()) || !existingLink.getTitle()
+            .equals(linkInfo.getLinkTitle());
     }
 }

--- a/src/main/java/com/foru/freebe/reservation/controller/CustomerReservationController.java
+++ b/src/main/java/com/foru/freebe/reservation/controller/CustomerReservationController.java
@@ -73,14 +73,13 @@ public class CustomerReservationController {
             .body(responseBody);
     }
 
-    @GetMapping("/reservation/{reservationFormId}")
+    @GetMapping("/reservation/{formId}")
     public ResponseEntity<ResponseBody<ReservationInfoResponse>> getReservationInfo(
         @AuthenticationPrincipal MemberAdapter memberAdapter,
-        @Valid @PathVariable("reservationFormId") Long reservationFormId) {
+        @Valid @PathVariable("formId") Long formId) {
 
         Member customer = memberAdapter.getMember();
-        ReservationInfoResponse responseData = customerReservationService.getReservationInfo(reservationFormId,
-            customer.getId());
+        ReservationInfoResponse responseData = customerReservationService.getReservationInfo(formId, customer.getId());
 
         ResponseBody<ReservationInfoResponse> responseBody = ResponseBody.<ReservationInfoResponse>builder()
             .message("Good Response")

--- a/src/main/java/com/foru/freebe/reservation/dto/BasicReservationInfoResponse.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/BasicReservationInfoResponse.java
@@ -20,17 +20,19 @@ public class BasicReservationInfoResponse {
     @NotBlank
     private String phoneNumber;
 
+    private String instagramId;
+
     @NotNull
     private List<ProductComponentDto> productComponentDtoList;
 
     private List<ProductOptionDto> productOptionDtoList;
 
     @Builder
-    public BasicReservationInfoResponse(String name, String phoneNumber,
-        List<ProductComponentDto> productComponentDtoList,
-        List<ProductOptionDto> productOptionDtoList) {
+    public BasicReservationInfoResponse(String name, String phoneNumber, String instagramId,
+        List<ProductComponentDto> productComponentDtoList, List<ProductOptionDto> productOptionDtoList) {
         this.name = name;
         this.phoneNumber = phoneNumber;
+        this.instagramId = instagramId;
         this.productComponentDtoList = productComponentDtoList;
         this.productOptionDtoList = productOptionDtoList;
     }

--- a/src/main/java/com/foru/freebe/reservation/dto/FormRegisterRequest.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/FormRegisterRequest.java
@@ -11,13 +11,13 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class FormRegisterRequest {
-    @NotNull
-    private Long photographerId;
+    @NotBlank(message = "Profile name must not be blank")
+    private String profileName;
 
-    @NotBlank
+    @NotBlank(message = "Instagram ID must not be blank")
     private String instagramId;
 
-    @NotBlank
+    @NotBlank(message = "Product title must not be blank")
     private String productTitle;
 
     private Map<String, String> photoInfo;

--- a/src/main/java/com/foru/freebe/reservation/service/ReservationVerifier.java
+++ b/src/main/java/com/foru/freebe/reservation/service/ReservationVerifier.java
@@ -7,10 +7,11 @@ import com.foru.freebe.errors.errorcode.ProductErrorCode;
 import com.foru.freebe.errors.errorcode.ReservationErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
 import com.foru.freebe.member.entity.Member;
-import com.foru.freebe.member.repository.MemberRepository;
 import com.foru.freebe.product.entity.ActiveStatus;
 import com.foru.freebe.product.entity.Product;
 import com.foru.freebe.product.respository.ProductRepository;
+import com.foru.freebe.profile.entity.Profile;
+import com.foru.freebe.profile.repository.ProfileRepository;
 import com.foru.freebe.reservation.dto.FormRegisterRequest;
 import com.foru.freebe.reservation.dto.ReservationStatusUpdateRequest;
 import com.foru.freebe.reservation.entity.ReservationForm;
@@ -23,11 +24,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ReservationVerifier {
     private final ProductRepository productRepository;
-    private final MemberRepository memberRepository;
+    private final ProfileRepository profileRepository;
 
-    public void validateReservationFormBeforeSave(FormRegisterRequest formRegisterRequest) {
-        validateProductTitleExists(formRegisterRequest);
-        validateProductIsActive(formRegisterRequest.getProductTitle());
+    public void validateReservationFormBeforeSave(FormRegisterRequest request) {
+        validateProductTitleExists(request);
+        validateProductIsActive(request.getProductTitle());
     }
 
     public void validateCustomerAccess(ReservationForm reservationForm, Long customerId) {
@@ -53,9 +54,9 @@ public class ReservationVerifier {
     }
 
     private void validateProductTitleExists(FormRegisterRequest request) {
-        Long photographerId = request.getPhotographerId();
-        Member photographer = memberRepository.findById(photographerId)
+        Profile photographerProfile = profileRepository.findByProfileName(request.getProfileName())
             .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+        Member photographer = photographerProfile.getMember();
 
         if (!productRepository.existsByMemberAndTitle(photographer, request.getProductTitle())) {
             throw new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND);

--- a/src/test/java/com/foru/freebe/profile/service/ProfileServiceTest.java
+++ b/src/test/java/com/foru/freebe/profile/service/ProfileServiceTest.java
@@ -82,7 +82,7 @@ class ProfileServiceTest {
         assertNotNull(result);
         assertEquals("http://thumbnails.com", result.getProfileImageUrl());
         assertEquals("banner.jpg", result.getBannerImageUrl());
-        assertEquals("johndoe", result.getInstagramId());
+        assertEquals("johndoe", result.getProfileName());
         assertEquals("Welcome to my profile!", result.getIntroductionContent());
 
         List<LinkInfo> linkInfos = result.getLinkInfos();

--- a/src/test/java/com/foru/freebe/profile/service/ProfileServiceTest.java
+++ b/src/test/java/com/foru/freebe/profile/service/ProfileServiceTest.java
@@ -32,7 +32,7 @@ import com.foru.freebe.s3.S3ImageService;
 
 class ProfileServiceTest {
 
-    private static final String UNIQUE_URL = "unique-url";
+    private static final String PROFILE_NAME = "unique-profile-name";
 
     @Mock
     private MemberRepository memberRepository;
@@ -56,8 +56,7 @@ class ProfileServiceTest {
     void setUp() {
         MockitoAnnotations.openMocks(this);
         profileService = spy(
-            new ProfileService(memberRepository, profileRepository, linkRepository, profileImageRepository,
-                s3ImageService));
+            new ProfileService(profileRepository, linkRepository, profileImageRepository, s3ImageService));
     }
 
     @DisplayName("사진작가 측 현재 프로필 조회")
@@ -82,7 +81,7 @@ class ProfileServiceTest {
         assertNotNull(result);
         assertEquals("http://thumbnails.com", result.getProfileImageUrl());
         assertEquals("banner.jpg", result.getBannerImageUrl());
-        assertEquals("johndoe", result.getProfileName());
+        assertEquals("unique-profile-name", result.getProfileName());
         assertEquals("Welcome to my profile!", result.getIntroductionContent());
 
         List<LinkInfo> linkInfos = result.getLinkInfos();
@@ -187,7 +186,7 @@ class ProfileServiceTest {
 
     private Profile createProfile(Member photographer) {
         return Profile.builder()
-            .uniqueUrl(UNIQUE_URL)
+            .profileName(PROFILE_NAME)
             .bannerImageUrl("banner.jpg")
             .introductionContent("Welcome to my profile!")
             .member(photographer)

--- a/src/test/java/com/foru/freebe/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/foru/freebe/reservation/service/ReservationServiceTest.java
@@ -16,8 +16,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.foru.freebe.errors.errorcode.CommonErrorCode;
 import com.foru.freebe.errors.errorcode.ReservationErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
-import com.foru.freebe.member.repository.MemberRepository;
 import com.foru.freebe.product.respository.ProductRepository;
+import com.foru.freebe.profile.repository.ProfileRepository;
 import com.foru.freebe.reservation.dto.ReservationStatusUpdateRequest;
 import com.foru.freebe.reservation.entity.ReservationForm;
 import com.foru.freebe.reservation.entity.ReservationHistory;
@@ -32,7 +32,7 @@ class ReservationServiceTest {
     private ProductRepository productRepository;
 
     @Mock
-    private MemberRepository memberRepository;
+    private ProfileRepository profileRepository;
 
     @Mock
     ReservationFormRepository reservationFormRepository;
@@ -46,7 +46,7 @@ class ReservationServiceTest {
 
     @BeforeEach
     void setUp() {
-        ReservationVerifier reservationVerifier = spy(new ReservationVerifier(productRepository, memberRepository));
+        ReservationVerifier reservationVerifier = spy(new ReservationVerifier(productRepository, profileRepository));
         reservationService = new ReservationService(reservationVerifier, reservationFormRepository,
             reservationHistoryRepository);
     }


### PR DESCRIPTION
## 체크리스트

- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
- 사진작가 고유 url 생성 방식이 변경되었습니다.
  - 기존: 랜덤스트링으로 고유 url 생성
  - 변경: 회원가입 시점에 profileName을 입력받아 프로필명으로 고유 url 생성
- 사진작가 회원가입 시점에 입력받는 profileName의 중복여부 검사 로직이 추가되었습니다.
- 사진작가 회원가입 시점에 프로필 이미지를 등록하는 로직이 제거되었습니다. 
  - 프로필 관리 페이지에서 프로필 이미지 등록/수정이 가능해졌습니다.
- 사진작가 프로필 관리 페이지에서 배너 이미지 등록/수정 로직이 추가되었습니다. 
  - 기존에는 multiFile이 아닌 url로 request 들어오던 것을 multiFile로 받아 s3에 이미지 업로드합니다.

## 고민한 사항

## 리뷰 요청사항
- 회원가입, 프로필 로직이 다소 수정되면서 ProfileServiceTest 코드의 리팩토링이 필요해졌습니다 ㅜ 해당 pr 머지된 이후에 바로 pull 받아서 테스트코드 수정 이어나갈 예정입니다!