### PR TITLE
[FU-215] 지난예약 목록 조회 및 필터링+페이징 기능 구현

### DIFF
--- a/src/main/java/com/foru/freebe/product/respository/ProductRepository.java
+++ b/src/main/java/com/foru/freebe/product/respository/ProductRepository.java
@@ -6,10 +6,13 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.foru.freebe.member.entity.Member;
+import com.foru.freebe.product.entity.ActiveStatus;
 import com.foru.freebe.product.entity.Product;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
-    Optional<List<Product>> findByMember(Member member);
+    List<Product> findByMember(Member member);
+
+    List<Product> findByMemberAndActiveStatus(Member member, ActiveStatus activeStatus);
 
     Boolean existsByMemberAndTitle(Member member, String title);
 

--- a/src/main/java/com/foru/freebe/product/service/CustomerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/CustomerProductService.java
@@ -10,6 +10,7 @@ import com.foru.freebe.errors.exception.RestApiException;
 import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.product.dto.customer.ProductDetailResponse;
 import com.foru.freebe.product.dto.customer.ProductListResponse;
+import com.foru.freebe.product.entity.ActiveStatus;
 import com.foru.freebe.product.entity.Product;
 import com.foru.freebe.product.entity.ProductImage;
 import com.foru.freebe.product.respository.ProductImageRepository;
@@ -51,8 +52,7 @@ public class CustomerProductService {
 
         Member photographer = photographerProfile.getMember();
 
-        List<Product> products = productRepository.findByMember(photographer)
-            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+        List<Product> products = productRepository.findByMemberAndActiveStatus(photographer, ActiveStatus.ACTIVE);
 
         List<ProductListResponse> productListResponseList = new ArrayList<>();
         for (Product product : products) {

--- a/src/main/java/com/foru/freebe/product/service/CustomerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/CustomerProductService.java
@@ -61,7 +61,7 @@ public class CustomerProductService {
             ProductListResponse productListResponse = ProductListResponse.builder()
                 .productId(product.getId())
                 .productTitle(product.getTitle())
-                .productRepresentativeImageUrl(productImage.get(0).getOriginUrl())
+                .productRepresentativeImageUrl(productImage.get(0).getThumbnailUrl())
                 .build();
 
             productListResponseList.add(productListResponse);

--- a/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
@@ -78,8 +78,7 @@ public class PhotographerProductService {
     }
 
     public List<RegisteredProductResponse> getRegisteredProductList(Member member) {
-        List<Product> registeredProductList = productRepository.findByMember(member)
-            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+        List<Product> registeredProductList = productRepository.findByMember(member);
 
         return registeredProductList.stream()
             .map(product -> RegisteredProductResponse.builder()

--- a/src/main/java/com/foru/freebe/product/service/ProductDetailConvertor.java
+++ b/src/main/java/com/foru/freebe/product/service/ProductDetailConvertor.java
@@ -93,7 +93,7 @@ public class ProductDetailConvertor {
         List<ProductImage> productImages = productImageRepository.findByProduct(product);
         List<String> productImageUrls = new ArrayList<>();
         for (ProductImage productImage : productImages) {
-            productImageUrls.add(productImage.getThumbnailUrl());
+            productImageUrls.add(productImage.getOriginUrl());
         }
         return productImageUrls;
     }

--- a/src/main/java/com/foru/freebe/reservation/controller/PhotographerReservationController.java
+++ b/src/main/java/com/foru/freebe/reservation/controller/PhotographerReservationController.java
@@ -97,7 +97,7 @@ public class PhotographerReservationController {
         @RequestParam(value = "to", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
         @RequestParam(value = "status", required = false) String status,
         @RequestParam(value = "keyword", required = false) String keyword,
-        @PageableDefault(page = 0) Pageable pageable) {
+        @PageableDefault(size = 4) Pageable pageable) {
 
         Member member = memberAdapter.getMember();
         PastReservationResponse pastReservationResponse = photographerPastReservationService.getPastReservationList(

--- a/src/main/java/com/foru/freebe/reservation/controller/PhotographerReservationController.java
+++ b/src/main/java/com/foru/freebe/reservation/controller/PhotographerReservationController.java
@@ -1,7 +1,11 @@
 package com.foru.freebe.reservation.controller;
 
+import java.time.LocalDate;
 import java.util.List;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -10,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.foru.freebe.auth.model.MemberAdapter;
@@ -17,7 +22,9 @@ import com.foru.freebe.common.dto.ResponseBody;
 import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.reservation.dto.FormDetailsViewResponse;
 import com.foru.freebe.reservation.dto.FormListViewResponse;
+import com.foru.freebe.reservation.dto.PastReservationResponse;
 import com.foru.freebe.reservation.dto.ReservationStatusUpdateRequest;
+import com.foru.freebe.reservation.service.PhotographerPastReservationService;
 import com.foru.freebe.reservation.service.PhotographerReservationDetails;
 import com.foru.freebe.reservation.service.PhotographerReservationService;
 import com.foru.freebe.reservation.service.ReservationService;
@@ -32,6 +39,7 @@ public class PhotographerReservationController {
     private final PhotographerReservationService photographerReservationService;
     private final PhotographerReservationDetails photographerReservationDetails;
     private final ReservationService reservationService;
+    private final PhotographerPastReservationService photographerPastReservationService;
 
     @GetMapping("/reservation/list")
     public ResponseEntity<ResponseBody<List<FormListViewResponse>>> getReservationList(
@@ -76,6 +84,28 @@ public class PhotographerReservationController {
 
         ResponseBody<Void> responseBody = ResponseBody.<Void>builder()
             .message("Successfully update reservation status")
+            .build();
+
+        return ResponseEntity.status(HttpStatus.OK.value())
+            .body(responseBody);
+    }
+
+    @GetMapping("/reservation/list/past")
+    public ResponseEntity<ResponseBody<PastReservationResponse>> getPastReservationList(
+        @AuthenticationPrincipal MemberAdapter memberAdapter,
+        @RequestParam(value = "from", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+        @RequestParam(value = "to", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+        @RequestParam(value = "status", required = false) String status,
+        @RequestParam(value = "keyword", required = false) String keyword,
+        @PageableDefault(page = 0) Pageable pageable) {
+
+        Member member = memberAdapter.getMember();
+        PastReservationResponse pastReservationResponse = photographerPastReservationService.getPastReservationList(
+            member.getId(), from, to, status, keyword, pageable);
+
+        ResponseBody<PastReservationResponse> responseBody = ResponseBody.<PastReservationResponse>builder()
+            .message("Successfully get reservation list")
+            .data(pastReservationResponse)
             .build();
 
         return ResponseEntity.status(HttpStatus.OK.value())

--- a/src/main/java/com/foru/freebe/reservation/dto/PastReservationFormComponent.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/PastReservationFormComponent.java
@@ -1,0 +1,53 @@
+package com.foru.freebe.reservation.dto;
+
+import java.time.LocalDate;
+
+import com.foru.freebe.reservation.entity.ReservationStatus;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PastReservationFormComponent {
+    @NotNull
+    private ReservationStatus reservationStatus;
+
+    @NotNull
+    private Long reservationId;
+
+    @NotNull
+    private LocalDate reservationSubmissionDate;
+
+    @NotBlank
+    private String customerName;
+
+    @NotBlank
+    private String productTitle;
+
+    @NotNull
+    private PreferredDate shootingDate;
+
+    @NotBlank
+    private Long price;
+
+    @NotBlank
+    private String image;
+
+    @Builder
+    public PastReservationFormComponent(ReservationStatus reservationStatus, Long reservationId,
+        LocalDate reservationSubmissionDate, String customerName, String productTitle, PreferredDate shootingDate,
+        Long price, String image) {
+        this.reservationStatus = reservationStatus;
+        this.reservationId = reservationId;
+        this.reservationSubmissionDate = reservationSubmissionDate;
+        this.customerName = customerName;
+        this.productTitle = productTitle;
+        this.shootingDate = shootingDate;
+        this.price = price;
+        this.image = image;
+    }
+}

--- a/src/main/java/com/foru/freebe/reservation/dto/PastReservationResponse.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/PastReservationResponse.java
@@ -1,0 +1,17 @@
+package com.foru.freebe.reservation.dto;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PastReservationResponse {
+    @NotNull
+    public int totalPages;
+
+    @NotNull
+    public List<PastReservationFormComponent> pastReservationFormComponent;
+}

--- a/src/main/java/com/foru/freebe/reservation/repository/ReservationFormRepository.java
+++ b/src/main/java/com/foru/freebe/reservation/repository/ReservationFormRepository.java
@@ -1,11 +1,15 @@
 package com.foru.freebe.reservation.repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.foru.freebe.reservation.entity.ReservationForm;
+import com.foru.freebe.reservation.entity.ReservationStatus;
 
 public interface ReservationFormRepository extends JpaRepository<ReservationForm, Long> {
     Optional<List<ReservationForm>> findAllByPhotographerId(Long photographerId);
@@ -15,4 +19,16 @@ public interface ReservationFormRepository extends JpaRepository<ReservationForm
     Optional<ReservationForm> findByCustomerIdAndId(Long customerId, Long id);
 
     List<ReservationForm> findAllByPhotographerIdAndProductTitle(Long photographerId, String productTitle);
+
+    Page<ReservationForm> findByPhotographerId(Long photographerId, Pageable pageable);
+
+    Page<ReservationForm> findByPhotographerIdAndReservationStatusIn(Long photographerId,
+        List<ReservationStatus> status, Pageable pageable);
+
+    Page<ReservationForm> findByPhotographerIdAndShootingDate_DateBetween(Long photographerId, LocalDate from,
+        LocalDate to,
+        Pageable pageable);
+
+    Page<ReservationForm> findByPhotographerIdAndReservationStatusInAndShootingDate_DateBetween(Long photographerId,
+        List<ReservationStatus> status, LocalDate from, LocalDate to, Pageable pageable);
 }

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerPastReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerPastReservationService.java
@@ -1,0 +1,126 @@
+package com.foru.freebe.reservation.service;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import com.foru.freebe.errors.errorcode.CommonErrorCode;
+import com.foru.freebe.errors.exception.RestApiException;
+import com.foru.freebe.product.entity.Product;
+import com.foru.freebe.product.entity.ProductImage;
+import com.foru.freebe.product.respository.ProductImageRepository;
+import com.foru.freebe.product.respository.ProductRepository;
+import com.foru.freebe.reservation.dto.PastReservationFormComponent;
+import com.foru.freebe.reservation.dto.PastReservationResponse;
+import com.foru.freebe.reservation.entity.ReservationForm;
+import com.foru.freebe.reservation.entity.ReservationStatus;
+import com.foru.freebe.reservation.repository.ReservationFormRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PhotographerPastReservationService {
+    private final ReservationFormRepository reservationFormRepository;
+    private final ProductImageRepository productImageRepository;
+    private final ProductRepository productRepository;
+    private static final String CANCELLED = "cancelled";
+    private static final String COMPLETED = "completed";
+
+    public PastReservationResponse getPastReservationList(Long photographerId, LocalDate from, LocalDate to,
+        String status, String keyword, Pageable defaultPageable) {
+
+        Pageable pageable = setCustomPageable(defaultPageable);
+        Page<ReservationForm> reservationFormPage;
+
+        switch (status) {
+            case CANCELLED:
+                if (from != null && to != null) {
+                    reservationFormPage = reservationFormRepository.findByPhotographerIdAndReservationStatusInAndShootingDate_DateBetween(
+                        photographerId, Arrays.asList(ReservationStatus.CANCELLED_BY_CUSTOMER,
+                            ReservationStatus.CANCELLED_BY_PHOTOGRAPHER), from, to, pageable);
+                } else {
+                    reservationFormPage = reservationFormRepository.findByPhotographerIdAndReservationStatusIn(
+                        photographerId, Arrays.asList(ReservationStatus.CANCELLED_BY_CUSTOMER,
+                            ReservationStatus.CANCELLED_BY_PHOTOGRAPHER), pageable);
+                }
+                break;
+            case COMPLETED:
+                if (from != null && to != null) {
+                    reservationFormPage = reservationFormRepository.findByPhotographerIdAndReservationStatusInAndShootingDate_DateBetween(
+                        photographerId, Collections.singletonList(ReservationStatus.PHOTO_COMPLETED), from, to,
+                        pageable);
+                } else {
+                    reservationFormPage = reservationFormRepository.findByPhotographerIdAndReservationStatusIn(
+                        photographerId, Collections.singletonList(ReservationStatus.PHOTO_COMPLETED), pageable);
+                }
+                break;
+            default:
+                if (from != null && to != null) {
+                    reservationFormPage = reservationFormRepository.findByPhotographerIdAndShootingDate_DateBetween(
+                        photographerId, from, to, pageable);
+                } else {
+                    reservationFormPage = reservationFormRepository.findByPhotographerId(photographerId, pageable);
+                }
+                break;
+        }
+
+        List<ReservationForm> reservationFormList = reservationFormPage.getContent();
+
+        if (keyword != null && !keyword.isEmpty()) {
+            reservationFormList = keywordFiltering(keyword, reservationFormPage);
+        }
+
+        int totalPages = reservationFormPage.getTotalPages();
+        List<PastReservationFormComponent> component = reservationFormList.stream()
+            .map(this::convertToPastReservationComponent)
+            .collect(Collectors.toList());
+
+        return new PastReservationResponse(totalPages, component);
+    }
+
+    private Pageable setCustomPageable(Pageable pageable) {
+        int page = pageable.getPageNumber() > 0 ? pageable.getPageNumber() - 1 : 0;
+        return PageRequest.of(page, pageable.getPageSize(), pageable.getSort());
+    }
+
+    private List<ReservationForm> keywordFiltering(String keyword, Page<ReservationForm> reservationFormPage) {
+        return reservationFormPage.stream()
+            .filter(reservationForm -> keywordMatches(reservationForm, keyword))
+            .toList();
+    }
+
+    private boolean keywordMatches(ReservationForm form, String keyword) {
+        return form.getCustomer().getName().contains(keyword) || form.getInstagramId().contains(keyword)
+            || form.getProductTitle().contains(keyword);
+    }
+
+    private PastReservationFormComponent convertToPastReservationComponent(ReservationForm form) {
+        Product product = productRepository.findByTitle(form.getProductTitle())
+            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+
+        List<ProductImage> productImage = productImageRepository.findByProduct(product);
+        String imageUrl = null;
+        if (productImage != null) {
+            imageUrl = productImage.get(0).getThumbnailUrl();
+        }
+
+        return PastReservationFormComponent.builder()
+            .reservationStatus(form.getReservationStatus())
+            .reservationId(form.getId())
+            .reservationSubmissionDate(LocalDate.from(form.getCreatedAt()))
+            .customerName(form.getCustomer().getName())
+            .productTitle(form.getProductTitle())
+            .shootingDate(form.getShootingDate())
+            .price(form.getTotalPrice())
+            .image(imageUrl)
+            .build();
+    }
+}


### PR DESCRIPTION
## 체크리스트

- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
- 지난 예약 목록을 조회할 수 있는 기능을 개발했습니다.
- 조회 시 `검색 키워드`, `기간`, `신청서 상태`를 필터링할 수 있습니다. (쿼리파라미터 이용)
- @eujin-shin ResponseBody 형식이 다소 변경되었습니다.
```
{
    "message": "Successfully get reservation list",
    "data": {
        "totalPages": 4,
        "pastReservationFormComponent": [
            {
                "reservationStatus": "CANCELLED_BY_PHOTOGRAPHER",
                "reservationId": 1,
                "reservationSubmissionDate": "2024-09-30",
                "customerName": "이유리",
                "productTitle": "야외스냅",
                "shootingDate": null,
                "price": 210000,
                "image": "https://freebe-data.s3.ap-northeast-2.amazonaws.com/photographers/1/products/thumbnail/f76b78a4-c3bf-4943-930f-6fe95693b24a%E1%84%89%E1%85%A1%E1%84%8C%E1%85%B5%E1%86%AB1.png"
            },
            {
                "reservationStatus": "CANCELLED_BY_PHOTOGRAPHER",
                "reservationId": 2,
                "reservationSubmissionDate": "2024-09-30",
                "customerName": "이유리",
                "productTitle": "야외스냅",
                "shootingDate": null,
                "price": 210000,
                "image": "https://freebe-data.s3.ap-northeast-2.amazonaws.com/photographers/1/products/thumbnail/f76b78a4-c3bf-4943-930f-6fe95693b24a%E1%84%89%E1%85%A1%E1%84%8C%E1%85%B5%E1%86%AB1.png"
            }
        ]
    }
}
```

## 고민한 사항
- 코드가 상당히 지저분해서 PR올리기가 머쓱하지만..🙄 배포 테스트가 급하니 우선 올려봅니닷.. API 테스트는 완료되었습니다!
- 내일 추가 티켓 배정해서 리팩터링 + 테스트코드 작성 추가할 예정입니다-! 리팩터링이 예정되어있어 현재 테스트코드는 작성하지 않았습니다.

## 리뷰 요청사항
(시급도) 내일 한 사이클 테스트가 예정되어 있어 시급도 높음입니다