### PR TITLE
[FU-124] 신청서 상태변경 & 회원가입 API 테스트코드 작성

### DIFF
--- a/.github/workflows/cd_workflow_dev.yml
+++ b/.github/workflows/cd_workflow_dev.yml
@@ -5,7 +5,7 @@ on:
     branches: [ "develop" ]
   pull_request:
     branches: [ "fix/*" ]
-    
+
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -33,7 +33,8 @@ jobs:
           echo "AWS_REGION=${{ secrets.AWS_REGION }}" >> .env
           echo "AWS_ACCESS_KEY=${{ secrets.CICD_ACCESS_KEY }}" >> .env
           echo "AWS_SECRET_KEY=${{ secrets.CICD_SECRET_KEY }}" >> .env
-          echo "AWS_S3_BUCKET=${{ secrets.AWS_S3_BUCKET }}" >> .env
+          echo "AWS_S3_CICD_BUCKET=${{ secrets.AWS_S3_CICD_BUCKET }}" >> .env
+          echo "AWS_S3_DATA_BUCKET=${{ secrets.AWS_S3_DATA_BUCKET }}" >> .env
           echo "AWS_S3_ORIGINAL_PATH=${{ secrets.AWS_S3_ORIGINAL_PATH }}" >> .env
           echo "AWS_S3_THUMBNAIL_PATH=${{ secrets.AWS_S3_THUMBNAIL_PATH }}" >> .env
           echo "AWS_S3_PHOTOGRAPHER_PATH=${{ secrets.AWS_S3_PHOTOGRAPHER_PATH }}" >> .env

--- a/src/main/java/com/foru/freebe/auth/service/KakaoAuthService.java
+++ b/src/main/java/com/foru/freebe/auth/service/KakaoAuthService.java
@@ -15,7 +15,7 @@ import reactor.core.publisher.Mono;
 
 @Service
 @RequiredArgsConstructor
-public class AuthService {
+public class KakaoAuthService {
     private final WebClient webClient;
 
     @Value("${KAKAO_CLIENT_ID}")

--- a/src/main/java/com/foru/freebe/member/controller/JoinController.java
+++ b/src/main/java/com/foru/freebe/member/controller/JoinController.java
@@ -13,7 +13,7 @@ import com.foru.freebe.auth.model.MemberAdapter;
 import com.foru.freebe.common.dto.ResponseBody;
 import com.foru.freebe.member.dto.PhotographerJoinRequest;
 import com.foru.freebe.member.entity.Member;
-import com.foru.freebe.member.service.MemberService;
+import com.foru.freebe.member.service.PhotographerJoinService;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,14 +21,14 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 public class JoinController {
-    private final MemberService memberService;
+    private final PhotographerJoinService photographerJoinService;
 
     @PostMapping("/photographer/join")
     public ResponseEntity<ResponseBody<String>> joinPhotographer(@AuthenticationPrincipal MemberAdapter memberAdapter,
         @Valid @RequestBody PhotographerJoinRequest request) throws IOException {
 
         Member member = memberAdapter.getMember();
-        String profileName = memberService.joinPhotographer(member, request);
+        String profileName = photographerJoinService.joinPhotographer(member, request);
 
         ResponseBody<String> responseBody = ResponseBody.<String>builder()
             .data(profileName)

--- a/src/main/java/com/foru/freebe/member/dto/PhotographerJoinRequest.java
+++ b/src/main/java/com/foru/freebe/member/dto/PhotographerJoinRequest.java
@@ -2,9 +2,12 @@ package com.foru.freebe.member.dto;
 
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class PhotographerJoinRequest {
     @NotBlank(message = "Profile name must not be blank")
     private String profileName;
@@ -16,4 +19,13 @@ public class PhotographerJoinRequest {
     private Boolean privacyPolicyAgreement;
 
     private Boolean marketingAgreement;
+
+    @Builder
+    public PhotographerJoinRequest(String profileName, Boolean termsOfServiceAgreement, Boolean privacyPolicyAgreement,
+        Boolean marketingAgreement) {
+        this.profileName = profileName;
+        this.termsOfServiceAgreement = termsOfServiceAgreement;
+        this.privacyPolicyAgreement = privacyPolicyAgreement;
+        this.marketingAgreement = marketingAgreement;
+    }
 }

--- a/src/main/java/com/foru/freebe/member/service/PhotographerJoinService.java
+++ b/src/main/java/com/foru/freebe/member/service/PhotographerJoinService.java
@@ -1,0 +1,48 @@
+package com.foru.freebe.member.service;
+
+import org.springframework.stereotype.Service;
+
+import com.foru.freebe.member.dto.PhotographerJoinRequest;
+import com.foru.freebe.member.entity.Member;
+import com.foru.freebe.member.entity.MemberTermAgreement;
+import com.foru.freebe.member.entity.Role;
+import com.foru.freebe.member.repository.MemberRepository;
+import com.foru.freebe.member.repository.MemberTermAgreementRepository;
+import com.foru.freebe.profile.entity.Profile;
+import com.foru.freebe.profile.service.ProfileService;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PhotographerJoinService {
+    private final ProfileService profileService;
+    private final MemberRepository memberRepository;
+    private final MemberTermAgreementRepository memberTermAgreementRepository;
+
+    @Transactional
+    public String joinPhotographer(Member member, PhotographerJoinRequest request) {
+        Member photographer = completePhotographerSignup(member);
+
+        savePhotographerAgreements(photographer, request);
+        Profile profile = profileService.initialProfileSetting(photographer, request.getProfileName());
+
+        return profile.getProfileName();
+    }
+
+    private Member completePhotographerSignup(Member member) {
+        member.assignRole(Role.PHOTOGRAPHER);
+        return memberRepository.save(member);
+    }
+
+    private void savePhotographerAgreements(Member member, PhotographerJoinRequest request) {
+        MemberTermAgreement memberTermAgreement = MemberTermAgreement.builder()
+            .member(member)
+            .termsOfServiceAgreement(request.getTermsOfServiceAgreement())
+            .privacyPolicyAgreement(request.getPrivacyPolicyAgreement())
+            .marketingAgreement(request.getMarketingAgreement())
+            .build();
+        memberTermAgreementRepository.save(memberTermAgreement);
+    }
+}

--- a/src/main/java/com/foru/freebe/reservation/dto/ReservationStatusUpdateRequest.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/ReservationStatusUpdateRequest.java
@@ -3,21 +3,14 @@ package com.foru.freebe.reservation.dto;
 import com.foru.freebe.reservation.entity.ReservationStatus;
 
 import jakarta.validation.constraints.NotNull;
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
 public class ReservationStatusUpdateRequest {
     @NotNull
     private ReservationStatus updateStatus;
 
     private String cancellationReason;
-
-    @Builder
-    public ReservationStatusUpdateRequest(ReservationStatus updateStatus, String cancellationReason) {
-        this.updateStatus = updateStatus;
-        this.cancellationReason = cancellationReason;
-    }
 }

--- a/src/test/java/com/foru/freebe/member/service/PhotographerJoinServiceTest.java
+++ b/src/test/java/com/foru/freebe/member/service/PhotographerJoinServiceTest.java
@@ -1,0 +1,87 @@
+package com.foru.freebe.member.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.foru.freebe.member.dto.PhotographerJoinRequest;
+import com.foru.freebe.member.entity.Member;
+import com.foru.freebe.member.entity.MemberTermAgreement;
+import com.foru.freebe.member.entity.Role;
+import com.foru.freebe.member.repository.MemberRepository;
+import com.foru.freebe.member.repository.MemberTermAgreementRepository;
+import com.foru.freebe.profile.entity.Profile;
+import com.foru.freebe.profile.repository.LinkRepository;
+import com.foru.freebe.profile.repository.ProfileImageRepository;
+import com.foru.freebe.profile.repository.ProfileRepository;
+import com.foru.freebe.profile.service.ProfileService;
+import com.foru.freebe.s3.S3ImageService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("사진작가측 회원가입 테스트")
+class PhotographerJoinServiceTest {
+    @Mock
+    private ProfileRepository profileRepository;
+
+    @Mock
+    private LinkRepository linkRepository;
+
+    @Mock
+    private ProfileImageRepository profileImageRepository;
+
+    @Mock
+    private S3ImageService s3ImageService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private MemberTermAgreementRepository memberTermAgreementRepository;
+
+    private PhotographerJoinService photographerJoinService;
+
+    private ProfileService profileService;
+
+    private Member photographer;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        profileService = spy(
+            new ProfileService(profileRepository, linkRepository, profileImageRepository, s3ImageService));
+        photographerJoinService = new PhotographerJoinService(profileService, memberRepository,
+            memberTermAgreementRepository);
+        photographer = Member.builder(1L, Role.PHOTOGRAPHER_PENDING, "이유리", "test@email", "010-0000-0000").build();
+    }
+
+    @Test
+    @DisplayName("(성공) 사진작가가 회원가입을 진행한다")
+    void joinPhotographer() {
+        // given
+        PhotographerJoinRequest request = PhotographerJoinRequest.builder()
+            .profileName("lee")
+            .termsOfServiceAgreement(true)
+            .privacyPolicyAgreement(true)
+            .marketingAgreement(true)
+            .build();
+        when(memberRepository.save(any(Member.class))).thenReturn(photographer);
+        when(profileService.initialProfileSetting(photographer, request.getProfileName()))
+            .thenReturn(Profile.builder().profileName("profileName").build());
+
+        // when
+        String profileName = photographerJoinService.joinPhotographer(photographer, request);
+
+        // then
+        assertThat(profileName).isEqualTo("profileName");
+        assertThat(photographer.getRole()).isEqualTo(Role.PHOTOGRAPHER);
+        verify(memberTermAgreementRepository).save(any(MemberTermAgreement.class));
+        verify(profileService).initialProfileSetting(any(Member.class), any(String.class));
+    }
+}


### PR DESCRIPTION
## 체크리스트

- [x] 불필요한 주석 처리가 없는가?
</br>

## 작업 내역
- 미뤄뒀던 레거시 코드에 대한 테스트 코드 작성 태스크를 완료했습니다.
  - 사진작가측 신청서 상태변경 서비스 로직에 대한 테스트 코드 작성
  - 사진작가측 회원가입 로직에 대한 테스트 코드 작성
- 회원가입 로직에 대한 테스트 코드를 작성하다보니, 관련 클래스들의 책임을 명확하게 구분할 필요성을 느껴 리팩터링을 진행했습니다.
  - 회원가입 서비스로직을 담당하는 클래스명 리팩터링
    - 기존: MemberService
    - 변경: PhotographerJoinService
  - 로그인 로직을 담당하는 클래스명 리팩터링
    - 기존: AuthService
    - 변경: KakaoLoginService
  - 카카오 인증 서버와 통신을 담당하는 로직은 새로운 클래스로 추출
    - 기존: AuthService
    - 변경: KakaoAuthService

</br>

## 고민한 사항
- 회원가입/로그인 로직에 대해서는 롤백 테스트도 함께 진행하면 좋겠다는 생각이 들었는데, 이번 스프린트에서 해야 할 일이 많아 기본적인 테스트코드만 작성했습니다 😓

</br>

## 리뷰 요청사항
- 특별한 리뷰 요청사항은 없습니다.
- 시급도 낮음입니다. 이번 스프린트 내에만 완료되면 될 것 같아요!