### PR TITLE
[FU-274] 외부링크 업데이트 로직 추가 구현

### DIFF
--- a/src/main/java/com/foru/freebe/auth/service/KakaoLoginService.java
+++ b/src/main/java/com/foru/freebe/auth/service/KakaoLoginService.java
@@ -82,6 +82,7 @@ public class KakaoLoginService {
                 .profileName(null);
         }
         throw new RestApiException(MemberErrorCode.INVALID_LOGIN_REQUEST);
+    }
 
     private Member registerNewMember(KakaoUser kakaoUser, Role role) {
         Member newMember = Member.builder(kakaoUser.getKakaoId(), role, kakaoUser.getUserName(),

--- a/src/main/java/com/foru/freebe/errors/errorcode/LinkErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/LinkErrorCode.java
@@ -1,0 +1,15 @@
+package com.foru.freebe.errors.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum LinkErrorCode implements ErrorCode {
+
+    DUPLICATE_TITLE(400, "Title is duplicated"),
+    DUPLICATE_URL(400, "Url is duplicated");
+
+    private final int httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/foru/freebe/errors/errorcode/LinkErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/LinkErrorCode.java
@@ -7,8 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum LinkErrorCode implements ErrorCode {
 
-    DUPLICATE_TITLE(400, "Title is duplicated"),
-    DUPLICATE_URL(400, "Url is duplicated");
+    DUPLICATE_TITLE(400, "Title is duplicated");
 
     private final int httpStatus;
     private final String message;

--- a/src/main/java/com/foru/freebe/errors/errorcode/ProductErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/ProductErrorCode.java
@@ -11,7 +11,7 @@ public enum ProductErrorCode implements ErrorCode {
     PRODUCT_ALREADY_EXISTS(400, "The product already exists, so it cannot be registered again"),
     COMPONENT_TITLE_ALREADY_EXISTS(400, "Component title already exists, so it cannot be registered again"),
     INVALID_FILE_NAME(400, "The url or filename in the json file is incorrect"),
-    INVALID_PRODUCT_TITLE(400, "The product title is incorrect");
+    INVALID_PRODUCT_TITLE(400, "The product title is incorrect"),
     PRODUCT_NOT_FOUND(404, "The product could not be found");
 
     private final int httpStatus;

--- a/src/main/java/com/foru/freebe/profile/entity/Link.java
+++ b/src/main/java/com/foru/freebe/profile/entity/Link.java
@@ -26,16 +26,24 @@ public class Link {
     @JoinColumn(name = "profile_id")
     private Profile profile;
 
+    private int linkOrder;
+
     private String title;
+
     private String url;
+
+    public void assignLinkOrder(int linkOrder) {
+        this.linkOrder = linkOrder;
+    }
 
     public void assignLinkUrl(String url) {
         this.url = url;
     }
 
     @Builder
-    public Link(Profile profile, String title, String url) {
+    public Link(Profile profile, int linkOrder, String title, String url) {
         this.profile = profile;
+        this.linkOrder = linkOrder;
         this.title = title;
         this.url = url;
     }

--- a/src/main/java/com/foru/freebe/profile/entity/Link.java
+++ b/src/main/java/com/foru/freebe/profile/entity/Link.java
@@ -26,15 +26,9 @@ public class Link {
     @JoinColumn(name = "profile_id")
     private Profile profile;
 
-    private int linkOrder;
-
     private String title;
 
     private String url;
-
-    public void assignLinkOrder(int linkOrder) {
-        this.linkOrder = linkOrder;
-    }
 
     public void assignLinkUrl(String url) {
         this.url = url;
@@ -43,7 +37,6 @@ public class Link {
     @Builder
     public Link(Profile profile, int linkOrder, String title, String url) {
         this.profile = profile;
-        this.linkOrder = linkOrder;
         this.title = title;
         this.url = url;
     }

--- a/src/main/java/com/foru/freebe/profile/service/PhotographerProfileService.java
+++ b/src/main/java/com/foru/freebe/profile/service/PhotographerProfileService.java
@@ -45,7 +45,7 @@ public class PhotographerProfileService {
         Profile profile = profileService.getProfile(photographer);
         ProfileImage profileImage = createProfileImageIfNotExists(profile);
 
-        hasDuplicates(request.getLinkInfos());
+        validateDuplicates(request.getLinkInfos());
 
         updateIntroductionContent(profile, request.getIntroductionContent());
         updateLinks(profile, request.getLinkInfos());
@@ -64,7 +64,7 @@ public class PhotographerProfileService {
         }
     }
 
-    private void hasDuplicates(List<LinkInfo> linkInfos) {
+    private void validateDuplicates(List<LinkInfo> linkInfos) {
         boolean isDuplicatedTitle = linkInfos.size() != linkInfos.stream()
             .map(LinkInfo::getLinkTitle)
             .distinct()
@@ -72,15 +72,6 @@ public class PhotographerProfileService {
 
         if (isDuplicatedTitle) {
             throw new RestApiException(LinkErrorCode.DUPLICATE_TITLE);
-        }
-
-        boolean isDuplicatedUrl = linkInfos.size() != linkInfos.stream()
-            .map(LinkInfo::getLinkUrl)
-            .distinct()
-            .count();
-
-        if (isDuplicatedUrl) {
-            throw new RestApiException(LinkErrorCode.DUPLICATE_URL);
         }
     }
 


### PR DESCRIPTION
### ## 체크리스트

- ✅ 불필요한 주석 처리가 없는가?

## 작업 내역
- 요청 들어온 링크들에서 title, url에 대한 중복체크
- Link entity에 linkOrder 필드를 추가해서 각 링크의 순서를 식별하도록 수정

## 고민한 사항

## 리뷰 요청사항
- 시급도는 높음입니다! (오늘 있을 통합테스트를 위해..!)
- profileService가 분리되면서 conflict 해결하느라 커밋명 양해 부탁드립니다🥲
- PhotographerProfileService 클래스 위주로 확인해주시면 됩니다! 
- 추가로 이미지 업로드 시 multipart/form-data의 인코딩 방식이 적용되면서 많이 길어지는 현상이 있습니다.  이때 변환하는 코드를 작성하는 것은 리소스가 많이 들어가 타입을 TEXT로 변경하는게 좋아보이는데 이 부분에 대해서 의견 남겨주시면 좋을 것 같아요!