### PR TITLE
[FU-270] 베타버전 출시 전 비즈니스 로직 개선

### DIFF
--- a/.github/workflows/cd_workflow_dev.yml
+++ b/.github/workflows/cd_workflow_dev.yml
@@ -43,6 +43,7 @@ jobs:
           echo "AWS_S3_CUSTOMER_PATH=${{ secrets.AWS_S3_CUSTOMER_PATH }}" >> .env
           echo "AWS_S3_PRODUCT_PATH=${{ secrets.AWS_S3_PRODUCT_PATH }}" >> .env
           echo "AWS_S3_PROFILE_PATH=${{ secrets.AWS_S3_PROFILE_PATH }}" >> .env
+          echo "AWS_S3_BANNER_PATH=${{ secrets.AWS_S3_BANNER_PATH }}" >> .env
           echo "AWS_S3_RESERVATION_PATH=${{ secrets.AWS_S3_RESERVATION_PATH }}" >> .env
           echo "AWS_CODE_DEPLOY_APPLICATION=${{ secrets.AWS_CODE_DEPLOY_APPLICATION }}" >> .env
           echo "AWS_CODE_DEPLOY_GROUP=${{ secrets.AWS_CODE_DEPLOY_GROUP }}" >> .env

--- a/src/main/java/com/foru/freebe/auth/service/KakaoLoginService.java
+++ b/src/main/java/com/foru/freebe/auth/service/KakaoLoginService.java
@@ -53,7 +53,8 @@ public class KakaoLoginService {
 
     private LoginResponse.LoginResponseBuilder validateRoleType(LoginResponse.LoginResponseBuilder builder,
         Member member, Role requestedRole) {
-        if (member.getRole() == requestedRole) {
+        if (member.getRole() == requestedRole ||
+            member.getRole() == Role.PHOTOGRAPHER_PENDING && requestedRole.equals(Role.PHOTOGRAPHER)) {
             return handleSameRoleLogin(builder, member);
         } else {
             return handleRoleChange(builder, member, requestedRole);

--- a/src/main/java/com/foru/freebe/config/SecurityConfig.java
+++ b/src/main/java/com/foru/freebe/config/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
                 .requestMatchers("/photographer/**").hasAnyRole("PHOTOGRAPHER")
                 .requestMatchers("/customer/product/**").permitAll()
                 .requestMatchers("/customer/profile/**").permitAll()
-                .requestMatchers("/customer/**").hasAnyRole("CUSTOMER")
+                .requestMatchers("/customer/**").hasAnyRole("CUSTOMER", "PHOTOGRAPHER")
                 .requestMatchers("/admin/**").hasAnyRole("ADMIN")
                 .anyRequest().permitAll())
 

--- a/src/main/java/com/foru/freebe/errors/errorcode/AwsErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/AwsErrorCode.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum AwsErrorCode implements ErrorCode {
     AMAZON_S3_EXCEPTION(404, "Amazon S3 exception"),
-    AMAZON_SERVICE_EXCEPTION(500, "Amazon service exception");
+    AMAZON_SERVICE_EXCEPTION(500, "Amazon service exception"),
+    DELETE_OBJECT_EXCEPTION(500, "Failed to delete image to S3 due to an internal error");
 
     private final int httpStatus;
     private final String message;

--- a/src/main/java/com/foru/freebe/errors/errorcode/CommonErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/CommonErrorCode.java
@@ -12,8 +12,7 @@ public enum CommonErrorCode implements ErrorCode {
     RESOURCE_NOT_FOUND(404, "Resource not exists"),
     INTERNAL_SERVER_ERROR(500, "Internal server error"),
     IO_EXCEPTION(500, "IoException occurred"),
-    DUPLICATED_RESOURCE(500, "Duplicated resource"),
-    ;
+    DUPLICATED_RESOURCE(500, "Duplicated resource");
 
     private final int httpStatus;
     private final String message;

--- a/src/main/java/com/foru/freebe/errors/errorcode/MemberErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/MemberErrorCode.java
@@ -1,0 +1,13 @@
+package com.foru.freebe.errors.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberErrorCode implements ErrorCode {
+    INVALID_LOGIN_REQUEST(400, "Invalid login request");
+
+    private final int httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/foru/freebe/errors/errorcode/MemberErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/MemberErrorCode.java
@@ -6,7 +6,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum MemberErrorCode implements ErrorCode {
-    INVALID_LOGIN_REQUEST(400, "Invalid login request");
+    INVALID_LOGIN_REQUEST(400, "Invalid login request"),
+    MEMBER_NOT_FOUND(404, "Member not found");
 
     private final int httpStatus;
     private final String message;

--- a/src/main/java/com/foru/freebe/errors/errorcode/ProductErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/ProductErrorCode.java
@@ -9,7 +9,9 @@ public enum ProductErrorCode implements ErrorCode {
     INVALID_ACTIVE_STATUS(400, "ActiveStatus must be different current stored ActiveStatus"),
     PRODUCT_INACTIVE_STATUS(400, "The product is currently inactive, so you can't register a booking form with it"),
     PRODUCT_ALREADY_EXISTS(400, "The product already exists, so it cannot be registered again"),
-    INVALID_FILE_NAME(400, "The url or filename in the json file is incorrect");
+    COMPONENT_TITLE_ALREADY_EXISTS(400, "Component title already exists, so it cannot be registered again"),
+    INVALID_FILE_NAME(400, "The url or filename in the json file is incorrect"),
+    PRODUCT_NOT_FOUND(404, "The product could not be found");
 
     private final int httpStatus;
     private final String message;

--- a/src/main/java/com/foru/freebe/errors/errorcode/ProductImageErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/ProductImageErrorCode.java
@@ -5,9 +5,8 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum ImageErrorCode implements ErrorCode {
-
-    PUT_OBJECT_EXCEPTION(500, "Failed to upload image to S3 due to an internal error");
+public enum ProductImageErrorCode implements ErrorCode {
+    PRODUCT_IMAGE_NOT_FOUND(404, "The product image could not be found");
 
     private final int httpStatus;
     private final String message;

--- a/src/main/java/com/foru/freebe/errors/errorcode/ProfileErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/ProfileErrorCode.java
@@ -6,7 +6,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ProfileErrorCode implements ErrorCode {
-    PROFILE_NAME_ALREADY_EXISTS(400, "이미 존재하는 프로필명입니다.");
+    PROFILE_NAME_ALREADY_EXISTS(400, "이미 존재하는 프로필명입니다."),
+    PROFILE_NAME_NOT_FOUND(404, "존재하지 않는 프로필명입니다."),
+    MEMBER_NOT_FOUND(404, "존재하지 않는 회원입니다.");
 
     private final int httpStatus;
     private final String message;

--- a/src/main/java/com/foru/freebe/product/controller/PhotographerProductController.java
+++ b/src/main/java/com/foru/freebe/product/controller/PhotographerProductController.java
@@ -87,12 +87,11 @@ public class PhotographerProductController {
     }
 
     @GetMapping("/product/{productId}")
-    public ResponseEntity<ResponseBody<ProductDetailResponse>> getProductById(
-        @PathVariable("productId") Long productId,
-        @AuthenticationPrincipal MemberAdapter memberAdapter) {
+    public ResponseEntity<ResponseBody<ProductDetailResponse>> getProductDetails(
+        @PathVariable("productId") Long productId, @AuthenticationPrincipal MemberAdapter memberAdapter) {
 
         Member photographer = memberAdapter.getMember();
-        ProductDetailResponse responseData = photographerProductService.getRegisteredProductInfo(productId,
+        ProductDetailResponse responseData = photographerProductService.getRegisteredProductDetails(productId,
             photographer.getId());
 
         ResponseBody<ProductDetailResponse> responseBody = ResponseBody.<ProductDetailResponse>builder()

--- a/src/main/java/com/foru/freebe/product/dto/customer/ProductDetailResponse.java
+++ b/src/main/java/com/foru/freebe/product/dto/customer/ProductDetailResponse.java
@@ -21,6 +21,9 @@ public class ProductDetailResponse {
     private String productDescription;
 
     @NotNull
+    private Long basicPrice;
+
+    @NotNull
     private List<String> productImageUrls;
 
     @NotNull
@@ -31,11 +34,12 @@ public class ProductDetailResponse {
     private List<ProductDiscountDto> productDiscounts;
 
     @Builder
-    public ProductDetailResponse(String productTitle, String productDescription, List<String> productImageUrls,
-        List<ProductComponentDto> productComponents, List<ProductOptionDto> productOptions,
-        List<ProductDiscountDto> productDiscounts) {
+    public ProductDetailResponse(String productTitle, String productDescription, Long basicPrice,
+        List<String> productImageUrls, List<ProductComponentDto> productComponents,
+        List<ProductOptionDto> productOptions, List<ProductDiscountDto> productDiscounts) {
         this.productTitle = productTitle;
         this.productDescription = productDescription;
+        this.basicPrice = basicPrice;
         this.productImageUrls = productImageUrls;
         this.productComponents = productComponents;
         this.productOptions = productOptions;

--- a/src/main/java/com/foru/freebe/product/dto/customer/ProductListResponse.java
+++ b/src/main/java/com/foru/freebe/product/dto/customer/ProductListResponse.java
@@ -15,13 +15,18 @@ public class ProductListResponse {
     @NotBlank
     private String productTitle;
 
+    @NotNull
+    private Long basicPrice;
+
     @NotBlank
     private String productRepresentativeImageUrl;
 
     @Builder
-    public ProductListResponse(Long productId, String productTitle, String productRepresentativeImageUrl) {
+    public ProductListResponse(Long productId, String productTitle, Long basicPrice,
+        String productRepresentativeImageUrl) {
         this.productId = productId;
         this.productTitle = productTitle;
+        this.basicPrice = basicPrice;
         this.productRepresentativeImageUrl = productRepresentativeImageUrl;
     }
 }

--- a/src/main/java/com/foru/freebe/product/dto/photographer/ProductRegisterRequest.java
+++ b/src/main/java/com/foru/freebe/product/dto/photographer/ProductRegisterRequest.java
@@ -3,6 +3,7 @@ package com.foru.freebe.product.dto.photographer;
 import java.util.List;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,7 +18,7 @@ public class ProductRegisterRequest {
     @Size(max = 100, message = "Description cannot be longer than 100 characters")
     private String productDescription;
 
-    // @NotNull
+    @NotNull(message = "Product components must not be null")
     private List<ProductComponentDto> productComponents;
 
     private List<ProductOptionDto> productOptions;

--- a/src/main/java/com/foru/freebe/product/dto/photographer/ProductRegisterRequest.java
+++ b/src/main/java/com/foru/freebe/product/dto/photographer/ProductRegisterRequest.java
@@ -18,6 +18,9 @@ public class ProductRegisterRequest {
     @Size(max = 100, message = "Description cannot be longer than 100 characters")
     private String productDescription;
 
+    @NotNull(message = "Basic price must not be null")
+    private Long basicPrice;
+
     @NotNull(message = "Product components must not be null")
     private List<ProductComponentDto> productComponents;
 

--- a/src/main/java/com/foru/freebe/product/dto/photographer/RegisteredProductResponse.java
+++ b/src/main/java/com/foru/freebe/product/dto/photographer/RegisteredProductResponse.java
@@ -18,6 +18,9 @@ public class RegisteredProductResponse {
     @NotBlank
     private String productTitle;
 
+    @NotBlank(message = "Representative image must not be blank")
+    private String representativeImage;
+
     @PositiveOrZero
     private Integer reservationCount;
 
@@ -26,10 +29,11 @@ public class RegisteredProductResponse {
     //TODO 추후 상품 대표 사진에 대한 로직 처리와 함께 대표사진 경로에 대한 필드 추가
 
     @Builder
-    public RegisteredProductResponse(Long productId, String productTitle, Integer reservationCount,
-        ActiveStatus activeStatus) {
+    public RegisteredProductResponse(Long productId, String productTitle, String representativeImage,
+        Integer reservationCount, ActiveStatus activeStatus) {
         this.productId = productId;
         this.productTitle = productTitle;
+        this.representativeImage = representativeImage;
         this.reservationCount = reservationCount;
         this.activeStatus = activeStatus;
     }

--- a/src/main/java/com/foru/freebe/product/dto/photographer/UpdateProductDetailRequest.java
+++ b/src/main/java/com/foru/freebe/product/dto/photographer/UpdateProductDetailRequest.java
@@ -25,6 +25,9 @@ public class UpdateProductDetailRequest {
     @Size(max = 100, message = "Description cannot be longer than 100 characters")
     private String productDescription;
 
+    @NotNull(message = "Basic price must not be null")
+    private Long basicPrice;
+
     @NotNull
     private List<ProductComponentDto> productComponents;
 
@@ -34,12 +37,14 @@ public class UpdateProductDetailRequest {
 
     @Builder
     public UpdateProductDetailRequest(Long productId, List<String> existingUrls, String productTitle,
-        String productDescription, List<ProductComponentDto> productComponents, List<ProductOptionDto> productOptions,
+        String productDescription, Long basicPrice, List<ProductComponentDto> productComponents,
+        List<ProductOptionDto> productOptions,
         List<ProductDiscountDto> productDiscounts) {
         this.productId = productId;
         this.existingUrls = existingUrls;
         this.productTitle = productTitle;
         this.productDescription = productDescription;
+        this.basicPrice = basicPrice;
         this.productComponents = productComponents;
         this.productOptions = productOptions;
         this.productDiscounts = productDiscounts;

--- a/src/main/java/com/foru/freebe/product/entity/Product.java
+++ b/src/main/java/com/foru/freebe/product/entity/Product.java
@@ -15,6 +15,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -38,23 +39,27 @@ public class Product extends BaseEntity {
     @NotNull
     private ActiveStatus activeStatus;
 
+    @NotBlank
+    private Long basicPrice;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    public Product(String title, String description, ActiveStatus activeStatus, Member member) {
+    public Product(String title, String description, ActiveStatus activeStatus, Long basicPrice, Member member) {
         this.title = title;
         this.description = description;
         this.activeStatus = activeStatus;
+        this.basicPrice = basicPrice;
         this.member = member;
     }
 
-    public static Product createProductAsActive(String title, String description, Member member) {
-        return new Product(title, description, ActiveStatus.ACTIVE, member);
+    public static Product createProductAsActive(String title, String description, Long basicPrice, Member member) {
+        return new Product(title, description, ActiveStatus.ACTIVE, basicPrice, member);
     }
 
-    public static Product createProductAsActiveWithoutDescription(String title, Member member) {
-        return new Product(title, null, ActiveStatus.ACTIVE, member);
+    public static Product createProductAsActiveWithoutDescription(String title, Long basicPrice, Member member) {
+        return new Product(title, null, ActiveStatus.ACTIVE, basicPrice, member);
     }
 
     public void updateProductActiveStatus(ActiveStatus newStatus) {
@@ -70,5 +75,9 @@ public class Product extends BaseEntity {
 
     public void assignDescription(String newDescription) {
         this.description = newDescription;
+    }
+
+    public void assignBasicPrice(Long basicPrice) {
+        this.basicPrice = basicPrice;
     }
 }

--- a/src/main/java/com/foru/freebe/product/entity/Product.java
+++ b/src/main/java/com/foru/freebe/product/entity/Product.java
@@ -15,7 +15,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -39,7 +38,7 @@ public class Product extends BaseEntity {
     @NotNull
     private ActiveStatus activeStatus;
 
-    @NotBlank
+    @NotNull
     private Long basicPrice;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/foru/freebe/product/entity/ProductImage.java
+++ b/src/main/java/com/foru/freebe/product/entity/ProductImage.java
@@ -46,10 +46,10 @@ public class ProductImage extends BaseEntity {
         return new ProductImage(imageOrder, originUrl, thumbnailUrl, product);
     }
 
-    private ProductImage(int imageOrder, String thumbnailUrl, String originUrl, Product product) {
+    private ProductImage(int imageOrder, String originUrl, String thumbnailUrl, Product product) {
         this.imageOrder = imageOrder;
-        this.thumbnailUrl = thumbnailUrl;
         this.originUrl = originUrl;
+        this.thumbnailUrl = thumbnailUrl;
         this.product = product;
     }
 }

--- a/src/main/java/com/foru/freebe/product/entity/ProductImage.java
+++ b/src/main/java/com/foru/freebe/product/entity/ProductImage.java
@@ -25,6 +25,9 @@ public class ProductImage extends BaseEntity {
     private Long id;
 
     @NotNull
+    private int imageOrder;
+
+    @NotNull
     private String thumbnailUrl;
 
     @NotNull
@@ -34,14 +37,19 @@ public class ProductImage extends BaseEntity {
     @JoinColumn(name = "product_id")
     private Product product;
 
-    public static ProductImage createProductImage(String thumbnailUrl, String originUrl, Product product) {
-        return new ProductImage(thumbnailUrl, originUrl, product);
+    public void updateImageOrder(int imageOrder) {
+        this.imageOrder = imageOrder;
     }
 
-    private ProductImage(String thumbnailUrl, String originUrl, Product product) {
+    public static ProductImage createProductImage(int imageOrder, String originUrl, String thumbnailUrl,
+        Product product) {
+        return new ProductImage(imageOrder, originUrl, thumbnailUrl, product);
+    }
+
+    private ProductImage(int imageOrder, String thumbnailUrl, String originUrl, Product product) {
+        this.imageOrder = imageOrder;
         this.thumbnailUrl = thumbnailUrl;
         this.originUrl = originUrl;
         this.product = product;
     }
-
 }

--- a/src/main/java/com/foru/freebe/product/service/CustomerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/CustomerProductService.java
@@ -51,7 +51,6 @@ public class CustomerProductService {
             .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
 
         Member photographer = photographerProfile.getMember();
-
         List<Product> products = productRepository.findByMemberAndActiveStatus(photographer, ActiveStatus.ACTIVE);
 
         List<ProductListResponse> productListResponseList = new ArrayList<>();
@@ -61,6 +60,7 @@ public class CustomerProductService {
             ProductListResponse productListResponse = ProductListResponse.builder()
                 .productId(product.getId())
                 .productTitle(product.getTitle())
+                .basicPrice(product.getBasicPrice())
                 .productRepresentativeImageUrl(productImage.get(0).getThumbnailUrl())
                 .build();
 

--- a/src/main/java/com/foru/freebe/product/service/CustomerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/CustomerProductService.java
@@ -43,7 +43,7 @@ public class CustomerProductService {
         Product product = productRepository.findById(productId)
             .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
 
-        return productDetailConvertor.convertProductToProductDetailResponse(product);
+        return productDetailConvertor.convertProductToProductDetailResponse(product, true);
     }
 
     public List<ProductListResponse> getProductList(String profileName) {

--- a/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
@@ -334,7 +334,6 @@ public class PhotographerProductService {
                 .description(productComponentDto.getDescription())
                 .product(product)
                 .build();
-
             productComponentRepository.save(productComponent);
         }
     }

--- a/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
@@ -59,20 +59,20 @@ public class PhotographerProductService {
     private final S3ImageService s3ImageService;
 
     @Transactional
-    public void registerProduct(ProductRegisterRequest productRegisterRequestDto,
-        List<MultipartFile> images, Long photographerId) throws IOException {
+    public void registerProduct(ProductRegisterRequest request, List<MultipartFile> images, Long photographerId) throws
+        IOException {
         Member photographer = getMember(photographerId);
 
-        Product productAsActive = registerActiveProduct(productRegisterRequestDto, photographer);
+        Product productAsActive = registerActiveProduct(request, photographer);
         registerProductImage(images, productAsActive, photographerId);
-        registerProductComponent(productRegisterRequestDto.getProductComponents(), productAsActive);
+        registerProductComponent(request.getProductComponents(), productAsActive);
 
-        if (productRegisterRequestDto.getProductOptions() != null) {
-            registerProductOption(productRegisterRequestDto.getProductOptions(), productAsActive);
+        if (request.getProductOptions() != null) {
+            registerProductOption(request.getProductOptions(), productAsActive);
         }
 
-        if (productRegisterRequestDto.getProductDiscounts() != null) {
-            registerDiscount(productRegisterRequestDto.getProductDiscounts(), productAsActive);
+        if (request.getProductDiscounts() != null) {
+            registerDiscount(request.getProductDiscounts(), productAsActive);
         }
     }
 
@@ -89,7 +89,7 @@ public class PhotographerProductService {
             .collect(Collectors.toList());
     }
 
-    public ProductDetailResponse getRegisteredProductInfo(Long productId, Long photographerId) {
+    public ProductDetailResponse getRegisteredProductDetails(Long productId, Long photographerId) {
         Member photographer = getMember(photographerId);
 
         Product product = productRepository.findByIdAndMember(productId, photographer)
@@ -119,6 +119,7 @@ public class PhotographerProductService {
 
         product.assignTitle(updateProductDetailRequest.getProductTitle());
         product.assignDescription(updateProductDetailRequest.getProductDescription());
+        product.assignBasicPrice(updateProductDetailRequest.getBasicPrice());
 
         List<ProductImage> productImages = productImageRepository.findByProduct(product);
         deleteSelectedImageByUser(updateProductDetailRequest, productImages);
@@ -274,15 +275,16 @@ public class PhotographerProductService {
             .count();
     }
 
-    private Product registerActiveProduct(ProductRegisterRequest productRegisterRequestDto, Member photographer) {
-        String productTitle = productRegisterRequestDto.getProductTitle();
-        String productDescription = productRegisterRequestDto.getProductDescription();
+    private Product registerActiveProduct(ProductRegisterRequest request, Member photographer) {
+        String productTitle = request.getProductTitle();
+        String productDescription = request.getProductDescription();
+        Long basicPrice = request.getBasicPrice();
 
         Product productAsActive;
         if (isExistingImage(productDescription)) {
-            productAsActive = Product.createProductAsActive(productTitle, productDescription, photographer);
+            productAsActive = Product.createProductAsActive(productTitle, productDescription, basicPrice, photographer);
         } else {
-            productAsActive = Product.createProductAsActiveWithoutDescription(productTitle, photographer);
+            productAsActive = Product.createProductAsActiveWithoutDescription(productTitle, basicPrice, photographer);
         }
 
         validateProductTitleBeforeRegister(productTitle, photographer);

--- a/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
@@ -1,6 +1,7 @@
 package com.foru.freebe.product.service;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -322,6 +323,8 @@ public class PhotographerProductService {
     }
 
     private void registerProductComponent(List<ProductComponentDto> productComponentDtoList, Product product) {
+        validateUniqueProductComponentTitle(productComponentDtoList);
+
         for (ProductComponentDto productComponentDto : productComponentDtoList) {
             ProductComponent productComponent = ProductComponent.builder()
                 .title(productComponentDto.getTitle())
@@ -330,6 +333,22 @@ public class PhotographerProductService {
                 .product(product)
                 .build();
             productComponentRepository.save(productComponent);
+        }
+    }
+
+    private void validateUniqueProductComponentTitle(List<ProductComponentDto> productComponentDtoList) {
+        List<String> componentTitle = productComponentDtoList
+            .stream()
+            .map(ProductComponentDto::getTitle)
+            .toList();
+
+        HashMap<String, Boolean> titleMap = new HashMap<>();
+        for (String title : componentTitle) {
+            if (!titleMap.containsKey(title)) {
+                titleMap.put(title, true);
+            } else {
+                throw new RestApiException(ProductErrorCode.COMPONENT_TITLE_ALREADY_EXISTS);
+            }
         }
     }
 

--- a/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
@@ -80,6 +80,7 @@ public class PhotographerProductService {
             .map(product -> RegisteredProductResponse.builder()
                 .productId(product.getId())
                 .productTitle(product.getTitle())
+                .representativeImage(getRepresentativeProductImage(product))
                 .reservationCount(getReservationCount(member.getId(), product.getTitle()))
                 .activeStatus(product.getActiveStatus())
                 .build())
@@ -355,5 +356,15 @@ public class PhotographerProductService {
                 .build();
             productDiscountRepository.save(productDiscount);
         }
+    }
+
+    private String getRepresentativeProductImage(Product product) {
+        List<ProductImage> productImage = productImageRepository.findByProduct(product);
+
+        return productImage.stream()
+            .filter(image -> image.getImageOrder() == 0)
+            .map(ProductImage::getThumbnailUrl)
+            .findFirst()
+            .orElseThrow(() -> new RestApiException(ProductImageErrorCode.PRODUCT_IMAGE_NOT_FOUND));
     }
 }

--- a/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
@@ -93,7 +93,7 @@ public class PhotographerProductService {
         Product product = productRepository.findByIdAndMember(productId, photographer)
             .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
 
-        return productDetailConvertor.convertProductToProductDetailResponse(product);
+        return productDetailConvertor.convertProductToProductDetailResponse(product, false);
     }
 
     @Transactional

--- a/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
@@ -11,6 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.foru.freebe.common.dto.ImageLinkSet;
 import com.foru.freebe.common.dto.SingleImageLink;
 import com.foru.freebe.errors.errorcode.CommonErrorCode;
+import com.foru.freebe.errors.errorcode.MemberErrorCode;
 import com.foru.freebe.errors.errorcode.ProductErrorCode;
 import com.foru.freebe.errors.errorcode.ProductImageErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
@@ -91,7 +92,7 @@ public class PhotographerProductService {
         Member photographer = getMember(photographerId);
 
         Product product = productRepository.findByIdAndMember(productId, photographer)
-            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+            .orElseThrow(() -> new RestApiException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
         return productDetailConvertor.convertProductToProductDetailResponse(product, false);
     }
@@ -99,7 +100,7 @@ public class PhotographerProductService {
     @Transactional
     public void updateProductActiveStatus(UpdateProductRequest requestDto) {
         Product product = productRepository.findById(requestDto.getProductId())
-            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+            .orElseThrow(() -> new RestApiException(ProductErrorCode.PRODUCT_NOT_FOUND));
         product.updateProductActiveStatus(requestDto.getActiveStatus());
     }
 
@@ -109,7 +110,7 @@ public class PhotographerProductService {
         Member photographer = getMember(photographerId);
 
         Product product = productRepository.findByIdAndMember(updateProductDetailRequest.getProductId(), photographer)
-            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+            .orElseThrow(() -> new RestApiException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
         if (!Objects.equals(updateProductDetailRequest.getProductTitle(), product.getTitle())) {
             validateProductTitleBeforeRegister(updateProductDetailRequest.getProductTitle(), photographer);
@@ -291,7 +292,7 @@ public class PhotographerProductService {
 
     private Member getMember(Long memberId) {
         return memberRepository.findById(memberId)
-            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+            .orElseThrow(() -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 
     private void registerProductImage(List<MultipartFile> images, Product product, Long photographerId) throws
@@ -316,7 +317,7 @@ public class PhotographerProductService {
 
     private void validateProductImage(List<MultipartFile> images) {
         if (images.isEmpty()) {
-            throw new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND);
+            throw new RestApiException(CommonErrorCode.INVALID_PARAMETER);
         }
     }
 

--- a/src/main/java/com/foru/freebe/product/service/ProductDetailConvertor.java
+++ b/src/main/java/com/foru/freebe/product/service/ProductDetailConvertor.java
@@ -30,8 +30,8 @@ public class ProductDetailConvertor {
     private final ProductOptionRepository productOptionRepository;
     private final ProductDiscountRepository productDiscountRepository;
 
-    public ProductDetailResponse convertProductToProductDetailResponse(Product product) {
-        List<String> productImageUrls = getProductImageUrls(product);
+    public ProductDetailResponse convertProductToProductDetailResponse(Product product, Boolean isOrigin) {
+        List<String> productImageUrls = getProductImageUrls(product, isOrigin);
         List<ProductComponentDto> productComponents = convertToProductComponentDtoList(product);
         List<ProductOptionDto> productOptions = convertToProductOptionDtoList(product);
         List<ProductDiscountDto> productDiscounts = convertToProductDiscountDtoList(product);
@@ -90,11 +90,18 @@ public class ProductDetailConvertor {
         return productComponentResponse;
     }
 
-    private List<String> getProductImageUrls(Product product) {
+    private List<String> getProductImageUrls(Product product, Boolean isOrigin) {
         List<ProductImage> productImages = productImageRepository.findByProduct(product);
         List<String> productImageUrls = new ArrayList<>();
-        for (ProductImage productImage : productImages) {
-            productImageUrls.add(productImage.getThumbnailUrl());
+
+        if (isOrigin) {
+            for (ProductImage productImage : productImages) {
+                productImageUrls.add(productImage.getOriginUrl());
+            }
+        } else {
+            for (ProductImage productImage : productImages) {
+                productImageUrls.add(productImage.getThumbnailUrl());
+            }
         }
         return productImageUrls;
     }

--- a/src/main/java/com/foru/freebe/product/service/ProductDetailConvertor.java
+++ b/src/main/java/com/foru/freebe/product/service/ProductDetailConvertor.java
@@ -1,6 +1,7 @@
 package com.foru.freebe.product.service;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -91,9 +92,12 @@ public class ProductDetailConvertor {
     }
 
     private List<String> getProductImageUrls(Product product, Boolean isOrigin) {
-        List<ProductImage> productImages = productImageRepository.findByProduct(product);
-        List<String> productImageUrls = new ArrayList<>();
+        List<ProductImage> productImages = productImageRepository.findByProduct(product)
+            .stream()
+            .sorted(Comparator.comparing(ProductImage::getImageOrder))
+            .toList();
 
+        List<String> productImageUrls = new ArrayList<>();
         if (isOrigin) {
             for (ProductImage productImage : productImages) {
                 productImageUrls.add(productImage.getOriginUrl());

--- a/src/main/java/com/foru/freebe/product/service/ProductDetailConvertor.java
+++ b/src/main/java/com/foru/freebe/product/service/ProductDetailConvertor.java
@@ -39,6 +39,7 @@ public class ProductDetailConvertor {
         return ProductDetailResponse.builder()
             .productTitle(product.getTitle())
             .productDescription(product.getDescription())
+            .basicPrice(product.getBasicPrice())
             .productImageUrls(productImageUrls)
             .productComponents(productComponents)
             .productOptions(productOptions)

--- a/src/main/java/com/foru/freebe/product/service/ProductDetailConvertor.java
+++ b/src/main/java/com/foru/freebe/product/service/ProductDetailConvertor.java
@@ -93,7 +93,7 @@ public class ProductDetailConvertor {
         List<ProductImage> productImages = productImageRepository.findByProduct(product);
         List<String> productImageUrls = new ArrayList<>();
         for (ProductImage productImage : productImages) {
-            productImageUrls.add(productImage.getOriginUrl());
+            productImageUrls.add(productImage.getThumbnailUrl());
         }
         return productImageUrls;
     }

--- a/src/main/java/com/foru/freebe/profile/Controller/CustomerProfileController.java
+++ b/src/main/java/com/foru/freebe/profile/Controller/CustomerProfileController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.foru.freebe.common.dto.ResponseBody;
 import com.foru.freebe.profile.dto.ProfileResponse;
-import com.foru.freebe.profile.service.ProfileService;
+import com.foru.freebe.profile.service.CustomerProfileService;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -18,13 +18,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/customer")
 public class CustomerProfileController {
-    private final ProfileService profileService;
+    private final CustomerProfileService customerProfileService;
 
     @GetMapping("/profile/{profileName}")
     public ResponseEntity<ResponseBody<ProfileResponse>> getPhotographerProfile(
         @Valid @PathVariable("profileName") String profileName) {
 
-        ProfileResponse responseData = profileService.getPhotographerProfile(profileName);
+        ProfileResponse responseData = customerProfileService.getPhotographerProfile(profileName);
 
         ResponseBody<ProfileResponse> responseBody = ResponseBody.<ProfileResponse>builder()
             .message("Good Response")

--- a/src/main/java/com/foru/freebe/profile/Controller/PhotographerProfileController.java
+++ b/src/main/java/com/foru/freebe/profile/Controller/PhotographerProfileController.java
@@ -17,7 +17,7 @@ import com.foru.freebe.common.dto.ResponseBody;
 import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.profile.dto.ProfileResponse;
 import com.foru.freebe.profile.dto.UpdateProfileRequest;
-import com.foru.freebe.profile.service.ProfileService;
+import com.foru.freebe.profile.service.PhotographerProfileService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,14 +25,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/photographer")
 public class PhotographerProfileController {
-    private final ProfileService profileService;
+    private final PhotographerProfileService photographerProfileService;
 
     @GetMapping("/profile")
     public ResponseEntity<ResponseBody<ProfileResponse>> getCurrentProfile(
         @AuthenticationPrincipal MemberAdapter memberAdapter) {
 
         Member photographer = memberAdapter.getMember();
-        ProfileResponse responseData = profileService.getMyCurrentProfile(photographer);
+        ProfileResponse responseData = photographerProfileService.getMyCurrentProfile(photographer);
 
         ResponseBody<ProfileResponse> responseBody = ResponseBody.<ProfileResponse>builder()
             .message("Good Response")
@@ -50,7 +50,7 @@ public class PhotographerProfileController {
         @RequestPart(value = "profileImage", required = false) MultipartFile profileImage) throws IOException {
 
         Member photographer = memberAdapter.getMember();
-        profileService.updateProfile(photographer, request, bannerImage, profileImage);
+        photographerProfileService.updateProfile(photographer, request, bannerImage, profileImage);
 
         ResponseBody<Void> responseBody = ResponseBody.<Void>builder()
             .message("Updated successfully")

--- a/src/main/java/com/foru/freebe/profile/dto/UpdateProfileRequest.java
+++ b/src/main/java/com/foru/freebe/profile/dto/UpdateProfileRequest.java
@@ -11,12 +11,15 @@ import lombok.NoArgsConstructor;
 public class UpdateProfileRequest {
     private String introductionContent;
     private String existingBannerImageUrl;
+    private String existingProfileImageUrl;
     private List<LinkInfo> linkInfos;
 
     @Builder
-    public UpdateProfileRequest(String introductionContent, String existingBannerImageUrl, List<LinkInfo> linkInfos) {
+    public UpdateProfileRequest(String introductionContent, String existingBannerImageUrl,
+        String existingProfileImageUrl, List<LinkInfo> linkInfos) {
         this.introductionContent = introductionContent;
         this.existingBannerImageUrl = existingBannerImageUrl;
+        this.existingProfileImageUrl = existingProfileImageUrl;
         this.linkInfos = linkInfos;
     }
 }

--- a/src/main/java/com/foru/freebe/profile/dto/UpdateProfileRequest.java
+++ b/src/main/java/com/foru/freebe/profile/dto/UpdateProfileRequest.java
@@ -10,11 +10,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class UpdateProfileRequest {
     private String introductionContent;
+    private String existingBannerImageUrl;
     private List<LinkInfo> linkInfos;
 
     @Builder
-    public UpdateProfileRequest(String introductionContent, List<LinkInfo> linkInfos) {
+    public UpdateProfileRequest(String introductionContent, String existingBannerImageUrl, List<LinkInfo> linkInfos) {
         this.introductionContent = introductionContent;
+        this.existingBannerImageUrl = existingBannerImageUrl;
         this.linkInfos = linkInfos;
     }
 }

--- a/src/main/java/com/foru/freebe/profile/entity/ProfileImage.java
+++ b/src/main/java/com/foru/freebe/profile/entity/ProfileImage.java
@@ -32,8 +32,6 @@ public class ProfileImage extends BaseEntity {
 
     private String profileOriginUrl;
 
-    private String profileThumbnailUrl;
-
     public void assignBannerOriginUrl(String bannerOriginUrl) {
         this.bannerOriginUrl = bannerOriginUrl;
     }
@@ -42,14 +40,9 @@ public class ProfileImage extends BaseEntity {
         this.profileOriginUrl = profileOriginUrl;
     }
 
-    public void assignProfileThumbnailUrl(String profileThumbnailUrl) {
-        this.profileThumbnailUrl = profileThumbnailUrl;
-    }
-
     @Builder
-    public ProfileImage(Profile profile, String profileThumbnailUrl, String profileOriginUrl, String bannerOriginUrl) {
+    public ProfileImage(Profile profile, String profileOriginUrl, String bannerOriginUrl) {
         this.profile = profile;
-        this.profileThumbnailUrl = profileThumbnailUrl;
         this.profileOriginUrl = profileOriginUrl;
         this.bannerOriginUrl = bannerOriginUrl;
     }

--- a/src/main/java/com/foru/freebe/profile/service/CustomerProfileService.java
+++ b/src/main/java/com/foru/freebe/profile/service/CustomerProfileService.java
@@ -1,0 +1,19 @@
+package com.foru.freebe.profile.service;
+
+import org.springframework.stereotype.Service;
+
+import com.foru.freebe.profile.dto.ProfileResponse;
+import com.foru.freebe.profile.entity.Profile;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CustomerProfileService {
+    private final ProfileService profileService;
+
+    public ProfileResponse getPhotographerProfile(String profileName) {
+        Profile profile = profileService.getProfile(profileName);
+        return profileService.findPhotographerProfile(profileName, profile);
+    }
+}

--- a/src/main/java/com/foru/freebe/profile/service/PhotographerProfileService.java
+++ b/src/main/java/com/foru/freebe/profile/service/PhotographerProfileService.java
@@ -1,0 +1,164 @@
+package com.foru.freebe.profile.service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.foru.freebe.common.dto.SingleImageLink;
+import com.foru.freebe.member.entity.Member;
+import com.foru.freebe.profile.dto.LinkInfo;
+import com.foru.freebe.profile.dto.ProfileResponse;
+import com.foru.freebe.profile.dto.UpdateProfileRequest;
+import com.foru.freebe.profile.entity.Link;
+import com.foru.freebe.profile.entity.Profile;
+import com.foru.freebe.profile.entity.ProfileImage;
+import com.foru.freebe.profile.repository.LinkRepository;
+import com.foru.freebe.profile.repository.ProfileImageRepository;
+import com.foru.freebe.s3.S3ImageService;
+import com.foru.freebe.s3.S3ImageType;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PhotographerProfileService {
+    private final ProfileService profileService;
+    private final S3ImageService s3ImageService;
+    private final ProfileImageRepository profileImageRepository;
+    private final LinkRepository linkRepository;
+
+    public ProfileResponse getMyCurrentProfile(Member photographer) {
+        Profile profile = profileService.getProfile(photographer);
+        return profileService.findPhotographerProfile(profile.getProfileName(), profile);
+    }
+
+    @Transactional
+    public void updateProfile(Member photographer, UpdateProfileRequest request, MultipartFile bannerImageFile,
+        MultipartFile profileImageFile) throws IOException {
+
+        Profile profile = profileService.getProfile(photographer);
+        ProfileImage profileImage = createProfileImageIfNotExists(profile);
+
+        updateIntroductionContent(profile, request.getIntroductionContent());
+        updateLinks(profile, request.getLinkInfos());
+        updateBannerImage(photographer, request, bannerImageFile, profileImage);
+        updateProfileImage(photographer.getId(), profileImageFile, profileImage);
+    }
+
+    private ProfileImage createProfileImageIfNotExists(Profile photographerProfile) {
+        return profileImageRepository.findByProfile(photographerProfile)
+            .orElse(ProfileImage.builder().profile(photographerProfile).build());
+    }
+
+    private void updateIntroductionContent(Profile profile, String newIntroductionContent) {
+        if (newIntroductionContent != null) {
+            profile.updateIntroductionContent(newIntroductionContent);
+        }
+    }
+
+    private void updateLinks(Profile profile, List<LinkInfo> linkInfos) {
+        List<Link> existingLinks = linkRepository.findByProfile(profile);
+
+        List<String> incomingLinkTitles = new ArrayList<>();
+        for (LinkInfo linkInfo : linkInfos) {
+            if (linkInfo.getLinkTitle() != null) {
+                String linkTitle = linkInfo.getLinkTitle();
+                incomingLinkTitles.add(linkTitle);
+            }
+        }
+
+        // 삭제할 링크 식별
+        existingLinks.stream()
+            .filter(link -> !incomingLinkTitles.contains(link.getTitle()))
+            .forEach(linkRepository::delete);
+
+        // 갱신 및 추가 처리
+        for (LinkInfo linkInfo : linkInfos) {
+            Link existingLink = existingLinks.stream()
+                .filter(link -> link.getTitle().equals(linkInfo.getLinkTitle()))
+                .findFirst()
+                .orElse(null);
+
+            if (existingLink == null) {
+                // 기존에 없는 새로운 링크 추가
+                Link newLink = Link.builder()
+                    .profile(profile)
+                    .title(linkInfo.getLinkTitle())
+                    .url(linkInfo.getLinkUrl())
+                    .build();
+                linkRepository.save(newLink);
+            } else { // 기존 링크 갱신 (URL이 변경된 경우)
+                if (isLinkInfoChanged(existingLink, linkInfo)) {
+                    existingLink.assignLinkUrl(linkInfo.getLinkUrl());
+                }
+            }
+        }
+    }
+
+    private void updateBannerImage(Member photographer, UpdateProfileRequest request, MultipartFile bannerImageFile,
+        ProfileImage profileImage) throws IOException {
+
+        if (bannerImageFile != null) {
+            registerNewBannerImage(profileImage, bannerImageFile, photographer.getId());
+
+        } else if (request.getExistingBannerImageUrl() != null) {
+            deleteCurrentBannerImage(profileImage);
+        }
+    }
+
+    private void updateProfileImage(Long photographerId, MultipartFile newImage, ProfileImage profileImage) throws
+        IOException {
+
+        if (newImage != null) {
+            deleteCurrentProfileImage(profileImage);
+
+            SingleImageLink profileImageLink = s3ImageService.imageUploadToS3(newImage, S3ImageType.PROFILE,
+                photographerId, true);
+            String originalImageUrl = profileImageLink.getOriginalUrl();
+            String thumbnailImageUrl = profileImage.getProfileThumbnailUrl();
+
+            profileImage.assignProfileOriginUrl(originalImageUrl);
+            profileImage.assignProfileThumbnailUrl(thumbnailImageUrl);
+            profileImageRepository.save(profileImage);
+        }
+    }
+
+    private Boolean isLinkInfoChanged(Link existingLink, LinkInfo linkInfo) {
+        return !existingLink.getUrl().equals(linkInfo.getLinkUrl()) || !existingLink.getTitle()
+            .equals(linkInfo.getLinkTitle());
+    }
+    
+    private void registerNewBannerImage(ProfileImage profileImage, MultipartFile newImage, Long photographerId) throws
+        IOException {
+
+        deleteCurrentBannerImage(profileImage);
+
+        SingleImageLink bannerImageLink = s3ImageService.imageUploadToS3(newImage, S3ImageType.PROFILE, photographerId,
+            false);
+        String newBannerImageUrl = bannerImageLink.getOriginalUrl();
+
+        profileImage.assignBannerOriginUrl(newBannerImageUrl);
+        profileImageRepository.save(profileImage);
+    }
+
+    private void deleteCurrentBannerImage(ProfileImage profileImage) {
+        String bannerImageUrl = profileImage.getBannerOriginUrl();
+        if (bannerImageUrl != null) {
+            s3ImageService.deleteImageFromS3(bannerImageUrl);
+            profileImage.assignBannerOriginUrl(null);
+        }
+    }
+
+    private void deleteCurrentProfileImage(ProfileImage profileImage) {
+        String profileImageOriginUrl = profileImage.getProfileOriginUrl();
+        String profileImageThumbnailUrl = profileImage.getProfileThumbnailUrl();
+        if (profileImageOriginUrl != null) {
+            s3ImageService.deleteImageFromS3(profileImageOriginUrl);
+            s3ImageService.deleteImageFromS3(profileImageThumbnailUrl);
+        }
+    }
+}

--- a/src/main/java/com/foru/freebe/profile/service/ProfileService.java
+++ b/src/main/java/com/foru/freebe/profile/service/ProfileService.java
@@ -41,12 +41,12 @@ public class ProfileService {
 
     public Profile getProfile(String profileName) {
         return profileRepository.findByProfileName(profileName)
-            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+            .orElseThrow(() -> new RestApiException(ProfileErrorCode.PROFILE_NAME_NOT_FOUND));
     }
 
     public Profile getProfile(Member photographer) {
         return profileRepository.findByMember(photographer)
-            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+            .orElseThrow(() -> new RestApiException(ProfileErrorCode.MEMBER_NOT_FOUND));
     }
 
     public String getProfileName(Long id) {
@@ -86,7 +86,7 @@ public class ProfileService {
 
     private Profile getProfile(Long memberId) {
         return profileRepository.findByMemberId(memberId)
-            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+            .orElseThrow(() -> new RestApiException(ProfileErrorCode.MEMBER_NOT_FOUND));
     }
 
     private List<LinkInfo> getProfileLinkInfos(Profile profile) {

--- a/src/main/java/com/foru/freebe/profile/service/ProfileService.java
+++ b/src/main/java/com/foru/freebe/profile/service/ProfileService.java
@@ -1,29 +1,22 @@
 package com.foru.freebe.profile.service;
 
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
-import com.foru.freebe.common.dto.SingleImageLink;
 import com.foru.freebe.errors.errorcode.CommonErrorCode;
 import com.foru.freebe.errors.errorcode.ProfileErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
 import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.profile.dto.LinkInfo;
 import com.foru.freebe.profile.dto.ProfileResponse;
-import com.foru.freebe.profile.dto.UpdateProfileRequest;
 import com.foru.freebe.profile.entity.Link;
 import com.foru.freebe.profile.entity.Profile;
 import com.foru.freebe.profile.entity.ProfileImage;
 import com.foru.freebe.profile.repository.LinkRepository;
 import com.foru.freebe.profile.repository.ProfileImageRepository;
 import com.foru.freebe.profile.repository.ProfileRepository;
-import com.foru.freebe.s3.S3ImageService;
-import com.foru.freebe.s3.S3ImageType;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -34,24 +27,34 @@ public class ProfileService {
     private final ProfileRepository profileRepository;
     private final LinkRepository linkRepository;
     private final ProfileImageRepository profileImageRepository;
-    private final S3ImageService s3ImageService;
+
+    @Transactional
+    public Profile initialProfileSetting(Member photographer, String profileName) {
+        boolean isProfileExists = profileRepository.existsByMemberId(photographer.getId());
+        if (isProfileExists) {
+            throw new RestApiException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+        }
+
+        validateProfileNameDuplicate(profileName);
+        return createMemberProfile(photographer, profileName);
+    }
+
+    public Profile getProfile(String profileName) {
+        return profileRepository.findByProfileName(profileName)
+            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+    }
+
+    public Profile getProfile(Member photographer) {
+        return profileRepository.findByMember(photographer)
+            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+    }
 
     public String getProfileName(Long id) {
         Profile profile = getProfile(id);
         return profile.getProfileName();
     }
 
-    public ProfileResponse getPhotographerProfile(String profileName) {
-        Profile profile = getProfile(profileName);
-        return findPhotographerProfile(profileName, profile);
-    }
-
-    public ProfileResponse getMyCurrentProfile(Member photographer) {
-        Profile profile = getProfile(photographer);
-        return findPhotographerProfile(profile.getProfileName(), profile);
-    }
-
-    private ProfileResponse findPhotographerProfile(String profileName, Profile profile) {
+    public ProfileResponse findPhotographerProfile(String profileName, Profile profile) {
         ProfileImage profileImage = profileImageRepository.findByProfile(profile).orElse(null);
 
         List<LinkInfo> linkInfos = getProfileLinkInfos(profile);
@@ -65,165 +68,10 @@ public class ProfileService {
             .build();
     }
 
-    @Transactional
-    public void updateProfile(Member photographer, UpdateProfileRequest request, MultipartFile bannerImageFile,
-        MultipartFile profileImageFile) throws IOException {
-
-        Profile profile = getProfile(photographer);
-        ProfileImage profileImage = createProfileImageIfNotExists(profile);
-
-        updateIntroductionContent(profile, request.getIntroductionContent());
-        updateLinks(profile, request.getLinkInfos());
-        updateBannerImage(photographer, request, bannerImageFile, profileImage);
-        updateProfileImage(photographer, profileImageFile, profileImage);
-    }
-
-    private void updateIntroductionContent(Profile profile, String newIntroductionContent) {
-        if (newIntroductionContent != null) {
-            profile.updateIntroductionContent(newIntroductionContent);
-        }
-    }
-
-    private void updateLinks(Profile profile, List<LinkInfo> linkInfos) {
-        List<Link> existingLinks = linkRepository.findByProfile(profile);
-
-        List<String> incomingLinkTitles = new ArrayList<>();
-        for (LinkInfo linkInfo : linkInfos) {
-            if (linkInfo.getLinkTitle() != null) {
-                String linkTitle = linkInfo.getLinkTitle();
-                incomingLinkTitles.add(linkTitle);
-            }
-        }
-
-        // 삭제할 링크 식별
-        existingLinks.stream()
-            .filter(link -> !incomingLinkTitles.contains(link.getTitle()))
-            .forEach(linkRepository::delete);
-
-        // 갱신 및 추가 처리
-        for (LinkInfo linkInfo : linkInfos) {
-            Link existingLink = existingLinks.stream()
-                .filter(link -> link.getTitle().equals(linkInfo.getLinkTitle()))
-                .findFirst()
-                .orElse(null);
-
-            if (existingLink == null) {
-                // 기존에 없는 새로운 링크 추가
-                Link newLink = Link.builder()
-                    .profile(profile)
-                    .title(linkInfo.getLinkTitle())
-                    .url(linkInfo.getLinkUrl())
-                    .build();
-                linkRepository.save(newLink);
-            } else { // 기존 링크 갱신 (URL이 변경된 경우)
-                if (isLinkInfoChanged(existingLink, linkInfo)) {
-                    existingLink.assignLinkUrl(linkInfo.getLinkUrl());
-                }
-            }
-        }
-    }
-
-    private void updateBannerImage(Member photographer, UpdateProfileRequest request, MultipartFile bannerImageFile,
-        ProfileImage profileImage) throws IOException {
-
-        if (bannerImageFile != null) {
-            registerNewBannerImage(profileImage, bannerImageFile, photographer.getId());
-
-        } else if (request.getExistingBannerImageUrl() != null) {
-            deleteCurrentBannerImage(profileImage);
-        }
-    }
-
-    private void registerNewBannerImage(ProfileImage profileImage, MultipartFile newImage, Long photographerId) throws
-        IOException {
-
-        deleteCurrentBannerImage(profileImage);
-
-        SingleImageLink bannerImageLink = s3ImageService.imageUploadToS3(newImage, S3ImageType.PROFILE, photographerId,
-            false);
-        String newBannerImageUrl = bannerImageLink.getOriginalUrl();
-
-        profileImage.assignBannerOriginUrl(newBannerImageUrl);
-        profileImageRepository.save(profileImage);
-    }
-
-    private void deleteCurrentBannerImage(ProfileImage profileImage) {
-        String bannerImageUrl = profileImage.getBannerOriginUrl();
-        if (bannerImageUrl != null) {
-            s3ImageService.deleteImageFromS3(bannerImageUrl);
-            profileImage.assignBannerOriginUrl(null);
-        }
-    }
-
-    private void updateProfileImage(Member photographer, MultipartFile profileImageFile,
-        ProfileImage profileImage) throws
-        IOException {
-        if (profileImageFile != null) {
-            updateProfileImage(profileImage, profileImageFile, photographer.getId());
-        }
-    }
-
-    @Transactional
-    public Profile initialProfileSetting(Member photographer, String profileName) {
-        boolean isProfileExists = profileRepository.existsByMemberId(photographer.getId());
-        if (isProfileExists) {
-            throw new RestApiException(CommonErrorCode.INTERNAL_SERVER_ERROR);
-        }
-
-        validateProfileNameDuplicate(profileName);
-        return createMemberProfile(photographer, profileName);
-    }
-
     private void validateProfileNameDuplicate(String profileName) {
         if (profileRepository.existsByProfileName(profileName)) {
             throw new RestApiException(ProfileErrorCode.PROFILE_NAME_ALREADY_EXISTS);
         }
-    }
-
-    private Profile getProfile(Long memberId) {
-        return profileRepository.findByMemberId(memberId)
-            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
-    }
-
-    private Profile getProfile(Member photographer) {
-        return profileRepository.findByMember(photographer)
-            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
-    }
-
-    private Profile getProfile(String profileName) {
-        return profileRepository.findByProfileName(profileName)
-            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
-    }
-
-    private List<LinkInfo> getProfileLinkInfos(Profile profile) {
-        List<Link> links = linkRepository.findByProfile(profile);
-
-        return links.stream()
-            .map(link -> new LinkInfo(link.getTitle(), link.getUrl()))
-            .collect(Collectors.toList());
-    }
-
-    private ProfileImage createProfileImageIfNotExists(Profile photographerProfile) {
-        return profileImageRepository.findByProfile(photographerProfile)
-            .orElse(ProfileImage.builder().profile(photographerProfile).build());
-    }
-
-    private void updateProfileImage(ProfileImage profileImage, MultipartFile imageFile, Long id) throws IOException {
-        String profileImageOriginUrl = profileImage.getProfileOriginUrl();
-        String profileImageThumbnailUrl = profileImage.getProfileThumbnailUrl();
-        if (profileImageOriginUrl != null) {
-            s3ImageService.deleteImageFromS3(profileImageOriginUrl);
-            s3ImageService.deleteImageFromS3(profileImageThumbnailUrl);
-        }
-
-        SingleImageLink profileImageLink = s3ImageService.imageUploadToS3(imageFile, S3ImageType.PROFILE, id, true);
-        String originalImageUrl = profileImageLink.getOriginalUrl();
-        String thumbnailImageUrl = profileImage.getProfileThumbnailUrl();
-
-        profileImage.assignProfileOriginUrl(originalImageUrl);
-        profileImage.assignProfileThumbnailUrl(thumbnailImageUrl);
-
-        profileImageRepository.save(profileImage);
     }
 
     private Profile createMemberProfile(Member member, String profileName) {
@@ -236,8 +84,16 @@ public class ProfileService {
         return profileRepository.save(profile);
     }
 
-    private Boolean isLinkInfoChanged(Link existingLink, LinkInfo linkInfo) {
-        return !existingLink.getUrl().equals(linkInfo.getLinkUrl()) || !existingLink.getTitle()
-            .equals(linkInfo.getLinkTitle());
+    private Profile getProfile(Long memberId) {
+        return profileRepository.findByMemberId(memberId)
+            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+    }
+
+    private List<LinkInfo> getProfileLinkInfos(Profile profile) {
+        List<Link> links = linkRepository.findByProfile(profile);
+
+        return links.stream()
+            .map(link -> new LinkInfo(link.getTitle(), link.getUrl()))
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/foru/freebe/profile/service/ProfileService.java
+++ b/src/main/java/com/foru/freebe/profile/service/ProfileService.java
@@ -61,7 +61,7 @@ public class ProfileService {
 
         return ProfileResponse.builder()
             .bannerImageUrl(profileImage != null ? profileImage.getBannerOriginUrl() : null)
-            .profileImageUrl(profileImage != null ? profileImage.getProfileThumbnailUrl() : null)
+            .profileImageUrl(profileImage != null ? profileImage.getProfileOriginUrl() : null)
             .profileName(profileName)
             .introductionContent(profile.getIntroductionContent())
             .linkInfos(linkInfos)

--- a/src/main/java/com/foru/freebe/reservation/dto/BasicReservationInfoResponse.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/BasicReservationInfoResponse.java
@@ -23,16 +23,20 @@ public class BasicReservationInfoResponse {
     private String instagramId;
 
     @NotNull
+    private Long basicPrice;
+
+    @NotNull
     private List<ProductComponentDto> productComponentDtoList;
 
     private List<ProductOptionDto> productOptionDtoList;
 
     @Builder
-    public BasicReservationInfoResponse(String name, String phoneNumber, String instagramId,
+    public BasicReservationInfoResponse(String name, String phoneNumber, String instagramId, Long basicPrice,
         List<ProductComponentDto> productComponentDtoList, List<ProductOptionDto> productOptionDtoList) {
         this.name = name;
         this.phoneNumber = phoneNumber;
         this.instagramId = instagramId;
+        this.basicPrice = basicPrice;
         this.productComponentDtoList = productComponentDtoList;
         this.productOptionDtoList = productOptionDtoList;
     }

--- a/src/main/java/com/foru/freebe/reservation/dto/FormDetailsViewResponse.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/FormDetailsViewResponse.java
@@ -30,6 +30,9 @@ public class FormDetailsViewResponse {
     private CustomerDetails customerDetails;
 
     @NotNull
+    private Long basicPrice;
+
+    @NotNull
     private Map<String, String> photoInfo;
 
     private Map<Integer, PhotoOption> photoOptions;
@@ -47,7 +50,7 @@ public class FormDetailsViewResponse {
 
     @Builder
     public FormDetailsViewResponse(Long reservationNumber, ReservationStatus currentReservationStatus,
-        List<StatusHistory> statusHistory, String productTitle, CustomerDetails customerDetails,
+        List<StatusHistory> statusHistory, String productTitle, CustomerDetails customerDetails, Long basicPrice,
         Map<String, String> photoInfo, Map<Integer, PhotoOption> photoOptions,
         Map<Integer, PreferredDate> preferredDates, List<String> originalImage,
         List<String> thumbnailImage, String requestMemo, String photographerMemo) {
@@ -56,6 +59,7 @@ public class FormDetailsViewResponse {
         this.statusHistory = statusHistory;
         this.productTitle = productTitle;
         this.customerDetails = customerDetails;
+        this.basicPrice = basicPrice;
         this.photoInfo = photoInfo;
         this.photoOptions = photoOptions;
         this.preferredDates = preferredDates;
@@ -66,15 +70,16 @@ public class FormDetailsViewResponse {
     }
 
     public static FormDetailsViewResponseBuilder builder(Long reservationNumber,
-        ReservationStatus currentReservationStatus,
-        List<StatusHistory> statusHistory, String productTitle, CustomerDetails customerDetails,
-        Map<String, String> photoInfo, Map<Integer, PreferredDate> preferredDates) {
+        ReservationStatus currentReservationStatus, List<StatusHistory> statusHistory, String productTitle,
+        CustomerDetails customerDetails, Long basicPrice, Map<String, String> photoInfo,
+        Map<Integer, PreferredDate> preferredDates) {
         return new FormDetailsViewResponseBuilder()
             .reservationNumber(reservationNumber)
             .currentReservationStatus(currentReservationStatus)
             .statusHistory(statusHistory)
             .productTitle(productTitle)
             .customerDetails(customerDetails)
+            .basicPrice(basicPrice)
             .photoInfo(photoInfo)
             .preferredDates(preferredDates);
     }

--- a/src/main/java/com/foru/freebe/reservation/dto/FormRegisterRequest.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/FormRegisterRequest.java
@@ -17,15 +17,15 @@ public class FormRegisterRequest {
     @NotBlank(message = "Profile name must not be blank")
     private String profileName;
 
-    @NotNull
+    @NotNull(message = "Product id must not be null")
     private Long productId;
-    
+
     @NotBlank(message = "Instagram ID must not be blank")
     @Pattern(regexp = "^[a-z0-9_.]+$", message = "인스타그램 아이디 입력 형식이 틀렸습니다")
     @Size(min = 3, max = 30, message = "인스타그램 아이디는 최소 3자 이상 최대 30자 이하여야합니다")
     private String instagramId;
 
-    @NotNull
+    @NotNull(message = "Preferred dates must not be null")
     private Map<Integer, PreferredDate> preferredDates;
 
     private Map<Integer, PhotoOption> photoOptions;

--- a/src/main/java/com/foru/freebe/reservation/dto/FormRegisterRequest.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/FormRegisterRequest.java
@@ -17,15 +17,13 @@ public class FormRegisterRequest {
     @NotBlank(message = "Profile name must not be blank")
     private String profileName;
 
+    @NotNull
+    private Long productId;
+    
     @NotBlank(message = "Instagram ID must not be blank")
     @Pattern(regexp = "^[a-z0-9_.]+$", message = "인스타그램 아이디 입력 형식이 틀렸습니다")
     @Size(min = 3, max = 30, message = "인스타그램 아이디는 최소 3자 이상 최대 30자 이하여야합니다")
     private String instagramId;
-
-    @NotBlank(message = "Product title must not be blank")
-    private String productTitle;
-
-    private Map<String, String> photoInfo;
 
     @NotNull
     private Map<Integer, PreferredDate> preferredDates;

--- a/src/main/java/com/foru/freebe/reservation/dto/ReservationInfoResponse.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/ReservationInfoResponse.java
@@ -20,6 +20,9 @@ public class ReservationInfoResponse {
     private String productTitle;
 
     @NotNull
+    private Long basicPrice;
+
+    @NotNull
     private Map<String, String> photoInfo;
 
     @NotNull
@@ -30,11 +33,12 @@ public class ReservationInfoResponse {
     private String customerMemo;
 
     @Builder
-    public ReservationInfoResponse(ReservationStatus reservationStatus, String productTitle,
+    public ReservationInfoResponse(ReservationStatus reservationStatus, String productTitle, Long basicPrice,
         Map<String, String> photoInfo, Map<Integer, PreferredDate> preferredDate,
         Map<Integer, PhotoOption> photoOptions, String customerMemo) {
         this.reservationStatus = reservationStatus;
         this.productTitle = productTitle;
+        this.basicPrice = basicPrice;
         this.photoInfo = photoInfo;
         this.preferredDate = preferredDate;
         this.photoOptions = photoOptions;

--- a/src/main/java/com/foru/freebe/reservation/entity/ReservationForm.java
+++ b/src/main/java/com/foru/freebe/reservation/entity/ReservationForm.java
@@ -53,6 +53,9 @@ public class ReservationForm extends BaseEntity {
     @NotBlank(message = "Product title must not be blank")
     private String productTitle;
 
+    @NotNull(message = "Basic price must not be null")
+    private Long basicPrice;
+
     @NotNull(message = "Total price must not be null")
     @Positive
     private Long totalPrice;
@@ -95,13 +98,14 @@ public class ReservationForm extends BaseEntity {
 
     @Builder
     public ReservationForm(Member photographer, Member customer, String instagramId, String productTitle,
-        Long totalPrice, Boolean serviceTermAgreement, Boolean photographerTermAgreement,
+        Long basicPrice, Long totalPrice, Boolean serviceTermAgreement, Boolean photographerTermAgreement,
         ReservationStatus reservationStatus, Map<String, String> photoInfo, Map<Integer, PreferredDate> preferredDate,
         Map<Integer, PhotoOption> photoOption, String customerMemo, String photographerMemo) {
         this.photographer = photographer;
         this.customer = customer;
         this.instagramId = instagramId;
         this.productTitle = productTitle;
+        this.basicPrice = basicPrice;
         this.totalPrice = totalPrice;
         this.serviceTermAgreement = serviceTermAgreement;
         this.photographerTermAgreement = photographerTermAgreement;
@@ -114,13 +118,14 @@ public class ReservationForm extends BaseEntity {
     }
 
     public static ReservationFormBuilder builder(Member photographer, Member customer, String instagramId,
-        String productTitle, Long totalPrice, Boolean serviceTermAgreement, Boolean photographerTermAgreement,
-        ReservationStatus reservationStatus) {
+        String productTitle, Long basicPrice, Long totalPrice, Boolean serviceTermAgreement,
+        Boolean photographerTermAgreement, ReservationStatus reservationStatus) {
         return new ReservationFormBuilder()
             .photographer(photographer)
             .customer(customer)
             .instagramId(instagramId)
             .productTitle(productTitle)
+            .basicPrice(basicPrice)
             .totalPrice(totalPrice)
             .serviceTermAgreement(serviceTermAgreement)
             .photographerTermAgreement(photographerTermAgreement)

--- a/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
@@ -98,6 +98,7 @@ public class CustomerReservationService {
             .name(customer.getName())
             .phoneNumber(customer.getPhoneNumber())
             .instagramId(customer.getInstagramId())
+            .basicPrice(product.getBasicPrice())
             .productComponentDtoList(productComponentDtoList)
             .productOptionDtoList(productOptionDtoList)
             .build();
@@ -112,6 +113,7 @@ public class CustomerReservationService {
         return ReservationInfoResponse.builder()
             .reservationStatus(reservationForm.getReservationStatus())
             .productTitle(reservationForm.getProductTitle())
+            .basicPrice(reservationForm.getBasicPrice())
             .photoInfo(reservationForm.getPhotoInfo())
             .preferredDate(reservationForm.getPreferredDate())
             .photoOptions(reservationForm.getPhotoOption())
@@ -153,7 +155,7 @@ public class CustomerReservationService {
         Map<String, String> photoInfo = getProductComponentsTitleAndContent(productComponents);
 
         ReservationForm.ReservationFormBuilder builder = ReservationForm.builder(photographer, customer,
-                request.getInstagramId(), product.getTitle(), request.getTotalPrice(),
+                request.getInstagramId(), product.getTitle(), product.getBasicPrice(), request.getTotalPrice(),
                 request.getServiceTermAgreement(), request.getPhotographerTermAgreement(), ReservationStatus.NEW)
             .photoInfo(photoInfo)
             .preferredDate(request.getPreferredDates())

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationDetails.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationDetails.java
@@ -6,8 +6,6 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
-import com.foru.freebe.errors.errorcode.CommonErrorCode;
-import com.foru.freebe.errors.exception.RestApiException;
 import com.foru.freebe.reservation.dto.CustomerDetails;
 import com.foru.freebe.reservation.dto.FormDetailsViewResponse;
 import com.foru.freebe.reservation.dto.PreferredDate;
@@ -30,13 +28,13 @@ public class PhotographerReservationDetails {
         List<StatusHistory> statusHistories = reservationService.getStatusHistories(reservationForm);
 
         CustomerDetails customerDetails = buildCustomerDetails(reservationForm);
-        Map<String, String> shootDetails = reservationForm.getPhotoInfo();
+        Map<String, String> photoInfo = reservationForm.getPhotoInfo();
         Map<Integer, PreferredDate> preferredDates = reservationForm.getPreferredDate();
         ReferenceImageUrls preferredImages = getPreferredImages(reservationForm);
 
-        return FormDetailsViewResponse.builder(reservationForm.getId(),
-                reservationForm.getReservationStatus(), statusHistories, reservationForm.getProductTitle(), customerDetails,
-                shootDetails, preferredDates)
+        return FormDetailsViewResponse.builder(reservationForm.getId(), reservationForm.getReservationStatus(),
+                statusHistories, reservationForm.getProductTitle(), customerDetails, reservationForm.getBasicPrice(),
+                photoInfo, preferredDates)
             .photoOptions(reservationForm.getPhotoOption())
             .originalImage(preferredImages.getOriginalImage())
             .thumbnailImage(preferredImages.getThumbnailImage())

--- a/src/main/java/com/foru/freebe/reservation/service/ReservationVerifier.java
+++ b/src/main/java/com/foru/freebe/reservation/service/ReservationVerifier.java
@@ -6,13 +6,10 @@ import com.foru.freebe.errors.errorcode.CommonErrorCode;
 import com.foru.freebe.errors.errorcode.ProductErrorCode;
 import com.foru.freebe.errors.errorcode.ReservationErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
-import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.product.entity.ActiveStatus;
 import com.foru.freebe.product.entity.Product;
 import com.foru.freebe.product.respository.ProductRepository;
-import com.foru.freebe.profile.entity.Profile;
 import com.foru.freebe.profile.repository.ProfileRepository;
-import com.foru.freebe.reservation.dto.FormRegisterRequest;
 import com.foru.freebe.reservation.dto.ReservationStatusUpdateRequest;
 import com.foru.freebe.reservation.entity.ReservationForm;
 import com.foru.freebe.reservation.entity.ReservationStatus;
@@ -26,9 +23,10 @@ public class ReservationVerifier {
     private final ProductRepository productRepository;
     private final ProfileRepository profileRepository;
 
-    public void validateReservationFormBeforeSave(FormRegisterRequest request) {
-        validateProductTitleExists(request);
-        validateProductIsActive(request.getProductTitle());
+    public void validateProductIsActive(Product product) {
+        if (product.getActiveStatus() != ActiveStatus.ACTIVE) {
+            throw new RestApiException(ProductErrorCode.PRODUCT_INACTIVE_STATUS);
+        }
     }
 
     public void validateCustomerAccess(ReservationForm reservationForm, Long customerId) {
@@ -51,25 +49,6 @@ public class ReservationVerifier {
         }
 
         validateStatusTransition(currentStatus, request.getUpdateStatus());
-    }
-
-    private void validateProductTitleExists(FormRegisterRequest request) {
-        Profile photographerProfile = profileRepository.findByProfileName(request.getProfileName())
-            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
-        Member photographer = photographerProfile.getMember();
-
-        if (!productRepository.existsByMemberAndTitle(photographer, request.getProductTitle())) {
-            throw new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND);
-        }
-    }
-
-    private void validateProductIsActive(String productTitle) {
-        Product product = productRepository.findByTitle(productTitle)
-            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
-
-        if (product.getActiveStatus() != ActiveStatus.ACTIVE) {
-            throw new RestApiException(ProductErrorCode.PRODUCT_INACTIVE_STATUS);
-        }
     }
 
     private void validateCustomerAuthorityToChangeStatus(ReservationStatus currentStatus,

--- a/src/main/java/com/foru/freebe/s3/S3ImageService.java
+++ b/src/main/java/com/foru/freebe/s3/S3ImageService.java
@@ -57,6 +57,9 @@ public class S3ImageService {
     @Value("${cloud.aws.s3.base-path.profile}")
     private String profilePath;
 
+    @Value("${cloud.aws.s3.base-path.banner}")
+    private String bannerPath;
+
     @Value("${cloud.aws.s3.base-path.reservation}")
     private String reservationPath;
 
@@ -101,6 +104,7 @@ public class S3ImageService {
         switch (s3ImageType) {
             case PROFILE -> size = 100;
             case PRODUCT, RESERVATION -> size = 200;
+            case BANNER -> size = 500;
             default -> throw new RestApiException(CommonErrorCode.INTERNAL_SERVER_ERROR);
         }
 
@@ -175,6 +179,7 @@ public class S3ImageService {
         switch (s3ImageType) {
             case PRODUCT -> basePath = photographerPath + memberId + productPath;
             case PROFILE -> basePath = photographerPath + memberId + profilePath;
+            case BANNER -> basePath = photographerPath + memberId + bannerPath;
             case RESERVATION -> basePath = customerPath + memberId + reservationPath;
             default -> throw new RestApiException(CommonErrorCode.INTERNAL_SERVER_ERROR);
         }

--- a/src/main/java/com/foru/freebe/s3/S3ImageService.java
+++ b/src/main/java/com/foru/freebe/s3/S3ImageService.java
@@ -162,7 +162,7 @@ public class S3ImageService {
         } catch (AmazonServiceException e) {
             throw new RestApiException(AwsErrorCode.AMAZON_SERVICE_EXCEPTION);
         } catch (Exception e) {
-            throw new RestApiException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+            throw new RestApiException(AwsErrorCode.DELETE_OBJECT_EXCEPTION);
         }
     }
 

--- a/src/main/java/com/foru/freebe/s3/S3ImageType.java
+++ b/src/main/java/com/foru/freebe/s3/S3ImageType.java
@@ -4,4 +4,5 @@ public enum S3ImageType {
     PROFILE,
     PRODUCT,
     RESERVATION,
+    BANNER
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -60,6 +60,7 @@ cloud:
         customer: ${AWS_S3_CUSTOMER_PATH}
         product: ${AWS_S3_PRODUCT_PATH}
         profile: ${AWS_S3_PROFILE_PATH}
+        banner: ${AWS_S3_BANNER_PATH}
         reservation: ${AWS_S3_RESERVATION_PATH}
 
 logging:

--- a/src/test/java/com/foru/freebe/member/service/PhotographerJoinServiceTest.java
+++ b/src/test/java/com/foru/freebe/member/service/PhotographerJoinServiceTest.java
@@ -22,7 +22,6 @@ import com.foru.freebe.profile.repository.LinkRepository;
 import com.foru.freebe.profile.repository.ProfileImageRepository;
 import com.foru.freebe.profile.repository.ProfileRepository;
 import com.foru.freebe.profile.service.ProfileService;
-import com.foru.freebe.s3.S3ImageService;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("사진작가측 회원가입 테스트")
@@ -35,9 +34,6 @@ class PhotographerJoinServiceTest {
 
     @Mock
     private ProfileImageRepository profileImageRepository;
-
-    @Mock
-    private S3ImageService s3ImageService;
 
     @Mock
     private MemberRepository memberRepository;
@@ -55,7 +51,7 @@ class PhotographerJoinServiceTest {
     void setUp() {
         MockitoAnnotations.openMocks(this);
         profileService = spy(
-            new ProfileService(profileRepository, linkRepository, profileImageRepository, s3ImageService));
+            new ProfileService(profileRepository, linkRepository, profileImageRepository));
         photographerJoinService = new PhotographerJoinService(profileService, memberRepository,
             memberTermAgreementRepository);
         photographer = Member.builder(1L, Role.PHOTOGRAPHER_PENDING, "이유리", "test@email", "010-0000-0000").build();

--- a/src/test/java/com/foru/freebe/profile/service/ProfileServiceTest.java
+++ b/src/test/java/com/foru/freebe/profile/service/ProfileServiceTest.java
@@ -50,8 +50,11 @@ class ProfileServiceTest {
     @Mock
     private S3ImageService s3ImageService;
 
-    @InjectMocks
+    @Mock
     private ProfileService profileService;
+
+    @InjectMocks
+    private PhotographerProfileService photographerProfileService;
 
     private final Member photographer = createNewMember();
 
@@ -125,7 +128,7 @@ class ProfileServiceTest {
             when(linkRepository.findByProfile(profile)).thenReturn(links);
 
             // when
-            ProfileResponse response = profileService.getMyCurrentProfile(photographer);
+            ProfileResponse response = photographerProfileService.getMyCurrentProfile(photographer);
 
             // then
             assertEquals(response.getBannerImageUrl(), "https://freebe/banner/origin");
@@ -189,7 +192,7 @@ class ProfileServiceTest {
                 false)).thenReturn(profileImageLinkSet);
 
             // when
-            profileService.updateProfile(photographer, request, bannerImageFile, profileImageFile);
+            photographerProfileService.updateProfile(photographer, request, bannerImageFile, profileImageFile);
 
             // then
             verify(profile).updateIntroductionContent("Welcome to my profile");
@@ -234,7 +237,7 @@ class ProfileServiceTest {
                 true)).thenReturn(profileImageLinkSet);
 
             // when
-            profileService.updateProfile(photographer, request, bannerImageFile, profileImageFile);
+            photographerProfileService.updateProfile(photographer, request, bannerImageFile, profileImageFile);
 
             // then
             verify(profile).updateIntroductionContent("Welcome to my profile");


### PR DESCRIPTION
## 체크리스트

- [x] 불필요한 주석 처리가 없는가?

</br>

## 작업 내역
(사진작가측)
- 프로필 업데이트 API 
  - MultipartFile image로는 배너 이미지, 프로필 이미지를 **유지하는 경우와 삭제하는 경우를 구분**할 수 없는 문제가 있어 요청 필드에  `existingBannerImageUrl`, `existingProfileImageUrl`을 추가해 이를 구분하도록 처리했습니다.
    - MultipartFile image가 첨부되어 있다면 무조건 등록/업데이트 함
    - MultipartFile image가 없고, existingxxxImageUrl도 없다면 기존에 저장되어 있던 이미지를 삭제함
- 지난예약 조회 API
  - 지난예약에서 예약상태를 `전체`로 조회할 때 아무것도 조회되지 않는 문제가 있어 이를 해결했습니다. 
- 접근 권한 확대
  - 사진작가가 의뢰자로서 가입을 원하면 사진작가의 Role type은 유지하면서 사진작가의 권한으로 의뢰자 페이지에 접근하고 기능을 수행할 수 있도록 했습니다.
- 상품 등록시 `기본 가격` 입력 필수화
  - 고객측에서 상품 목록 조회, 상품 상세 조회, 예약서 양식 조회, 제출한 예약서 조회 할 때도 기본 가격을 확인할 수 있도록 했으며 사진작가측 상품 상세정보 조회 페이지에서도 기본가격 확인 및 수정이 가능하도록 했습니다.
- 상품 상세정보 업데이트 시, 상품 이미지의 순서를 유지하는 로직 개선
  - 기존: 상품 상세정보 업데이트 요청 시 기존에 등록되어있는 상품 이미지는 db에서 삭제한뒤 다시 저장해서 요청으로 들어온 이미지 순서를 유지하면서 순서대로 저장될 수 있도록 구현되어 있었습니다.
  - 변경: 상품이미지 table에 `imageOrder` 컬럼을 추가하여 상품이미지 등록/수정/삭제 요청 시 상품 이미지의 등록 순서를 재조정하도록 구현하고, 상품 조회 시에는 imageOrder 컬럼을 기준으로 오름차순 정렬하는 방식으로 구현했습니다.
- 상품 목록 조회 시, 대표 이미지를 응답하는 로직을 추가 구현했습니다.

</br>

(고객측)
- 접근 권한 확대
  - 사진의뢰자가 사진작가로서 가입을 원하면 Role type을 사진작가로 업데이트하고, 사진작가의 페이지에 접근하고 기능을 수행할 수 있도록 했습니다.
- 예약서 등록 로직 변경
  - 기존: ProductTitle, PhotoInfo를 request dto에 포함시켜 보내면 DB에 바로 저장하는 형식
  - 변경: 위 두 필드를 제외하고 ProductId를 request dto에 포함시켜 보내면 DB에서 상품 제목과 상품 구성을 조회한 뒤, 이를 스냅샷으로 떠서 Reservation form에 저장하는 형식

</br>

(리팩터링)
- 클래스 분리
  - ProfileService 클래스가 너무 커져서 PhotographerProfileService, CustomerProfileService로 분리했습니다.
- 에러메시지 보완
  - 기존에 DB에서 데이터를 찾지 못하면 단순히 (404, RESOURCE_NOT_FOUND)로만 예외를 던지고 있었는데, 배포 환경에서 테스트 이후에 로그를 확인할 때 이 에러메시지로는 어떤 자원을 못찾은건지 구분하기가 어려워 각 엔티티별로 xxx_NOT_FOUND 형식으로 에러메시지를 보완했습니다.
- S3 경로 세분화
  - 기존: 프로필 이미지, 배너 이미지가 똑같은 s3 경로에 저장되고 있었음
  - 변경: 두 유형에 따라 이미지가 저장되는 디렉터리 위치를 분리함

</br>

## 고민한 사항
- 비즈니스 로직을 많이 건드리게 되면서 테스트코드의 리팩터링 양이 많아졌습니다. 테스트코드 리팩터링 티켓을 새로 만들어서 유석이와 함께 나눠서 작업할 예정입니다 .. 🙇‍♀️🥹
- 고객측에서 예약서 기본 양식을 조회할때 상품 구성을 title을 키로 가지고, content를 밸류로 가지는 해시맵 형태로 구성하게 되는데, title이 똑같을 경우 키 중복 문제가 발생했습니다. 따라서 작가측에서 상품 등록하는 시점에 컴포넌트 타이틀의 중복검사를 추가하였습니다.

</br>

## 리뷰 요청사항
- 이번 티켓에서 너무 다양한 일을 하게 되어서 리뷰하기 힘들 거 같아서 미안하네욥.. 😓
- 이미지 등록/수정/삭제와 유저 권한에 대한 적절한 처리가 이뤄지고 있는지 확인 부탁드립니다! .. :)
- `src/main/java/com/foru/freebe/auth/service/KakaoLoginService.java` 유저별 접근권한
- `src/main/java/com/foru/freebe/product/service/PhotographerProductService.java` 상품이미지 등록/수정/삭제
- `src/main/java/com/foru/freebe/profile/service/PhotographerProfileService.java` 프로필이미지, 배너이미지 등록/수정/삭제