### PR TITLE
[FU-249] Kakao OAuth 연결 끊기(회원 탈퇴) API 구현

### DIFF
--- a/src/main/java/com/foru/freebe/auth/controller/AuthController.java
+++ b/src/main/java/com/foru/freebe/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.foru.freebe.auth.controller;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -10,11 +11,14 @@ import org.springframework.web.bind.annotation.RestController;
 import com.foru.freebe.auth.dto.LoginRequest;
 import com.foru.freebe.auth.dto.LoginResponse;
 import com.foru.freebe.auth.model.KakaoUser;
+import com.foru.freebe.auth.model.MemberAdapter;
 import com.foru.freebe.auth.service.KakaoAuthService;
 import com.foru.freebe.auth.service.KakaoLoginService;
+import com.foru.freebe.auth.service.KakaoUnlinkService;
 import com.foru.freebe.common.dto.ResponseBody;
 import com.foru.freebe.jwt.model.JwtTokenModel;
 import com.foru.freebe.jwt.service.JwtService;
+import com.foru.freebe.member.entity.Member;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +29,7 @@ public class AuthController {
     private final JwtService jwtService;
     private final KakaoAuthService kakaoAuthService;
     private final KakaoLoginService kakaoLoginService;
+    private final KakaoUnlinkService kakaoUnlinkService;
 
     @PostMapping("/login")
     public ResponseEntity<ResponseBody<?>> login(@RequestBody LoginRequest loginRequest) {
@@ -57,5 +62,20 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.OK.value())
             .headers(headers)
             .body(null);
+    }
+
+    @PostMapping("/unlink")
+    public ResponseEntity<ResponseBody<Void>> unlinkKakao(@AuthenticationPrincipal MemberAdapter memberAdapter) {
+
+        Member member = memberAdapter.getMember();
+        kakaoUnlinkService.unlinkKakaoAccount(member.getId());
+
+        ResponseBody<Void> responseBody = ResponseBody.<Void>builder()
+            .message("Successfully delete member")
+            .data(null)
+            .build();
+
+        return ResponseEntity.status(HttpStatus.CREATED.value())
+            .body(responseBody);
     }
 }

--- a/src/main/java/com/foru/freebe/auth/controller/AuthController.java
+++ b/src/main/java/com/foru/freebe/auth/controller/AuthController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.foru.freebe.auth.dto.LoginRequest;
 import com.foru.freebe.auth.dto.LoginResponse;
+import com.foru.freebe.auth.dto.UnlinkRequest;
 import com.foru.freebe.auth.model.KakaoUser;
 import com.foru.freebe.auth.model.MemberAdapter;
 import com.foru.freebe.auth.service.KakaoAuthService;
@@ -21,6 +22,7 @@ import com.foru.freebe.jwt.service.JwtService;
 import com.foru.freebe.member.entity.Member;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -65,10 +67,11 @@ public class AuthController {
     }
 
     @PostMapping("/unlink")
-    public ResponseEntity<ResponseBody<Void>> unlinkKakao(@AuthenticationPrincipal MemberAdapter memberAdapter) {
+    public ResponseEntity<ResponseBody<Void>> unlinkKakao(@Valid @RequestBody UnlinkRequest request,
+        @AuthenticationPrincipal MemberAdapter memberAdapter) {
 
         Member member = memberAdapter.getMember();
-        kakaoUnlinkService.unlinkKakaoAccount(member.getId());
+        kakaoUnlinkService.unlinkKakaoAccount(member.getId(), request);
 
         ResponseBody<Void> responseBody = ResponseBody.<Void>builder()
             .message("Successfully delete member")

--- a/src/main/java/com/foru/freebe/auth/dto/UnlinkRequest.java
+++ b/src/main/java/com/foru/freebe/auth/dto/UnlinkRequest.java
@@ -1,0 +1,12 @@
+package com.foru.freebe.auth.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UnlinkRequest {
+    @NotNull
+    private String reason;
+}

--- a/src/main/java/com/foru/freebe/auth/service/KakaoUnlinkService.java
+++ b/src/main/java/com/foru/freebe/auth/service/KakaoUnlinkService.java
@@ -13,7 +13,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientException;
 
 import com.foru.freebe.auth.dto.UnlinkRequest;
-import com.foru.freebe.errors.errorcode.AuthErrorCode;
 import com.foru.freebe.errors.errorcode.MemberErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
 import com.foru.freebe.member.entity.DeletedMember;
@@ -51,8 +50,6 @@ public class KakaoUnlinkService {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        validateUnlinkReason(unlinkRequest);
-
         Long kakaoUserId = member.getKakaoId();
         try {
             ResponseEntity<String> response = webClient.post()
@@ -71,12 +68,6 @@ public class KakaoUnlinkService {
             }
         } catch (WebClientException e) {
             throw new RestApiException(MemberErrorCode.ERROR_MEMBER_LEAVING_FAILED);
-        }
-    }
-
-    private static void validateUnlinkReason(UnlinkRequest unlinkRequest) {
-        if (unlinkRequest.getReason() == null) {
-            throw new RestApiException(AuthErrorCode.NO_UNLINK_REASON);
         }
     }
 

--- a/src/main/java/com/foru/freebe/auth/service/KakaoUnlinkService.java
+++ b/src/main/java/com/foru/freebe/auth/service/KakaoUnlinkService.java
@@ -38,10 +38,10 @@ public class KakaoUnlinkService {
     private final ProfileService profileService;
     private final DeletedMemberRepository deletedMemberRepository;
 
-    public KakaoUnlinkService(RestTemplateBuilder builder, MemberRepository memberRepository,
+    public KakaoUnlinkService(RestTemplateBuilder restTemplateBuilder, MemberRepository memberRepository,
         ProductRepository productRepository, PhotographerProductService photographerProductService,
         ProfileService profileService, DeletedMemberRepository deletedMemberRepository) {
-        restTemplate = builder.build();
+        restTemplate = restTemplateBuilder.build();
         this.memberRepository = memberRepository;
         this.productRepository = productRepository;
         this.photographerProductService = photographerProductService;

--- a/src/main/java/com/foru/freebe/auth/service/KakaoUnlinkService.java
+++ b/src/main/java/com/foru/freebe/auth/service/KakaoUnlinkService.java
@@ -45,6 +45,7 @@ public class KakaoUnlinkService {
     public void unlinkKakaoAccount(Long memberId, UnlinkRequest unlinkRequest) {
         final String AUTHORIZATION_HEADER = "Authorization";
         final String KAKAO_AUTH_PREFIX = "KakaoAK ";
+        final String kakaoUnlinkUrl = "https://kapi.kakao.com/v1/user/unlink";
 
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
@@ -52,8 +53,6 @@ public class KakaoUnlinkService {
         Long kakaoUserId = member.getKakaoId();
 
         try {
-            String kakaoUnlinkUrl = "https://kapi.kakao.com/v1/user/unlink";
-
             ResponseEntity<String> response = webClient.post()
                 .uri(kakaoUnlinkUrl)
                 .header(AUTHORIZATION_HEADER, KAKAO_AUTH_PREFIX + adminKey)

--- a/src/main/java/com/foru/freebe/auth/service/KakaoUnlinkService.java
+++ b/src/main/java/com/foru/freebe/auth/service/KakaoUnlinkService.java
@@ -88,6 +88,7 @@ public class KakaoUnlinkService {
             profileService.deleteProfile(member);
         } else if (member.getRole() == Role.PHOTOGRAPHER_PENDING) {
             member.updateMemberRoleToLeavingStatus();
+            createDeletedMember(member.getId(), member, reason);
         } else if (member.getRole() == Role.CUSTOMER) {
             member.updateMemberRoleToLeavingStatus();
             createDeletedMember(member.getId(), member, reason);

--- a/src/main/java/com/foru/freebe/auth/service/KakaoUnlinkService.java
+++ b/src/main/java/com/foru/freebe/auth/service/KakaoUnlinkService.java
@@ -23,7 +23,7 @@ import com.foru.freebe.member.repository.MemberRepository;
 import com.foru.freebe.product.entity.Product;
 import com.foru.freebe.product.respository.ProductRepository;
 import com.foru.freebe.product.service.PhotographerProductService;
-import com.foru.freebe.profile.service.ProfileService;
+import com.foru.freebe.profile.service.PhotographerProfileService;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -35,7 +35,7 @@ public class KakaoUnlinkService {
     private final MemberRepository memberRepository;
     private final ProductRepository productRepository;
     private final PhotographerProductService photographerProductService;
-    private final ProfileService profileService;
+    private final PhotographerProfileService photographerProfileService;
     private final DeletedMemberRepository deletedMemberRepository;
 
     @Value("${KAKAO_API_ADMIN_KEY}")
@@ -84,7 +84,7 @@ public class KakaoUnlinkService {
             member.updateMemberRoleToLeavingStatus();
             createDeletedMember(member.getId(), member, reason);
             deletePhotographerProducts(member);
-            profileService.deleteProfile(member);
+            photographerProfileService.deleteProfile(member);
         } else if (member.getRole() == Role.PHOTOGRAPHER_PENDING) {
             member.updateMemberRoleToLeavingStatus();
             createDeletedMember(member.getId(), member, reason);

--- a/src/main/java/com/foru/freebe/auth/service/KakaoUnlinkService.java
+++ b/src/main/java/com/foru/freebe/auth/service/KakaoUnlinkService.java
@@ -65,6 +65,8 @@ public class KakaoUnlinkService {
 
             if (response != null && response.getStatusCode() == HttpStatus.OK) {
                 handleMemberLeaving(member, unlinkRequest.getReason());
+            } else if (response != null && response.getStatusCode() != HttpStatus.OK) {
+                throw new RestApiException(MemberErrorCode.ERROR_MEMBER_LEAVING_FAILED);
             }
         } catch (WebClientException e) {
             throw new RestApiException(MemberErrorCode.ERROR_MEMBER_LEAVING_FAILED);

--- a/src/main/java/com/foru/freebe/auth/service/KakaoUnlinkService.java
+++ b/src/main/java/com/foru/freebe/auth/service/KakaoUnlinkService.java
@@ -17,7 +17,6 @@ import org.springframework.web.client.RestTemplate;
 
 import com.foru.freebe.errors.errorcode.MemberErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
-import com.foru.freebe.jwt.repository.JwtTokenRepository;
 import com.foru.freebe.member.entity.DeletedMember;
 import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.member.entity.Role;
@@ -33,38 +32,33 @@ import jakarta.transaction.Transactional;
 @Service
 public class KakaoUnlinkService {
     private final RestTemplate restTemplate;
-    private final MemberRepository memberRepository; // 회원 정보를 저장하는 Repository
+    private final MemberRepository memberRepository;
     private final ProductRepository productRepository;
     private final PhotographerProductService photographerProductService;
     private final ProfileService profileService;
     private final DeletedMemberRepository deletedMemberRepository;
-    private final JwtTokenRepository jwtTokenRepository;
 
     public KakaoUnlinkService(RestTemplateBuilder builder, MemberRepository memberRepository,
         ProductRepository productRepository, PhotographerProductService photographerProductService,
-        ProfileService profileService, DeletedMemberRepository deletedMemberRepository,
-        JwtTokenRepository jwtTokenRepository) {
+        ProfileService profileService, DeletedMemberRepository deletedMemberRepository) {
         restTemplate = builder.build();
         this.memberRepository = memberRepository;
         this.productRepository = productRepository;
         this.photographerProductService = photographerProductService;
         this.profileService = profileService;
         this.deletedMemberRepository = deletedMemberRepository;
-        this.jwtTokenRepository = jwtTokenRepository;
     }
 
     @Value("${KAKAO_API_ADMIN_KEY}")
-    private String adminKey; // 카카오 디벨로퍼스에서 발급받은 Admin Key
+    private String adminKey;
 
     @Transactional
     public void unlinkKakaoAccount(Long memberId) {
-        // 회원 정보에서 카카오 userId 조회
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         Long kakaoUserId = member.getKakaoId(); // 회원의 카카오 유저 ID
 
-        // 카카오 API에 보낼 헤더 및 파라미터 설정
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         headers.set("Authorization", "KakaoAK " + adminKey);

--- a/src/main/java/com/foru/freebe/auth/service/KakaoUnlinkService.java
+++ b/src/main/java/com/foru/freebe/auth/service/KakaoUnlinkService.java
@@ -13,6 +13,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientException;
 
 import com.foru.freebe.auth.dto.UnlinkRequest;
+import com.foru.freebe.errors.errorcode.AuthErrorCode;
 import com.foru.freebe.errors.errorcode.MemberErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
 import com.foru.freebe.member.entity.DeletedMember;
@@ -50,8 +51,9 @@ public class KakaoUnlinkService {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        Long kakaoUserId = member.getKakaoId();
+        validateUnlinkReason(unlinkRequest);
 
+        Long kakaoUserId = member.getKakaoId();
         try {
             ResponseEntity<String> response = webClient.post()
                 .uri(kakaoUnlinkUrl)
@@ -69,6 +71,12 @@ public class KakaoUnlinkService {
             }
         } catch (WebClientException e) {
             throw new RestApiException(MemberErrorCode.ERROR_MEMBER_LEAVING_FAILED);
+        }
+    }
+
+    private static void validateUnlinkReason(UnlinkRequest unlinkRequest) {
+        if (unlinkRequest.getReason() == null) {
+            throw new RestApiException(AuthErrorCode.NO_UNLINK_REASON);
         }
     }
 

--- a/src/main/java/com/foru/freebe/auth/service/KakaoUnlinkService.java
+++ b/src/main/java/com/foru/freebe/auth/service/KakaoUnlinkService.java
@@ -82,12 +82,14 @@ public class KakaoUnlinkService {
 
     private void handleMemberLeaving(Member member, String reason) {
         if (member.getRole() == Role.PHOTOGRAPHER) {
-            member.updateMemberRole(Role.PHOTOGRAPHER_LEAVING);
+            member.updateMemberRoleToLeavingStatus();
             createDeletedMember(member.getId(), member, reason);
             deletePhotographerProducts(member);
             profileService.deleteProfile(member);
+        } else if (member.getRole() == Role.PHOTOGRAPHER_PENDING) {
+            member.updateMemberRoleToLeavingStatus();
         } else if (member.getRole() == Role.CUSTOMER) {
-            member.updateMemberRole(Role.CUSTOMER_LEAVING);
+            member.updateMemberRoleToLeavingStatus();
             createDeletedMember(member.getId(), member, reason);
         }
     }

--- a/src/main/java/com/foru/freebe/auth/service/KakaoUnlinkService.java
+++ b/src/main/java/com/foru/freebe/auth/service/KakaoUnlinkService.java
@@ -1,0 +1,117 @@
+package com.foru.freebe.auth.service;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import com.foru.freebe.errors.errorcode.MemberErrorCode;
+import com.foru.freebe.errors.exception.RestApiException;
+import com.foru.freebe.jwt.repository.JwtTokenRepository;
+import com.foru.freebe.member.entity.DeletedMember;
+import com.foru.freebe.member.entity.Member;
+import com.foru.freebe.member.entity.Role;
+import com.foru.freebe.member.repository.DeletedMemberRepository;
+import com.foru.freebe.member.repository.MemberRepository;
+import com.foru.freebe.product.entity.Product;
+import com.foru.freebe.product.respository.ProductRepository;
+import com.foru.freebe.product.service.PhotographerProductService;
+import com.foru.freebe.profile.service.ProfileService;
+
+import jakarta.transaction.Transactional;
+
+@Service
+public class KakaoUnlinkService {
+    private final RestTemplate restTemplate;
+    private final MemberRepository memberRepository; // 회원 정보를 저장하는 Repository
+    private final ProductRepository productRepository;
+    private final PhotographerProductService photographerProductService;
+    private final ProfileService profileService;
+    private final DeletedMemberRepository deletedMemberRepository;
+    private final JwtTokenRepository jwtTokenRepository;
+
+    public KakaoUnlinkService(RestTemplateBuilder builder, MemberRepository memberRepository,
+        ProductRepository productRepository, PhotographerProductService photographerProductService,
+        ProfileService profileService, DeletedMemberRepository deletedMemberRepository,
+        JwtTokenRepository jwtTokenRepository) {
+        restTemplate = builder.build();
+        this.memberRepository = memberRepository;
+        this.productRepository = productRepository;
+        this.photographerProductService = photographerProductService;
+        this.profileService = profileService;
+        this.deletedMemberRepository = deletedMemberRepository;
+        this.jwtTokenRepository = jwtTokenRepository;
+    }
+
+    @Value("${KAKAO_API_ADMIN_KEY}")
+    private String adminKey; // 카카오 디벨로퍼스에서 발급받은 Admin Key
+
+    @Transactional
+    public void unlinkKakaoAccount(Long memberId) {
+        // 회원 정보에서 카카오 userId 조회
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        Long kakaoUserId = member.getKakaoId(); // 회원의 카카오 유저 ID
+
+        // 카카오 API에 보낼 헤더 및 파라미터 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set("Authorization", "KakaoAK " + adminKey);
+
+        MultiValueMap<String, Object> params = new LinkedMultiValueMap<>();
+        params.add("target_id_type", "user_id");
+        params.add("target_id", kakaoUserId);
+
+        HttpEntity<MultiValueMap<String, Object>> request = new HttpEntity<>(params, headers);
+
+        try {
+            String kakaoUnlinkUrl = "https://kapi.kakao.com/v1/user/unlink";
+            ResponseEntity<String> response = restTemplate.postForEntity(kakaoUnlinkUrl, request, String.class);
+
+            if (response.getStatusCode() == HttpStatus.OK) {
+                handleMemberLeaving(member);
+            }
+        } catch (RestClientException e) {
+            throw new RestApiException(MemberErrorCode.ERROR_MEMBER_LEAVING_FAILED);
+        }
+    }
+
+    private void handleMemberLeaving(Member member) {
+        if (member.getRole() == Role.PHOTOGRAPHER) {
+            member.updateMemberRole(Role.PHOTOGRAPHER_LEAVING);
+            createDeletedMember(member.getId(), member);
+            deletePhotographerProducts(member.getId(), member);
+            profileService.deleteProfile(member);
+        } else if (member.getRole() == Role.CUSTOMER) {
+            member.updateMemberRole(Role.CUSTOMER_LEAVING);
+            createDeletedMember(member.getId(), member);
+        }
+    }
+
+    private void deletePhotographerProducts(Long memberId, Member member) {
+        List<Product> productList = productRepository.findByMember(member);
+        for (Product product : productList) {
+            photographerProductService.deleteProduct(product.getId(), memberId);
+        }
+    }
+
+    private void createDeletedMember(Long memberId, Member member) {
+        DeletedMember deletedMember = DeletedMember.builder()
+            .kakaoId(member.getKakaoId())
+            .memberId(memberId)
+            .build();
+        deletedMemberRepository.save(deletedMember);
+        member.deleteKakaoId();
+    }
+}

--- a/src/main/java/com/foru/freebe/errors/errorcode/AuthErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/AuthErrorCode.java
@@ -1,0 +1,14 @@
+package com.foru.freebe.errors.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+
+    NO_UNLINK_REASON(400, "Reason for leaving is essential");
+
+    private final int httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/foru/freebe/errors/errorcode/MemberErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/MemberErrorCode.java
@@ -1,0 +1,15 @@
+package com.foru.freebe.errors.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberErrorCode implements ErrorCode {
+
+    MEMBER_NOT_FOUND(400, "Member not found"),
+    ERROR_MEMBER_LEAVING_FAILED(500, "Failed to complete the membership leaving. Please try again later.");
+
+    private final int httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/foru/freebe/member/entity/DeletedMember.java
+++ b/src/main/java/com/foru/freebe/member/entity/DeletedMember.java
@@ -28,9 +28,13 @@ public class DeletedMember extends BaseEntity {
     @NotNull
     private Long memberId;
 
+    @NotNull
+    private String unlinkReason;
+
     @Builder
-    public DeletedMember(Long kakaoId, Long memberId) {
+    public DeletedMember(Long kakaoId, Long memberId, String unlinkReason) {
         this.kakaoId = kakaoId;
         this.memberId = memberId;
+        this.unlinkReason = unlinkReason;
     }
 }

--- a/src/main/java/com/foru/freebe/member/entity/DeletedMember.java
+++ b/src/main/java/com/foru/freebe/member/entity/DeletedMember.java
@@ -1,0 +1,36 @@
+package com.foru.freebe.member.entity;
+
+import com.foru.freebe.common.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class DeletedMember extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "deleted_member_id")
+    private Long id;
+
+    @NotNull
+    private Long kakaoId;
+
+    @NotNull
+    private Long memberId;
+
+    @Builder
+    public DeletedMember(Long kakaoId, Long memberId) {
+        this.kakaoId = kakaoId;
+        this.memberId = memberId;
+    }
+}

--- a/src/main/java/com/foru/freebe/member/entity/Member.java
+++ b/src/main/java/com/foru/freebe/member/entity/Member.java
@@ -61,8 +61,8 @@ public class Member extends BaseEntity {
         return "ROLE_" + role.name();
     }
 
-    public void updateMemberRole(Role updateRole) {
-        this.role = updateRole;
+    public void updateMemberRoleToLeavingStatus() {
+        this.role = Role.LEAVING;
     }
 
     public void deleteKakaoId() {

--- a/src/main/java/com/foru/freebe/member/entity/Member.java
+++ b/src/main/java/com/foru/freebe/member/entity/Member.java
@@ -27,7 +27,6 @@ public class Member extends BaseEntity {
     @Column(name = "member_id")
     private Long id;
 
-    @NotNull
     private Long kakaoId;
 
     @Enumerated(EnumType.STRING)
@@ -60,6 +59,14 @@ public class Member extends BaseEntity {
 
     public String getAuthority() {
         return "ROLE_" + role.name();
+    }
+
+    public void updateMemberRole(Role updateRole) {
+        this.role = updateRole;
+    }
+
+    public void deleteKakaoId() {
+        this.kakaoId = null;
     }
 
     @Builder

--- a/src/main/java/com/foru/freebe/member/entity/Role.java
+++ b/src/main/java/com/foru/freebe/member/entity/Role.java
@@ -12,7 +12,9 @@ public enum Role {
     PHOTOGRAPHER_PENDING,
     @JsonProperty("PHOTOGRAPHER")
     PHOTOGRAPHER,
+    PHOTOGRAPHER_LEAVING,
     @JsonProperty("CUSTOMER")
     CUSTOMER,
+    CUSTOMER_LEAVING,
     ADMIN
 }

--- a/src/main/java/com/foru/freebe/member/entity/Role.java
+++ b/src/main/java/com/foru/freebe/member/entity/Role.java
@@ -12,9 +12,8 @@ public enum Role {
     PHOTOGRAPHER_PENDING,
     @JsonProperty("PHOTOGRAPHER")
     PHOTOGRAPHER,
-    PHOTOGRAPHER_LEAVING,
     @JsonProperty("CUSTOMER")
     CUSTOMER,
-    CUSTOMER_LEAVING,
+    LEAVING,
     ADMIN
 }

--- a/src/main/java/com/foru/freebe/member/repository/DeletedMemberRepository.java
+++ b/src/main/java/com/foru/freebe/member/repository/DeletedMemberRepository.java
@@ -1,0 +1,8 @@
+package com.foru.freebe.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.foru.freebe.member.entity.DeletedMember;
+
+public interface DeletedMemberRepository extends JpaRepository<DeletedMember, Long> {
+}

--- a/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
@@ -136,6 +136,30 @@ public class PhotographerProductService {
         updateProductCompositionExcludingImage(updateProductDetailRequest, product);
     }
 
+    @Transactional
+    public void deleteProduct(Long productId, Long photographerId) {
+        Member photographer = getMember(photographerId);
+
+        Product product = productRepository.findByIdAndMember(productId, photographer)
+            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+
+        List<ProductImage> productImages = productImageRepository.findByProduct(product);
+        for (ProductImage productImage : productImages) {
+            String originUrl = productImage.getOriginUrl();
+            String thumbnailUrl = productImage.getThumbnailUrl();
+
+            s3ImageService.deleteImageFromS3(originUrl);
+            s3ImageService.deleteImageFromS3(thumbnailUrl);
+        }
+
+        productImageRepository.deleteByProduct(product);
+        productComponentRepository.deleteByProduct(product);
+        productOptionRepository.deleteByProduct(product);
+        productDiscountRepository.deleteByProduct(product);
+
+        productRepository.delete(product);
+    }
+
     private void updateProductCompositionExcludingImage(UpdateProductDetailRequest updateProductDetailRequest,
         Product product) {
         List<ProductComponent> productComponents = productComponentRepository.findByProduct(product);
@@ -192,30 +216,6 @@ public class PhotographerProductService {
         ProductImage updateProductImage = ProductImage.createProductImage(thumbnailUrl, originUrl, product);
         productImageRepository.save(updateProductImage);
         productImageRepository.deleteById(oldImageId);
-    }
-
-    @Transactional
-    public void deleteProduct(Long productId, Long photographerId) {
-        Member photographer = getMember(photographerId);
-
-        Product product = productRepository.findByIdAndMember(productId, photographer)
-            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
-
-        List<ProductImage> productImages = productImageRepository.findByProduct(product);
-        for (ProductImage productImage : productImages) {
-            String originUrl = productImage.getOriginUrl();
-            String thumbnailUrl = productImage.getThumbnailUrl();
-
-            s3ImageService.deleteImageFromS3(originUrl);
-            s3ImageService.deleteImageFromS3(thumbnailUrl);
-        }
-
-        productImageRepository.deleteByProduct(product);
-        productComponentRepository.deleteByProduct(product);
-        productOptionRepository.deleteByProduct(product);
-        productDiscountRepository.deleteByProduct(product);
-
-        productRepository.delete(product);
     }
 
     private void updateProductDiscount(UpdateProductDetailRequest updateProductDetailRequest,

--- a/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
@@ -154,6 +154,15 @@ public class PhotographerProductService {
         Product product = productRepository.findByIdAndMember(productId, photographer)
             .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
 
+        deleteEntityAboutProduct(product);
+    }
+
+    @Transactional
+    public void deleteProductForUnlike(Product product) {
+        deleteEntityAboutProduct(product);
+    }
+
+    private void deleteEntityAboutProduct(Product product) {
         List<ProductImage> productImages = productImageRepository.findByProduct(product);
         for (ProductImage productImage : productImages) {
             String originUrl = productImage.getOriginUrl();

--- a/src/main/java/com/foru/freebe/profile/service/PhotographerProfileService.java
+++ b/src/main/java/com/foru/freebe/profile/service/PhotographerProfileService.java
@@ -18,6 +18,7 @@ import com.foru.freebe.profile.entity.Profile;
 import com.foru.freebe.profile.entity.ProfileImage;
 import com.foru.freebe.profile.repository.LinkRepository;
 import com.foru.freebe.profile.repository.ProfileImageRepository;
+import com.foru.freebe.profile.repository.ProfileRepository;
 import com.foru.freebe.s3.S3ImageService;
 import com.foru.freebe.s3.S3ImageType;
 
@@ -28,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PhotographerProfileService {
     private final ProfileService profileService;
+    private final ProfileRepository profileRepository;
     private final S3ImageService s3ImageService;
     private final ProfileImageRepository profileImageRepository;
     private final LinkRepository linkRepository;
@@ -50,6 +52,37 @@ public class PhotographerProfileService {
         updateLinks(profile, request.getLinkInfos());
         updateBannerImage(photographer.getId(), request.getExistingBannerImageUrl(), bannerImageFile, profileImage);
         updateProfileImage(photographer.getId(), request.getExistingProfileImageUrl(), profileImageFile, profileImage);
+    }
+
+    @Transactional
+    public void deleteProfile(Member photographer) {
+        Profile profile = profileService.getProfile(photographer);
+        deleteLinks(profile);
+        deleteProfileImage(profile);
+        profileRepository.delete(profile);
+    }
+
+    private void deleteLinks(Profile profile) {
+        List<Link> links = linkRepository.findByProfile(profile);
+        linkRepository.deleteAll(links);
+    }
+
+    private void deleteProfileImage(Profile profile) {
+        ProfileImage profileImage = profileImageRepository.findByProfile(profile)
+            .orElse(null);
+
+        if (profileImage != null) {
+            deleteImageFromS3(profileImage);
+            profileImageRepository.delete(profileImage);
+        }
+    }
+
+    private void deleteImageFromS3(ProfileImage profileImage) {
+        if (profileImage.getProfileOriginUrl() != null) {
+            s3ImageService.deleteImageFromS3(profileImage.getProfileOriginUrl());
+        } else if (profileImage.getBannerOriginUrl() != null) {
+            s3ImageService.deleteImageFromS3(profileImage.getBannerOriginUrl());
+        }
     }
 
     private ProfileImage createProfileImageIfNotExists(Profile photographerProfile) {

--- a/src/main/java/com/foru/freebe/profile/service/PhotographerProfileService.java
+++ b/src/main/java/com/foru/freebe/profile/service/PhotographerProfileService.java
@@ -46,7 +46,7 @@ public class PhotographerProfileService {
         Profile profile = profileService.getProfile(photographer);
         ProfileImage profileImage = createProfileImageIfNotExists(profile);
 
-        validateDuplicates(request.getLinkInfos());
+        validateLinkTitleDuplicate(request.getLinkInfos());
 
         updateIntroductionContent(profile, request.getIntroductionContent());
         updateLinks(profile, request.getLinkInfos());
@@ -96,7 +96,7 @@ public class PhotographerProfileService {
         }
     }
 
-    private void validateDuplicates(List<LinkInfo> linkInfos) {
+    private void validateLinkTitleDuplicate(List<LinkInfo> linkInfos) {
         boolean isDuplicatedTitle = linkInfos.size() != linkInfos.stream()
             .map(LinkInfo::getLinkTitle)
             .distinct()

--- a/src/main/java/com/foru/freebe/reservation/repository/ReservationFormRepository.java
+++ b/src/main/java/com/foru/freebe/reservation/repository/ReservationFormRepository.java
@@ -12,7 +12,7 @@ import com.foru.freebe.reservation.entity.ReservationForm;
 import com.foru.freebe.reservation.entity.ReservationStatus;
 
 public interface ReservationFormRepository extends JpaRepository<ReservationForm, Long> {
-    Optional<List<ReservationForm>> findAllByPhotographerId(Long photographerId);
+    List<ReservationForm> findAllByPhotographerId(Long photographerId);
 
     Optional<ReservationForm> findByPhotographerIdAndId(Long photographerId, Long id);
 

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
@@ -1,6 +1,5 @@
 package com.foru.freebe.reservation.service;
 
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -27,8 +26,7 @@ public class PhotographerReservationService {
     }
 
     private List<FormListViewResponse> getReservationListAsStatus(Long id) {
-        List<ReservationForm> formList = reservationFormRepository.findAllByPhotographerId(id)
-            .orElseGet(ArrayList::new);
+        List<ReservationForm> formList = reservationFormRepository.findAllByPhotographerId(id);
 
         Map<ReservationStatus, List<FormComponent>> reservationStatusMap = groupingFormAsStatus(formList);
 


### PR DESCRIPTION
## 체크리스트

- ✅ 불필요한 주석 처리가 없는가?

## 작업 내역
- Kakao developers에서 제공하는 API 호출을 통해 카카오 OAuth와 연동되어 있는 것을 해제
- 재가입 시 KakaoId 충돌 문제로 인해 기존 Member Entity에서의 KakaoId는 null값으로 업데이트 후, 백업 entity인 DeletedMember에 백업 로직 구현
- 탈퇴하고자 하는 사용자가 사진작가의 경우 profile, product 관련 모든 엔티티 삭제 및 S3에 업로드 된 사진파일 삭제
- 탈퇴하고자 하는 사용자가 사진의뢰자의 경우 백업만 진행

## 고민한 사항
- 테스트 코드에서 에러를 잡을 수 없었지만 API 테스트는 통과했기 때문에 PR을 올렸습니다..! 추후 리팩터링된 코드에 대한 테스트코드 작성 티켓에서 같이 진행하도록 할게요🥲

## 리뷰 요청사항
- 시급도는 보통입니다. 유진이가 회원 탈퇴 쪽 구현하기 전까지 해주면 될 것 같습니다!
- KakaoUnlinkService 클래스 리뷰해주시면 됩니다~!
