### PR TITLE
[FU-269] 레퍼런스 이미지 Multipart parsing 에러, 배너이미지 삭제 안되는 문제 해결

### DIFF
--- a/src/main/java/com/foru/freebe/common/dto/ImageLinkSet.java
+++ b/src/main/java/com/foru/freebe/common/dto/ImageLinkSet.java
@@ -8,14 +8,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class ImageLinkSet {
-    private List<String> originUrl;
-    private List<String> thumbnailUrl;
-
-    public String getFirstOriginUrl() {
-        return originUrl.get(0);
-    }
-
-    public String getFirstThumbnailUrl() {
-        return thumbnailUrl.get(0);
-    }
+    private List<String> originUrls;
+    private List<String> thumbnailUrls;
 }

--- a/src/main/java/com/foru/freebe/common/dto/SingleImageLink.java
+++ b/src/main/java/com/foru/freebe/common/dto/SingleImageLink.java
@@ -1,0 +1,11 @@
+package com.foru.freebe.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SingleImageLink {
+    private String originalUrl;
+    private String thumbnailUrl;
+}

--- a/src/main/java/com/foru/freebe/member/dto/PhotographerJoinRequest.java
+++ b/src/main/java/com/foru/freebe/member/dto/PhotographerJoinRequest.java
@@ -2,6 +2,8 @@ package com.foru.freebe.member.dto;
 
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +12,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class PhotographerJoinRequest {
     @NotBlank(message = "Profile name must not be blank")
+    @Pattern(regexp = "^[a-z0-9_.]+$", message = "프로필명 입력 형식이 틀렸습니다")
+    @Size(min = 3, max = 30, message = "프로필명은 최소 3자 이상 최대 30자 이하여야합니다")
     private String profileName;
 
     @AssertTrue

--- a/src/main/java/com/foru/freebe/profile/service/ProfileService.java
+++ b/src/main/java/com/foru/freebe/profile/service/ProfileService.java
@@ -80,6 +80,10 @@ public class ProfileService {
 
         if (bannerImageFile != null) {
             updateBannerImage(profileImage, bannerImageFile, photographer.getId());
+        } else {
+            String bannerImageUrl = profileImage.getBannerOriginUrl();
+            s3ImageService.deleteImageFromS3(bannerImageUrl);
+            profileImage.assignBannerOriginUrl(null);
         }
 
         if (profileImageFile != null) {

--- a/src/main/java/com/foru/freebe/profile/service/ProfileService.java
+++ b/src/main/java/com/foru/freebe/profile/service/ProfileService.java
@@ -2,14 +2,13 @@ package com.foru.freebe.profile.service;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.foru.freebe.common.dto.ImageLinkSet;
+import com.foru.freebe.common.dto.SingleImageLink;
 import com.foru.freebe.errors.errorcode.CommonErrorCode;
 import com.foru.freebe.errors.errorcode.ProfileErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
@@ -32,8 +31,6 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class ProfileService {
-    private static final int PROFILE_THUMBNAIL_SIZE = 100;
-
     private final ProfileRepository profileRepository;
     private final LinkRepository linkRepository;
     private final ProfileImageRepository profileImageRepository;
@@ -141,10 +138,9 @@ public class ProfileService {
             s3ImageService.deleteImageFromS3(bannerImageUrl);
         }
 
-        List<MultipartFile> bannerImages = Collections.singletonList(imageFile);
-        ImageLinkSet bannerImageLinkSet = s3ImageService.imageUploadToS3(bannerImages, S3ImageType.PROFILE, id);
+        SingleImageLink bannerImageLink = s3ImageService.imageUploadToS3(imageFile, S3ImageType.PROFILE, id, false);
 
-        String newBannerImageUrl = bannerImageLinkSet.getFirstOriginUrl();
+        String newBannerImageUrl = bannerImageLink.getOriginalUrl();
         profileImage.assignBannerOriginUrl(newBannerImageUrl);
 
         profileImageRepository.save(profileImage);
@@ -158,12 +154,9 @@ public class ProfileService {
             s3ImageService.deleteImageFromS3(profileImageThumbnailUrl);
         }
 
-        List<MultipartFile> profileImages = Collections.singletonList(imageFile);
-        ImageLinkSet profileImageLinkSet = s3ImageService.imageUploadToS3(profileImages, S3ImageType.PROFILE, id,
-            PROFILE_THUMBNAIL_SIZE);
-
-        String originalImageUrl = profileImageLinkSet.getFirstOriginUrl();
-        String thumbnailImageUrl = profileImageLinkSet.getFirstThumbnailUrl();
+        SingleImageLink profileImageLink = s3ImageService.imageUploadToS3(imageFile, S3ImageType.PROFILE, id, true);
+        String originalImageUrl = profileImageLink.getOriginalUrl();
+        String thumbnailImageUrl = profileImage.getProfileThumbnailUrl();
 
         profileImage.assignProfileOriginUrl(originalImageUrl);
         profileImage.assignProfileThumbnailUrl(thumbnailImageUrl);

--- a/src/main/java/com/foru/freebe/reservation/controller/CustomerReservationController.java
+++ b/src/main/java/com/foru/freebe/reservation/controller/CustomerReservationController.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.util.List;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -37,10 +36,9 @@ public class CustomerReservationController {
     private final CustomerReservationService customerReservationService;
     private final ReservationService reservationService;
 
-    @PostMapping(value = "/reservation", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE,
-        MediaType.APPLICATION_JSON_VALUE})
+    @PostMapping(value = "/reservation")
     public ResponseEntity<ResponseBody<Long>> registerReservationForm(
-        @RequestPart("request") FormRegisterRequest request,
+        @Valid @RequestPart("request") FormRegisterRequest request,
         @AuthenticationPrincipal MemberAdapter memberAdapter,
         @RequestPart(value = "images", required = false) List<MultipartFile> images) throws IOException {
 

--- a/src/main/java/com/foru/freebe/reservation/controller/CustomerReservationController.java
+++ b/src/main/java/com/foru/freebe/reservation/controller/CustomerReservationController.java
@@ -40,7 +40,7 @@ public class CustomerReservationController {
     public ResponseEntity<ResponseBody<Long>> registerReservationForm(
         @Valid @RequestPart("request") FormRegisterRequest request,
         @AuthenticationPrincipal MemberAdapter memberAdapter,
-        @RequestPart(value = "images", required = false) List<MultipartFile> images) throws IOException {
+        @RequestPart(value = "images") List<MultipartFile> images) throws IOException {
 
         Member customer = memberAdapter.getMember();
         Long responseData = customerReservationService.registerReservationForm(customer.getId(), request, images);

--- a/src/main/java/com/foru/freebe/reservation/dto/FormRegisterRequest.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/FormRegisterRequest.java
@@ -1,8 +1,10 @@
 package com.foru.freebe.reservation.dto;
 
+import java.util.List;
 import java.util.Map;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -26,6 +28,10 @@ public class FormRegisterRequest {
     private Map<Integer, PreferredDate> preferredDates;
 
     private Map<Integer, PhotoOption> photoOptions;
+
+    @NotEmpty
+    @Size(min = 1)
+    private List<String> referenceImages;
 
     @Size(max = 300, message = "Memo cannot be longer than 300 characters")
     private String customerMemo;

--- a/src/main/java/com/foru/freebe/reservation/dto/FormRegisterRequest.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/FormRegisterRequest.java
@@ -34,7 +34,7 @@ public class FormRegisterRequest {
 
     @NotEmpty
     @Size(min = 1)
-    private List<String> referenceImages;
+    private List<String> existingImages;
 
     @Size(max = 300, message = "Memo cannot be longer than 300 characters")
     private String customerMemo;
@@ -48,3 +48,4 @@ public class FormRegisterRequest {
     @NotNull
     private Boolean photographerTermAgreement;
 }
+

--- a/src/main/java/com/foru/freebe/reservation/dto/FormRegisterRequest.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/FormRegisterRequest.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,6 +18,8 @@ public class FormRegisterRequest {
     private String profileName;
 
     @NotBlank(message = "Instagram ID must not be blank")
+    @Pattern(regexp = "^[a-z0-9_.]+$", message = "인스타그램 아이디 입력 형식이 틀렸습니다")
+    @Size(min = 3, max = 30, message = "인스타그램 아이디는 최소 3자 이상 최대 30자 이하여야합니다")
     private String instagramId;
 
     @NotBlank(message = "Product title must not be blank")

--- a/src/main/java/com/foru/freebe/reservation/entity/ReferenceImage.java
+++ b/src/main/java/com/foru/freebe/reservation/entity/ReferenceImage.java
@@ -1,5 +1,7 @@
 package com.foru.freebe.reservation.entity;
 
+import com.foru.freebe.common.entity.BaseEntity;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -16,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ReferenceImage {
+public class ReferenceImage extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "reference_image_id")

--- a/src/main/java/com/foru/freebe/s3/S3ImageService.java
+++ b/src/main/java/com/foru/freebe/s3/S3ImageService.java
@@ -100,7 +100,7 @@ public class S3ImageService {
 
         switch (s3ImageType) {
             case PROFILE -> size = 100;
-            case PRODUCT -> size = 200;
+            case PRODUCT, RESERVATION -> size = 200;
             default -> throw new RestApiException(CommonErrorCode.INTERNAL_SERVER_ERROR);
         }
 

--- a/src/main/java/com/foru/freebe/s3/S3ImageService.java
+++ b/src/main/java/com/foru/freebe/s3/S3ImageService.java
@@ -24,6 +24,7 @@ import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.foru.freebe.common.dto.ImageLinkSet;
+import com.foru.freebe.common.dto.SingleImageLink;
 import com.foru.freebe.errors.errorcode.AwsErrorCode;
 import com.foru.freebe.errors.errorcode.CommonErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
@@ -59,23 +60,54 @@ public class S3ImageService {
     @Value("${cloud.aws.s3.base-path.reservation}")
     private String reservationPath;
 
-    public ImageLinkSet imageUploadToS3(List<MultipartFile> images, S3ImageType s3ImageType, Long memberId) throws
-        IOException {
-
-        List<String> originUrl = uploadOriginalImages(images, s3ImageType, memberId);
-        return new ImageLinkSet(originUrl, null);
-    }
-
     public ImageLinkSet imageUploadToS3(List<MultipartFile> images, S3ImageType s3ImageType, Long memberId,
-        int thumbnailSize) throws IOException {
+        boolean createThumbnail) throws IOException {
 
-        List<String> originUrl = uploadOriginalImages(images, s3ImageType, memberId);
-        List<String> thumbnailUrl = uploadThumbnailImages(images, s3ImageType, memberId, thumbnailSize);
+        List<String> originUrls = new ArrayList<>();
+        List<String> thumbnailUrls = new ArrayList<>();
 
-        return new ImageLinkSet(originUrl, thumbnailUrl);
+        for (MultipartFile image : images) {
+            String originUrl = uploadOriginalImage(image, s3ImageType, memberId);
+            originUrls.add(originUrl);
+        }
+        if (createThumbnail) {
+            for (MultipartFile image : images) {
+                int thumbnailSize = determineThumbnailSize(s3ImageType);
+                String thumbnailUrl = uploadThumbnailImage(image, s3ImageType, memberId, thumbnailSize);
+                thumbnailUrls.add(thumbnailUrl);
+            }
+        }
+
+        return new ImageLinkSet(originUrls, thumbnailUrls);
     }
 
-    public String uploadOriginalImage(MultipartFile image, S3ImageType s3ImageType, Long memberId) throws IOException {
+    public SingleImageLink imageUploadToS3(MultipartFile image, S3ImageType s3ImageType, Long memberId,
+        Boolean createThumbnail) throws IOException {
+
+        String originUrl = uploadOriginalImage(image, s3ImageType, memberId);
+        String thumbnailUrl = null;
+
+        if (createThumbnail) {
+            int thumbnailSize = determineThumbnailSize(s3ImageType);
+            thumbnailUrl = uploadThumbnailImage(image, s3ImageType, memberId, thumbnailSize);
+        }
+
+        return new SingleImageLink(originUrl, thumbnailUrl);
+    }
+
+    private int determineThumbnailSize(S3ImageType s3ImageType) {
+        int size;
+
+        switch (s3ImageType) {
+            case PROFILE -> size = 100;
+            case PRODUCT -> size = 200;
+            default -> throw new RestApiException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+        }
+
+        return size;
+    }
+
+    private String uploadOriginalImage(MultipartFile image, S3ImageType s3ImageType, Long memberId) throws IOException {
         String originKey = generateImagePath(image, s3ImageType, memberId, true);
 
         ObjectMetadata metadata = new ObjectMetadata();
@@ -87,7 +119,7 @@ public class S3ImageService {
         return amazonS3.getUrl(bucketName, originKey).toString();
     }
 
-    public String uploadThumbnailImage(MultipartFile image, S3ImageType s3ImageType, Long memberId,
+    private String uploadThumbnailImage(MultipartFile image, S3ImageType s3ImageType, Long memberId,
         int thumbnailSize) throws IOException {
         String thumbnailKey = generateImagePath(image, s3ImageType, memberId, false);
         try (InputStream originalImageStream = image.getInputStream();
@@ -106,48 +138,7 @@ public class S3ImageService {
         }
     }
 
-    private List<String> uploadOriginalImages(List<MultipartFile> images, S3ImageType s3ImageType, Long memberId) throws
-        IOException {
-
-        List<String> originalImageUrls = new ArrayList<>();
-        for (MultipartFile image : images) {
-            String originKey = generateImagePath(image, s3ImageType, memberId, true);
-
-            ObjectMetadata metadata = new ObjectMetadata();
-            metadata.setContentLength(image.getSize());
-            metadata.setContentType(image.getContentType());
-
-            uploadToS3(originKey, image.getInputStream(), metadata);
-            addImageUrlFromS3(originKey, originalImageUrls);
-        }
-        return originalImageUrls;
-    }
-
-    private List<String> uploadThumbnailImages(List<MultipartFile> images, S3ImageType s3ImageType, Long memberId,
-        int thumbnailSize) throws IOException {
-
-        List<String> thumbnailImageUrls = new ArrayList<>();
-
-        for (MultipartFile image : images) {
-            String thumbnailKey = generateImagePath(image, s3ImageType, memberId, false);
-
-            try (InputStream originalImageStream = image.getInputStream();
-                 ByteArrayOutputStream thumbnailOutputStream = new ByteArrayOutputStream()) {
-
-                resizeForThumbnail(thumbnailSize, originalImageStream, thumbnailOutputStream);
-
-                InputStream thumbnailInputStream = new ByteArrayInputStream(thumbnailOutputStream.toByteArray());
-                ObjectMetadata thumbnailMetadata = createMetadataForThumbnail(image, thumbnailOutputStream);
-
-                uploadToS3(thumbnailKey, thumbnailInputStream, thumbnailMetadata);
-                addImageUrlFromS3(thumbnailKey, thumbnailImageUrls);
-            }
-        }
-
-        return thumbnailImageUrls;
-    }
-
-    private static ObjectMetadata createMetadataForThumbnail(MultipartFile image,
+    private ObjectMetadata createMetadataForThumbnail(MultipartFile image,
         ByteArrayOutputStream thumbnailOutputStream) {
         ObjectMetadata thumbnailMetadata = new ObjectMetadata();
         thumbnailMetadata.setContentType(image.getContentType());
@@ -155,7 +146,7 @@ public class S3ImageService {
         return thumbnailMetadata;
     }
 
-    private static void resizeForThumbnail(int thumbnailSize, InputStream originalImageStream,
+    private void resizeForThumbnail(int thumbnailSize, InputStream originalImageStream,
         ByteArrayOutputStream thumbnailOutputStream) throws IOException {
         Thumbnails.of(originalImageStream)
             .size(thumbnailSize, thumbnailSize)

--- a/src/test/java/com/foru/freebe/product/service/PhotographerProductServiceTest.java
+++ b/src/test/java/com/foru/freebe/product/service/PhotographerProductServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.foru.freebe.common.dto.SingleImageLink;
 import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.member.entity.Role;
 import com.foru.freebe.member.repository.MemberRepository;
@@ -99,6 +100,7 @@ class PhotographerProductServiceTest {
         // Mock MultipartFile
         MultipartFile image = mock(MultipartFile.class);
         List<MultipartFile> images = Arrays.asList(image);
+        SingleImageLink singleImageLink = new SingleImageLink("new_origin_url", "new_thumbnail_url");
 
         // Mock 행동 정의
         when(memberRepository.findById(photographerId)).thenReturn(Optional.of(photographer));
@@ -106,10 +108,8 @@ class PhotographerProductServiceTest {
         when(productImageRepository.findByProduct(product)).thenReturn(productImages);
         when(productImageRepository.findByThumbnailUrl("existing_thumbnail_url_1"))
             .thenReturn(Optional.of(productImage1));
-        when(s3ImageService.uploadOriginalImage(any(MultipartFile.class), any(S3ImageType.class), anyLong()))
-            .thenReturn("new_origin_url");
-        when(s3ImageService.uploadThumbnailImage(any(MultipartFile.class), any(S3ImageType.class), anyLong(), anyInt()))
-            .thenReturn("new_thumbnail_url");
+        when(s3ImageService.imageUploadToS3(any(MultipartFile.class), any(S3ImageType.class), anyLong(), true))
+            .thenReturn(singleImageLink);
 
         // 서비스 메서드 실행
         photographerProductService.updateProductDetail(images, request, photographerId);

--- a/src/test/java/com/foru/freebe/profile/service/ProfileServiceTest.java
+++ b/src/test/java/com/foru/freebe/profile/service/ProfileServiceTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -19,9 +18,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.web.multipart.MultipartFile;
 
-import com.foru.freebe.common.dto.ImageLinkSet;
+import com.foru.freebe.common.dto.SingleImageLink;
 import com.foru.freebe.errors.errorcode.ProfileErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
 import com.foru.freebe.member.entity.Member;
@@ -181,17 +179,14 @@ class ProfileServiceTest {
             MockMultipartFile bannerImageFile = createMockMultipartFile("banner");
             MockMultipartFile profileImageFile = createMockMultipartFile("profile");
 
-            ImageLinkSet bannerImageLinkSet = new ImageLinkSet(Collections.singletonList("originUrl"), null);
-            List<MultipartFile> bannerImageFiles = Collections.singletonList(bannerImageFile);
+            SingleImageLink bannerImageLinkSet = new SingleImageLink("originUrl", null);
             when(
-                s3ImageService.imageUploadToS3(bannerImageFiles, S3ImageType.PROFILE, photographer.getId())).thenReturn(
-                bannerImageLinkSet);
+                s3ImageService.imageUploadToS3(bannerImageFile, S3ImageType.PROFILE, photographer.getId(),
+                    false)).thenReturn(bannerImageLinkSet);
 
-            ImageLinkSet profileImageLinkSet = new ImageLinkSet(Collections.singletonList("originUrl"),
-                Collections.singletonList("thumbnailUrl"));
-            List<MultipartFile> profileImageFiles = Collections.singletonList(profileImageFile);
-            when(s3ImageService.imageUploadToS3(profileImageFiles, S3ImageType.PROFILE, photographer.getId(),
-                100)).thenReturn(profileImageLinkSet);
+            SingleImageLink profileImageLinkSet = new SingleImageLink("originUrl", "thumbnailUrl");
+            when(s3ImageService.imageUploadToS3(profileImageFile, S3ImageType.PROFILE, photographer.getId(),
+                false)).thenReturn(profileImageLinkSet);
 
             // when
             profileService.updateProfile(photographer, request, bannerImageFile, profileImageFile);
@@ -230,17 +225,13 @@ class ProfileServiceTest {
             MockMultipartFile bannerImageFile = createMockMultipartFile("banner");
             MockMultipartFile profileImageFile = createMockMultipartFile("profile");
 
-            ImageLinkSet bannerImageLinkSet = new ImageLinkSet(Collections.singletonList("newBannerOriginUrl"), null);
-            List<MultipartFile> bannerImageFiles = Collections.singletonList(bannerImageFile);
-            when(
-                s3ImageService.imageUploadToS3(bannerImageFiles, S3ImageType.PROFILE, photographer.getId())).thenReturn(
-                bannerImageLinkSet);
+            SingleImageLink bannerImageLinkSet = new SingleImageLink("newBannerOriginUrl", null);
+            when(s3ImageService.imageUploadToS3(bannerImageFile, S3ImageType.PROFILE, photographer.getId(),
+                false)).thenReturn(bannerImageLinkSet);
 
-            ImageLinkSet profileImageLinkSet = new ImageLinkSet(Collections.singletonList("newProfileOriginUrl"),
-                Collections.singletonList("newProfileThumbnailUrl"));
-            List<MultipartFile> profileImageFiles = Collections.singletonList(profileImageFile);
-            when(s3ImageService.imageUploadToS3(profileImageFiles, S3ImageType.PROFILE, photographer.getId(),
-                100)).thenReturn(profileImageLinkSet);
+            SingleImageLink profileImageLinkSet = new SingleImageLink("newProfileOriginUrl", "newProfileThumbnailUrl");
+            when(s3ImageService.imageUploadToS3(profileImageFile, S3ImageType.PROFILE, photographer.getId(),
+                true)).thenReturn(profileImageLinkSet);
 
             // when
             profileService.updateProfile(photographer, request, bannerImageFile, profileImageFile);


### PR DESCRIPTION
## 체크리스트

- [ ] 불필요한 주석 처리가 없는가?

## 작업 내역
- 레퍼런스 이미지 등록 시 Multipart File과 Existing url을 모두 처리할 수 있도록 로직을 수정했습니다.
- 배너 이미지가 삭제되지 않는 문제를 해결했습니다.
- (유저 권한 부여에 대해서는 내일 작업해서 PR 올라갈 예정입니다!)

## 고민한 사항
- 리팩터링은 내일 새 티켓에서.. ㅜㅜ

## 리뷰 요청사항
