### PR TITLE
[FU-254] 카카오 로그인 배포용 애플리케이션 설정

### DIFF
--- a/src/main/java/com/foru/freebe/auth/model/KakaoUser.java
+++ b/src/main/java/com/foru/freebe/auth/model/KakaoUser.java
@@ -33,8 +33,12 @@ public class KakaoUser {
         return "0" + phoneNumber.replace("+82 ", "");
     }
 
-    public Integer getBirthYear() {
-        return (Integer)kakaoAccount.get("birth_year");
+    public String getBirthYear() {
+        return (String)kakaoAccount.get("birthyear");
+    }
+
+    public String getBirthDay() {
+        return (String)kakaoAccount.get("birthday");
     }
 
     public String getGender() {

--- a/src/main/java/com/foru/freebe/auth/service/KakaoAuthService.java
+++ b/src/main/java/com/foru/freebe/auth/service/KakaoAuthService.java
@@ -44,7 +44,7 @@ public class KakaoAuthService {
             .uri(uriBuilder -> uriBuilder
                 .path("v2/user/me")
                 .queryParam("property_keys",
-                    "[\"kakao_account.email\", \"kakao_account.name\", \"kakao_account.birthday\", \"kakao_account.birthyear\", \"kakao_account.phone_number\"]")
+                    "[\"kakao_account.email\", \"kakao_account.name\", \"kakao_account.birthday\", \"kakao_account.birthyear\", \"kakao_account.phone_number\", \"kakao_account.gender\"]")
                 .build()
             )
             .retrieve()

--- a/src/main/java/com/foru/freebe/auth/service/KakaoLoginService.java
+++ b/src/main/java/com/foru/freebe/auth/service/KakaoLoginService.java
@@ -60,7 +60,8 @@ public class KakaoLoginService {
     private Member registerNewMember(KakaoUser kakaoUser, Role role) {
         Member newMember = Member.builder(kakaoUser.getKakaoId(), role, kakaoUser.getUserName(),
                 kakaoUser.getEmail(), kakaoUser.getPhoneNumber())
-            .birthyear(kakaoUser.getBirthYear())
+            .birthYear(kakaoUser.getBirthYear())
+            .birthDay(kakaoUser.getBirthDay())
             .gender(kakaoUser.getGender())
             .build();
         return memberRepository.save(newMember);

--- a/src/main/java/com/foru/freebe/member/entity/Member.java
+++ b/src/main/java/com/foru/freebe/member/entity/Member.java
@@ -44,7 +44,9 @@ public class Member extends BaseEntity {
     @NotBlank
     private String phoneNumber;
 
-    private Integer birthYear;
+    private String birthYear;
+
+    private String birthDay;
 
     private String gender;
 
@@ -63,14 +65,15 @@ public class Member extends BaseEntity {
     }
 
     @Builder
-    public Member(Long kakaoId, Role role, String name, String email, String phoneNumber, Integer birthyear,
-        String gender, String instagramId) {
+    public Member(Long kakaoId, Role role, String name, String email, String phoneNumber, String birthYear,
+        String birthDay, String gender, String instagramId) {
         this.kakaoId = kakaoId;
         this.role = role;
         this.name = name;
         this.email = email;
         this.phoneNumber = phoneNumber;
-        this.birthYear = birthyear;
+        this.birthYear = birthYear;
+        this.birthDay = birthDay;
         this.gender = gender;
         this.instagramId = instagramId;
     }


### PR DESCRIPTION
## 체크리스트

- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
1. 그동안 개발 단계에서 카카오 로그인을 테스트용 애플리케이션으로 사용하고 있던 것을 배포용 애플리케이션으로 바꾸기 위해 환경변수 세팅을 완료했습니다. (커밋 이력은 따로 없음)
2. 카카오 로그인 시 선택적 동의로 생년월일, 성별 데이터를 받아올 수 있게끔 코드 보완했습니다.

## 고민한 사항
- 얼마 전 카카오 디벨로퍼스에 개인정보 동의항목 심사 신청 시, 만 14세 이상인지 여부를 자체적으로 판단하기 위해 `생년월일`을 필수 항목으로 하고 개인정보 처리방침 약관에도 생년월일을 필수로 구분했었습니다. 하지만 카카오 배포용 애플리케이션 설정 중에 `간편가입` 기능 활성화를 통해 서비스 약관 동의와 만 14세 이상 연령 동의를 필수로 받을 수 있도록 설정할 수 있음을 알게 되었습니다 🤓
- 따라서 개인정보 처리방침에 생년월일은 `선택적 수집항목`으로 재분류하고 로그인 시점에도 생년월일을 선택항목으로 재설정하게 되었습니다! 
- 사진작가측 회원가입 페이지에서도 만 14세 이상인지 여부를 별도로 체크하도록 하지 않아도 괜찮을 거 같습니다 🙇‍♀️
<img width="904" alt="image" src="https://github.com/user-attachments/assets/4f5b89fa-b18b-439e-8790-acc545c285b8">


## 리뷰 요청사항
(시급도) 높음. 프론트엔드에서도 PR에 관련 설정 반영했기 때문에 동시에 병합되어야 할 것 같습니당