### PR TITLE
[FU-257] Profile service 테스트코드 리팩터링

### DIFF
--- a/src/main/java/com/foru/freebe/profile/Controller/PhotographerProfileController.java
+++ b/src/main/java/com/foru/freebe/profile/Controller/PhotographerProfileController.java
@@ -32,7 +32,7 @@ public class PhotographerProfileController {
         @AuthenticationPrincipal MemberAdapter memberAdapter) {
 
         Member photographer = memberAdapter.getMember();
-        ProfileResponse responseData = profileService.getCurrentProfile(photographer);
+        ProfileResponse responseData = profileService.getMyCurrentProfile(photographer);
 
         ResponseBody<ProfileResponse> responseBody = ResponseBody.<ProfileResponse>builder()
             .message("Good Response")

--- a/src/main/java/com/foru/freebe/profile/service/ProfileService.java
+++ b/src/main/java/com/foru/freebe/profile/service/ProfileService.java
@@ -46,7 +46,15 @@ public class ProfileService {
 
     public ProfileResponse getPhotographerProfile(String profileName) {
         Profile profile = getProfile(profileName);
+        return findPhotographerProfile(profileName, profile);
+    }
 
+    public ProfileResponse getMyCurrentProfile(Member photographer) {
+        Profile profile = getProfile(photographer);
+        return findPhotographerProfile(profile.getProfileName(), profile);
+    }
+
+    private ProfileResponse findPhotographerProfile(String profileName, Profile profile) {
         ProfileImage profileImage = profileImageRepository.findByProfile(profile).orElse(null);
 
         List<LinkInfo> linkInfos = getProfileLinkInfos(profile);
@@ -58,11 +66,6 @@ public class ProfileService {
             .introductionContent(profile.getIntroductionContent())
             .linkInfos(linkInfos)
             .build();
-    }
-
-    public ProfileResponse getCurrentProfile(Member photographer) {
-        Profile profile = getProfile(photographer);
-        return getPhotographerProfile(profile.getProfileName());
     }
 
     @Transactional
@@ -138,8 +141,8 @@ public class ProfileService {
             s3ImageService.deleteImageFromS3(bannerImageUrl);
         }
 
-        List<MultipartFile> profileImages = Collections.singletonList(imageFile);
-        ImageLinkSet bannerImageLinkSet = s3ImageService.imageUploadToS3(profileImages, S3ImageType.PROFILE, id);
+        List<MultipartFile> bannerImages = Collections.singletonList(imageFile);
+        ImageLinkSet bannerImageLinkSet = s3ImageService.imageUploadToS3(bannerImages, S3ImageType.PROFILE, id);
 
         String newBannerImageUrl = bannerImageLinkSet.getFirstOriginUrl();
         profileImage.assignBannerOriginUrl(newBannerImageUrl);

--- a/src/main/java/com/foru/freebe/profile/service/ProfileService.java
+++ b/src/main/java/com/foru/freebe/profile/service/ProfileService.java
@@ -66,8 +66,6 @@ public class ProfileService {
     }
 
     @Transactional
-    //ToDO: 기존에 존재하는 이미지는 s3에서 제거.
-    //ToDo: persisten 유지
     public void updateProfile(Member photographer, UpdateProfileRequest request, MultipartFile bannerImageFile,
         MultipartFile profileImageFile) throws IOException {
 
@@ -135,6 +133,11 @@ public class ProfileService {
     }
 
     private void updateBannerImage(ProfileImage profileImage, MultipartFile imageFile, Long id) throws IOException {
+        String bannerImageUrl = profileImage.getBannerOriginUrl();
+        if (bannerImageUrl != null) {
+            s3ImageService.deleteImageFromS3(bannerImageUrl);
+        }
+
         List<MultipartFile> profileImages = Collections.singletonList(imageFile);
         ImageLinkSet bannerImageLinkSet = s3ImageService.imageUploadToS3(profileImages, S3ImageType.PROFILE, id);
 
@@ -145,6 +148,13 @@ public class ProfileService {
     }
 
     private void updateProfileImage(ProfileImage profileImage, MultipartFile imageFile, Long id) throws IOException {
+        String profileImageOriginUrl = profileImage.getProfileOriginUrl();
+        String profileImageThumbnailUrl = profileImage.getProfileThumbnailUrl();
+        if (profileImageOriginUrl != null) {
+            s3ImageService.deleteImageFromS3(profileImageOriginUrl);
+            s3ImageService.deleteImageFromS3(profileImageThumbnailUrl);
+        }
+
         List<MultipartFile> profileImages = Collections.singletonList(imageFile);
         ImageLinkSet profileImageLinkSet = s3ImageService.imageUploadToS3(profileImages, S3ImageType.PROFILE, id,
             PROFILE_THUMBNAIL_SIZE);

--- a/src/main/java/com/foru/freebe/s3/S3ImageService.java
+++ b/src/main/java/com/foru/freebe/s3/S3ImageService.java
@@ -142,7 +142,7 @@ public class S3ImageService {
             default -> throw new RestApiException(CommonErrorCode.INTERNAL_SERVER_ERROR);
         }
 
-        return basePath + imageType + uniqueId + fileName;
+        return basePath + imageType + uniqueId + "/" + fileName;
     }
 
     private void uploadToS3(String key, InputStream imageInputStream, ObjectMetadata metadata) {

--- a/src/test/java/com/foru/freebe/profile/service/ProfileServiceTest.java
+++ b/src/test/java/com/foru/freebe/profile/service/ProfileServiceTest.java
@@ -158,7 +158,6 @@ class ProfileServiceTest {
                 s3ImageService.imageUploadToS3(bannerImageFiles, S3ImageType.PROFILE, photographer.getId())).thenReturn(
                 bannerImageLinkSet);
 
-            // profile Image
             ImageLinkSet profileImageLinkSet = new ImageLinkSet(Collections.singletonList("originUrl"),
                 Collections.singletonList("thumbnailUrl"));
             List<MultipartFile> profileImageFiles = Collections.singletonList(profileImageFile);
@@ -207,8 +206,7 @@ class ProfileServiceTest {
             when(
                 s3ImageService.imageUploadToS3(bannerImageFiles, S3ImageType.PROFILE, photographer.getId())).thenReturn(
                 bannerImageLinkSet);
-
-            // profile Image
+            
             ImageLinkSet profileImageLinkSet = new ImageLinkSet(Collections.singletonList("newProfileOriginUrl"),
                 Collections.singletonList("newProfileThumbnailUrl"));
             List<MultipartFile> profileImageFiles = Collections.singletonList(profileImageFile);

--- a/src/test/java/com/foru/freebe/profile/service/ProfileServiceTest.java
+++ b/src/test/java/com/foru/freebe/profile/service/ProfileServiceTest.java
@@ -4,21 +4,25 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
+import com.foru.freebe.common.dto.ImageLinkSet;
 import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.member.entity.Role;
-import com.foru.freebe.member.repository.MemberRepository;
 import com.foru.freebe.profile.dto.LinkInfo;
 import com.foru.freebe.profile.dto.ProfileResponse;
 import com.foru.freebe.profile.dto.UpdateProfileRequest;
@@ -29,22 +33,18 @@ import com.foru.freebe.profile.repository.LinkRepository;
 import com.foru.freebe.profile.repository.ProfileImageRepository;
 import com.foru.freebe.profile.repository.ProfileRepository;
 import com.foru.freebe.s3.S3ImageService;
+import com.foru.freebe.s3.S3ImageType;
 
+@ExtendWith(MockitoExtension.class)
 class ProfileServiceTest {
-
-    private static final String PROFILE_NAME = "unique-profile-name";
-
-    @Mock
-    private MemberRepository memberRepository;
-
     @Mock
     private ProfileRepository profileRepository;
 
     @Mock
-    private ProfileImageRepository profileImageRepository;
+    private LinkRepository linkRepository;
 
     @Mock
-    private LinkRepository linkRepository;
+    private ProfileImageRepository profileImageRepository;
 
     @Mock
     private S3ImageService s3ImageService;
@@ -52,152 +52,181 @@ class ProfileServiceTest {
     @InjectMocks
     private ProfileService profileService;
 
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-        profileService = spy(
-            new ProfileService(profileRepository, linkRepository, profileImageRepository, s3ImageService));
-    }
-
-    @DisplayName("사진작가 측 현재 프로필 조회")
-    @Test
-    void testGetCurrentProfile() {
-        // Given
-        Member photographer = createNewMember();
-        Profile profile = createProfile(photographer);
-        ProfileImage profileImage = createProfileImage(profile);
-
-        Link link1 = createLink(profile, "My Portfolio", "http://portfolio.com");
-        Link link2 = createLink(profile, "My Blog", "http://blog.com");
-
-        when(profileRepository.findByMember(photographer)).thenReturn(Optional.of(profile));
-        when(linkRepository.findByProfile(profile)).thenReturn(Arrays.asList(link1, link2));
-        when(profileImageRepository.findByProfile(profile)).thenReturn(Optional.ofNullable(profileImage));
-
-        // When
-        ProfileResponse result = profileService.getCurrentProfile(photographer);
-
-        // Then
-        assertNotNull(result);
-        assertEquals("http://thumbnails.com", result.getProfileImageUrl());
-        assertEquals("banner.jpg", result.getBannerImageUrl());
-        assertEquals("unique-profile-name", result.getProfileName());
-        assertEquals("Welcome to my profile!", result.getIntroductionContent());
-
-        List<LinkInfo> linkInfos = result.getLinkInfos();
-        assertNotNull(linkInfos);
-        assertEquals(2, linkInfos.size());
-
-        LinkInfo linkInfo1 = linkInfos.get(0);
-        assertEquals("My Portfolio", linkInfo1.getLinkTitle());
-        assertEquals("http://portfolio.com", linkInfo1.getLinkUrl());
-
-        LinkInfo linkInfo2 = linkInfos.get(1);
-        assertEquals("My Blog", linkInfo2.getLinkTitle());
-        assertEquals("http://blog.com", linkInfo2.getLinkUrl());
-    }
-
-    @DisplayName("사진작가 측 외부 링크를 제외한 프로필 업데이트")
-    @Test
-    void testUpdateProfile() throws IOException {
-        // Given
-        Member photographer = createNewMember();
-        Profile existingProfile = createProfile(photographer);
-        ProfileImage profileImage = createProfileImage(existingProfile);
-
-        List<LinkInfo> linkInfos = Arrays.asList(
-            new LinkInfo("changed blog", "www.url.com"),
-            new LinkInfo("My Portfolio", "www.change.com"),
-            new LinkInfo("new info", "nice"));
-
-        UpdateProfileRequest updateRequest = UpdateProfileRequest.builder()
-            .bannerImageUrl("banner.jpg")
-            .introductionContent("changed content")
-            .linkInfos(linkInfos)
-            .build();
-
-        MockMultipartFile requestImage = new MockMultipartFile("file", "profile_change.jpg", "image/jpeg",
-            "file contents".getBytes());
-
-        when(profileRepository.findByMember(photographer)).thenReturn(Optional.of(existingProfile));
-        when(memberRepository.findById(photographer.getId())).thenReturn(Optional.of(photographer));
-
-        // When
-        profileService.updateProfile(updateRequest, photographer, requestImage);
-
-        // then
-        assertEquals("http://originurl.com", profileImage.getOriginUrl());
-        assertEquals("changed content", existingProfile.getIntroductionContent());
-        assertEquals("banner.jpg", existingProfile.getBannerImageUrl());
-    }
-
-    private ProfileImage createProfileImage(Profile existingProfile) {
-        return ProfileImage.builder()
-            .profile(existingProfile)
-            .thumbnailUrl("http://thumbnails.com")
-            .originUrl("http://originurl.com")
-            .build();
-    }
-
-    @DisplayName("사진작가 측 프로필의 외부 링크 업데이트")
-    @Test
-    void testUpdateLinks() throws IOException {
-        // Given
-        Member photographer = createNewMember();
-        Profile existingProfile = createProfile(photographer);
-
-        Link link1 = createLink(existingProfile, "Naver Blog", "www.naver.blog");
-        Link link2 = createLink(existingProfile, "Pinterest", "www.pinterest.com");
-
-        List<LinkInfo> linkInfos = Arrays.asList(
-            new LinkInfo("changed blog", "www.url.com"),
-            new LinkInfo("Naver Blog", "www.change.com"),
-            new LinkInfo("new info", "nice"));
-
-        UpdateProfileRequest updateRequest = UpdateProfileRequest.builder()
-            .bannerImageUrl("banner.jpg")
-            .introductionContent("Welcome to my profile!")
-            .linkInfos(linkInfos)
-            .build();
-
-        MockMultipartFile requestImage = new MockMultipartFile("file", "profile_change.jpg", "image/jpeg",
-            "file contents".getBytes());
-
-        when(profileRepository.findByMember(photographer)).thenReturn(Optional.of(existingProfile));
-        when(linkRepository.findByProfile(existingProfile)).thenReturn(Arrays.asList(link1, link2));
-        when(memberRepository.findById(photographer.getId())).thenReturn(Optional.of(photographer));
-
-        // When
-        profileService.updateProfile(updateRequest, photographer, requestImage);
-
-        // Then
-        verify(linkRepository).save(argThat(link ->
-            "changed blog".equals(link.getTitle()) && "www.url.com".equals(link.getUrl())));
-        verify(linkRepository).save(argThat(link ->
-            "new info".equals(link.getTitle()) && "nice".equals(link.getUrl())));
-
-        verify(linkRepository, times(2)).save(any(Link.class));
-    }
+    private final Member photographer = createNewMember();
 
     private Member createNewMember() {
-        return new Member(1L, Role.PHOTOGRAPHER, "John Doe", "john@example.com",
-            "1234567890", 1980, "Male", "johndoe");
-    }
-
-    private Profile createProfile(Member photographer) {
-        return Profile.builder()
-            .profileName(PROFILE_NAME)
-            .bannerImageUrl("banner.jpg")
-            .introductionContent("Welcome to my profile!")
-            .member(photographer)
+        return Member
+            .builder(1L, Role.PHOTOGRAPHER, "이유리", "yuri@naver.com", "010-1234-5678")
             .build();
     }
 
-    private Link createLink(Profile profile, String title, String url) {
-        return Link.builder()
-            .profile(profile)
-            .title(title)
-            .url(url)
-            .build();
+    @Nested
+    @DisplayName("프로필 조회 테스트")
+    class ProfileQueryTest {
+        private Profile profile;
+        private ProfileImage profileImage;
+        private List<Link> links;
+
+        @BeforeEach
+        void setUp() {
+            MockitoAnnotations.openMocks(this);
+
+            profile = Profile.builder()
+                .profileName("uniqueName")
+                .member(photographer)
+                .introductionContent("Welcome to my profile")
+                .build();
+
+            profileImage = ProfileImage.builder()
+                .bannerOriginUrl("https://freebe/banner/origin")
+                .profileOriginUrl("https://freebe/profile/origin")
+                .profileThumbnailUrl("https://freebe/profile/thumbnail")
+                .build();
+
+            links = List.of(
+                Link.builder().profile(profile).title("title1").url("url1").build(),
+                Link.builder().profile(profile).title("title2").url("url2").build()
+            );
+        }
+
+        @Test
+        @DisplayName("(성공) 사진작가가 자신의 프로필을 조회한다")
+        void testGetMyCurrentProfile() {
+            // given
+            when(profileRepository.findByMember(photographer)).thenReturn(Optional.of(profile));
+            when(profileImageRepository.findByProfile(profile)).thenReturn(Optional.of(profileImage));
+            when(linkRepository.findByProfile(profile)).thenReturn(links);
+
+            // when
+            ProfileResponse response = profileService.getMyCurrentProfile(photographer);
+
+            // then
+            assertEquals(response.getBannerImageUrl(), "https://freebe/banner/origin");
+            assertEquals(response.getProfileImageUrl(), "https://freebe/profile/thumbnail");
+            assertEquals(response.getProfileName(), "uniqueName");
+            assertEquals(response.getIntroductionContent(), "Welcome to my profile");
+            List<LinkInfo> linkInfos = response.getLinkInfos();
+            assertEquals(linkInfos.size(), 2);
+            assertEquals(linkInfos.get(0).getLinkTitle(), "title1");
+            assertEquals(linkInfos.get(1).getLinkTitle(), "title2");
+        }
+    }
+
+    @Nested
+    @DisplayName("프로필 업데이트 테스트")
+    class ProfileUpdateTest {
+        private Profile profile;
+        private ProfileImage profileImage;
+        private List<Link> links;
+
+        @BeforeEach
+        void setUp() {
+            MockitoAnnotations.openMocks(this);
+            profile = mock(Profile.class);
+            profileImage = mock(ProfileImage.class);
+            links = List.of(
+                Link.builder().profile(profile).title("existingTitle1").url("existingUrl1").build(),
+                Link.builder().profile(profile).title("existingTitle2").url("existingUrl2").build()
+            );
+        }
+
+        private MockMultipartFile createMockMultipartFile(String name) throws IOException {
+            return new MockMultipartFile(name, name + ".jpg", "image/jpeg", new byte[] {1, 2, 3});
+        }
+
+        @Test
+        @DisplayName("(성공) 사진작가가 최초 회원가입 직후 프로필 정보를 등록한다")
+        void testInitialUpdateProfile() throws IOException {
+            // given
+            when(profileRepository.findByMember(photographer)).thenReturn(Optional.of(profile));
+            when(profileImageRepository.findByProfile(profile)).thenReturn(Optional.of(profileImage));
+            when(linkRepository.findByProfile(profile)).thenReturn(links);
+
+            UpdateProfileRequest request = UpdateProfileRequest.builder()
+                .introductionContent("Welcome to my profile")
+                .linkInfos(List.of(
+                    new LinkInfo("existingTitle1", "existingUrl1"),
+                    new LinkInfo("newTitle1", "newUrl1")
+                ))
+                .build();
+            MockMultipartFile bannerImageFile = createMockMultipartFile("banner");
+            MockMultipartFile profileImageFile = createMockMultipartFile("profile");
+
+            ImageLinkSet bannerImageLinkSet = new ImageLinkSet(Collections.singletonList("originUrl"), null);
+            List<MultipartFile> bannerImageFiles = Collections.singletonList(bannerImageFile);
+            when(
+                s3ImageService.imageUploadToS3(bannerImageFiles, S3ImageType.PROFILE, photographer.getId())).thenReturn(
+                bannerImageLinkSet);
+
+            // profile Image
+            ImageLinkSet profileImageLinkSet = new ImageLinkSet(Collections.singletonList("originUrl"),
+                Collections.singletonList("thumbnailUrl"));
+            List<MultipartFile> profileImageFiles = Collections.singletonList(profileImageFile);
+            when(s3ImageService.imageUploadToS3(profileImageFiles, S3ImageType.PROFILE, photographer.getId(),
+                100)).thenReturn(profileImageLinkSet);
+
+            // when
+            profileService.updateProfile(photographer, request, bannerImageFile, profileImageFile);
+
+            // then
+            verify(profile).updateIntroductionContent("Welcome to my profile");
+            verify(linkRepository, times(1)).delete(any(Link.class));
+            verify(s3ImageService, never()).deleteImageFromS3(anyString());
+            verify(profileImage).assignBannerOriginUrl(anyString());
+            verify(profileImage).assignProfileOriginUrl(anyString());
+            verify(profileImage).assignProfileThumbnailUrl(anyString());
+            verify(profileImageRepository, times(2)).save(any(ProfileImage.class));
+        }
+
+        @Test
+        @DisplayName("(성공) 사진작가가 프로필 정보를 새로 업데이트한다")
+        void testUpdateProfile() throws IOException {
+            // given
+            ProfileImage existingProfileImage = ProfileImage.builder()
+                .bannerOriginUrl("existingBannerOriginUrl")
+                .profileOriginUrl("existingProfileOriginUrl")
+                .profileThumbnailUrl("existingProfileThumbnailUrl")
+                .build();
+
+            when(profileRepository.findByMember(photographer)).thenReturn(Optional.of(profile));
+            when(profileImageRepository.findByProfile(profile)).thenReturn(Optional.of(existingProfileImage));
+            when(linkRepository.findByProfile(profile)).thenReturn(links);
+
+            UpdateProfileRequest request = UpdateProfileRequest.builder()
+                .introductionContent("Welcome to my profile")
+                .linkInfos(List.of(
+                    new LinkInfo("existingTitle1", "existingUrl1"),
+                    new LinkInfo("newTitle1", "newUrl1")
+                ))
+                .build();
+            MockMultipartFile bannerImageFile = createMockMultipartFile("banner");
+            MockMultipartFile profileImageFile = createMockMultipartFile("profile");
+
+            ImageLinkSet bannerImageLinkSet = new ImageLinkSet(Collections.singletonList("newBannerOriginUrl"), null);
+            List<MultipartFile> bannerImageFiles = Collections.singletonList(bannerImageFile);
+            when(
+                s3ImageService.imageUploadToS3(bannerImageFiles, S3ImageType.PROFILE, photographer.getId())).thenReturn(
+                bannerImageLinkSet);
+
+            // profile Image
+            ImageLinkSet profileImageLinkSet = new ImageLinkSet(Collections.singletonList("newProfileOriginUrl"),
+                Collections.singletonList("newProfileThumbnailUrl"));
+            List<MultipartFile> profileImageFiles = Collections.singletonList(profileImageFile);
+            when(s3ImageService.imageUploadToS3(profileImageFiles, S3ImageType.PROFILE, photographer.getId(),
+                100)).thenReturn(profileImageLinkSet);
+
+            // when
+            profileService.updateProfile(photographer, request, bannerImageFile, profileImageFile);
+
+            // then
+            verify(profile).updateIntroductionContent("Welcome to my profile");
+            verify(linkRepository, times(1)).delete(any(Link.class));
+            verify(s3ImageService, times(3)).deleteImageFromS3(anyString());
+            assertEquals(existingProfileImage.getBannerOriginUrl(), "newBannerOriginUrl");
+            assertEquals(existingProfileImage.getProfileOriginUrl(), "newProfileOriginUrl");
+            assertEquals(existingProfileImage.getProfileThumbnailUrl(), "newProfileThumbnailUrl");
+            verify(profileImageRepository, times(2)).save(any(ProfileImage.class));
+        }
+
     }
 }


### PR DESCRIPTION
## 체크리스트

- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
- FU-256 티켓에서 사진작가 url 생성/프로필 업데이트 API를 수정하면서 ProfileService 클래스의 구조가 많이 바뀌게 되었습니다. FU-256에서는 배포 테스트가 시급해 테스트코드 수정을 미처 하지 못해서 이번 티켓에서 ProfileService 테스트코드를 리팩터링해 작성했습니다.
- S3에 이미지 업로드하는 경로를 재구성하였습니다.
- S3에 이미지 업데이트 시, 기존 존재하는 이미지는 삭제하는 로직이 추가되었습니다.

## 고민한 사항

## 리뷰 요청사항
- 변경 파일이 많지 않아 전반적인 검토 부탁드려용
- 예상 리뷰시간: 5분
- 시급도: 보통
