### PR TITLE
[FU-293] 사진작가 메모 등록 및 회원가입 시 연락처 등록 API

### DIFF
--- a/.github/workflows/cd_workflow_dev.yml
+++ b/.github/workflows/cd_workflow_dev.yml
@@ -27,6 +27,7 @@ jobs:
           echo "KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }}" >> .env
           echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}" >> .env
           echo "KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }}" >> .env
+          echo "KAKAO_API_ADMIN_KEY=${{ secrets.KAKAO_API_ADMIN_KEY }}" >> .env
           echo "SPRING_DATASOURCE_URL=${{ secrets.SPRING_DATASOURCE_URL }}" >> .env
           echo "SPRING_DATASOURCE_USERNAME=${{ secrets.SPRING_DATASOURCE_USERNAME }}" >> .env
           echo "SPRING_DATASOURCE_PASSWORD=${{ secrets.SPRING_DATASOURCE_PASSWORD }}" >> .env

--- a/src/main/java/com/foru/freebe/auth/dto/UnlinkRequest.java
+++ b/src/main/java/com/foru/freebe/auth/dto/UnlinkRequest.java
@@ -1,12 +1,12 @@
 package com.foru.freebe.auth.dto;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 public class UnlinkRequest {
-    @NotNull
+    @NotBlank
     private String reason;
 }

--- a/src/main/java/com/foru/freebe/errors/errorcode/ProfileErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/ProfileErrorCode.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum ProfileErrorCode implements ErrorCode {
     PROFILE_NAME_ALREADY_EXISTS(400, "이미 존재하는 프로필명입니다."),
     PROFILE_NAME_NOT_FOUND(404, "존재하지 않는 프로필명입니다."),
-    MEMBER_NOT_FOUND(404, "존재하지 않는 회원입니다.");
+    MEMBER_NOT_FOUND(404, "존재하지 않는 회원입니다."),
+    CONTACT_NOT_PROVIDED(400, "연락처는 필수로 입력해야 합니다.");
 
     private final int httpStatus;
     private final String message;

--- a/src/main/java/com/foru/freebe/member/dto/PhotographerJoinRequest.java
+++ b/src/main/java/com/foru/freebe/member/dto/PhotographerJoinRequest.java
@@ -2,7 +2,6 @@ package com.foru.freebe.member.dto;
 
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
@@ -17,7 +16,7 @@ public class PhotographerJoinRequest {
     @Size(min = 3, max = 30, message = "프로필명은 최소 3자 이상 최대 30자 이하여야합니다")
     private String profileName;
 
-    @NotNull
+    @NotBlank
     private String contact;
 
     @AssertTrue

--- a/src/main/java/com/foru/freebe/member/dto/PhotographerJoinRequest.java
+++ b/src/main/java/com/foru/freebe/member/dto/PhotographerJoinRequest.java
@@ -2,6 +2,7 @@ package com.foru.freebe.member.dto;
 
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
@@ -16,6 +17,9 @@ public class PhotographerJoinRequest {
     @Size(min = 3, max = 30, message = "프로필명은 최소 3자 이상 최대 30자 이하여야합니다")
     private String profileName;
 
+    @NotNull
+    private String contact;
+
     @AssertTrue
     private Boolean termsOfServiceAgreement;
 
@@ -25,9 +29,10 @@ public class PhotographerJoinRequest {
     private Boolean marketingAgreement;
 
     @Builder
-    public PhotographerJoinRequest(String profileName, Boolean termsOfServiceAgreement, Boolean privacyPolicyAgreement,
-        Boolean marketingAgreement) {
+    public PhotographerJoinRequest(String profileName, String contact, Boolean termsOfServiceAgreement,
+        Boolean privacyPolicyAgreement, Boolean marketingAgreement) {
         this.profileName = profileName;
+        this.contact = contact;
         this.termsOfServiceAgreement = termsOfServiceAgreement;
         this.privacyPolicyAgreement = privacyPolicyAgreement;
         this.marketingAgreement = marketingAgreement;

--- a/src/main/java/com/foru/freebe/member/service/PhotographerJoinService.java
+++ b/src/main/java/com/foru/freebe/member/service/PhotographerJoinService.java
@@ -26,7 +26,8 @@ public class PhotographerJoinService {
         Member photographer = completePhotographerSignup(member);
 
         savePhotographerAgreements(photographer, request);
-        Profile profile = profileService.initialProfileSetting(photographer, request.getProfileName());
+        Profile profile = profileService.initialProfileSetting(photographer, request.getProfileName(),
+            request.getContact());
 
         return profile.getProfileName();
     }

--- a/src/main/java/com/foru/freebe/product/controller/PhotographerProductController.java
+++ b/src/main/java/com/foru/freebe/product/controller/PhotographerProductController.java
@@ -22,7 +22,7 @@ import com.foru.freebe.common.dto.ResponseBody;
 import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.product.dto.customer.ProductDetailResponse;
 import com.foru.freebe.product.dto.photographer.ProductRegisterRequest;
-import com.foru.freebe.product.dto.photographer.ProductTitleDto;
+import com.foru.freebe.product.dto.photographer.ProductTitleResponse;
 import com.foru.freebe.product.dto.photographer.RegisteredProductResponse;
 import com.foru.freebe.product.dto.photographer.UpdateProductDetailRequest;
 import com.foru.freebe.product.dto.photographer.UpdateProductRequest;
@@ -139,13 +139,13 @@ public class PhotographerProductController {
     }
 
     @GetMapping("/product/title")
-    public ResponseEntity<ResponseBody<List<ProductTitleDto>>> getAllProductTitle(
+    public ResponseEntity<ResponseBody<List<ProductTitleResponse>>> getAllProductTitle(
         @AuthenticationPrincipal MemberAdapter memberAdapter) {
         Member photographer = memberAdapter.getMember();
 
-        List<ProductTitleDto> responseData = photographerProductService.getAllProductTitle(photographer.getId());
+        List<ProductTitleResponse> responseData = photographerProductService.getAllProductTitle(photographer.getId());
 
-        ResponseBody<List<ProductTitleDto>> responseBody = ResponseBody.<List<ProductTitleDto>>builder()
+        ResponseBody<List<ProductTitleResponse>> responseBody = ResponseBody.<List<ProductTitleResponse>>builder()
             .message("Successfully retrieved list of product titles")
             .data(responseData)
             .build();

--- a/src/main/java/com/foru/freebe/product/dto/photographer/ProductOptionDto.java
+++ b/src/main/java/com/foru/freebe/product/dto/photographer/ProductOptionDto.java
@@ -1,5 +1,6 @@
 package com.foru.freebe.product.dto.photographer;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
@@ -10,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class ProductOptionDto {
-    @NotNull
+    @NotBlank
     @Size(max = 30, message = "Title cannot be longer than 30 characters")
     private String title;
 

--- a/src/main/java/com/foru/freebe/product/dto/photographer/ProductTitleResponse.java
+++ b/src/main/java/com/foru/freebe/product/dto/photographer/ProductTitleResponse.java
@@ -5,10 +5,10 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class ProductTitleDto {
+public class ProductTitleResponse {
     private String title;
 
-    public ProductTitleDto(String title) {
+    public ProductTitleResponse(String title) {
         this.title = title;
     }
 }

--- a/src/main/java/com/foru/freebe/product/entity/ProductImage.java
+++ b/src/main/java/com/foru/freebe/product/entity/ProductImage.java
@@ -28,9 +28,11 @@ public class ProductImage extends BaseEntity {
     private int imageOrder;
 
     @NotNull
+    @Column(length = 600)
     private String thumbnailUrl;
 
     @NotNull
+    @Column(length = 600)
     private String originUrl;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
@@ -23,7 +23,7 @@ import com.foru.freebe.product.dto.photographer.ProductComponentDto;
 import com.foru.freebe.product.dto.photographer.ProductDiscountDto;
 import com.foru.freebe.product.dto.photographer.ProductOptionDto;
 import com.foru.freebe.product.dto.photographer.ProductRegisterRequest;
-import com.foru.freebe.product.dto.photographer.ProductTitleDto;
+import com.foru.freebe.product.dto.photographer.ProductTitleResponse;
 import com.foru.freebe.product.dto.photographer.RegisteredProductResponse;
 import com.foru.freebe.product.dto.photographer.UpdateProductDetailRequest;
 import com.foru.freebe.product.dto.photographer.UpdateProductRequest;
@@ -126,13 +126,13 @@ public class PhotographerProductService {
         updateProductCompositionExcludingImage(updateProductDetailRequest, product);
     }
 
-    public List<ProductTitleDto> getAllProductTitle(Long photographerId) {
+    public List<ProductTitleResponse> getAllProductTitle(Long photographerId) {
         Member photographer = getMember(photographerId);
 
         List<Product> productList = productRepository.findByMember(photographer);
 
         return productList.stream()
-            .map(product -> new ProductTitleDto(product.getTitle()))
+            .map(product -> new ProductTitleResponse(product.getTitle()))
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/foru/freebe/profile/Controller/CustomerProfileController.java
+++ b/src/main/java/com/foru/freebe/profile/Controller/CustomerProfileController.java
@@ -11,7 +11,6 @@ import com.foru.freebe.common.dto.ResponseBody;
 import com.foru.freebe.profile.dto.ProfileResponse;
 import com.foru.freebe.profile.service.CustomerProfileService;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -22,7 +21,7 @@ public class CustomerProfileController {
 
     @GetMapping("/profile/{profileName}")
     public ResponseEntity<ResponseBody<ProfileResponse>> getPhotographerProfile(
-        @Valid @PathVariable("profileName") String profileName) {
+        @PathVariable("profileName") String profileName) {
 
         ProfileResponse responseData = customerProfileService.getPhotographerProfile(profileName);
 

--- a/src/main/java/com/foru/freebe/profile/Controller/PhotographerProfileController.java
+++ b/src/main/java/com/foru/freebe/profile/Controller/PhotographerProfileController.java
@@ -19,6 +19,7 @@ import com.foru.freebe.profile.dto.ProfileResponse;
 import com.foru.freebe.profile.dto.UpdateProfileRequest;
 import com.foru.freebe.profile.service.PhotographerProfileService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -45,7 +46,7 @@ public class PhotographerProfileController {
     @PutMapping("/profile")
     public ResponseEntity<ResponseBody<Void>> updateProfile(
         @AuthenticationPrincipal MemberAdapter memberAdapter,
-        @RequestPart(value = "request") UpdateProfileRequest request,
+        @Valid @RequestPart(value = "request") UpdateProfileRequest request,
         @RequestPart(value = "bannerImage", required = false) MultipartFile bannerImage,
         @RequestPart(value = "profileImage", required = false) MultipartFile profileImage) throws IOException {
 

--- a/src/main/java/com/foru/freebe/profile/dto/UpdateProfileRequest.java
+++ b/src/main/java/com/foru/freebe/profile/dto/UpdateProfileRequest.java
@@ -2,6 +2,7 @@ package com.foru.freebe.profile.dto;
 
 import java.util.List;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class UpdateProfileRequest {
+    @NotBlank
     private String contact;
     private String introductionContent;
     private String existingBannerImageUrl;

--- a/src/main/java/com/foru/freebe/profile/dto/UpdateProfileRequest.java
+++ b/src/main/java/com/foru/freebe/profile/dto/UpdateProfileRequest.java
@@ -9,14 +9,16 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class UpdateProfileRequest {
+    private String contact;
     private String introductionContent;
     private String existingBannerImageUrl;
     private String existingProfileImageUrl;
     private List<LinkInfo> linkInfos;
 
     @Builder
-    public UpdateProfileRequest(String introductionContent, String existingBannerImageUrl,
+    public UpdateProfileRequest(String contact, String introductionContent, String existingBannerImageUrl,
         String existingProfileImageUrl, List<LinkInfo> linkInfos) {
+        this.contact = contact;
         this.introductionContent = introductionContent;
         this.existingBannerImageUrl = existingBannerImageUrl;
         this.existingProfileImageUrl = existingProfileImageUrl;

--- a/src/main/java/com/foru/freebe/profile/entity/Profile.java
+++ b/src/main/java/com/foru/freebe/profile/entity/Profile.java
@@ -42,6 +42,10 @@ public class Profile extends BaseEntity {
         this.introductionContent = introductionContent;
     }
 
+    public void updateContact(String contact) {
+        this.contact = contact;
+    }
+
     @Builder
     public Profile(Member member, String profileName, String contact, String introductionContent) {
         this.member = member;

--- a/src/main/java/com/foru/freebe/profile/entity/Profile.java
+++ b/src/main/java/com/foru/freebe/profile/entity/Profile.java
@@ -33,6 +33,9 @@ public class Profile extends BaseEntity {
     @NotBlank(message = "Profile name must not be blank")
     private String profileName;
 
+    @NotBlank(message = "Contact must not be blank")
+    private String contact;
+
     private String introductionContent;
 
     public void updateIntroductionContent(String introductionContent) {
@@ -40,9 +43,10 @@ public class Profile extends BaseEntity {
     }
 
     @Builder
-    public Profile(String profileName, String introductionContent, Member member) {
-        this.profileName = profileName;
-        this.introductionContent = introductionContent;
+    public Profile(Member member, String profileName, String contact, String introductionContent) {
         this.member = member;
+        this.profileName = profileName;
+        this.contact = contact;
+        this.introductionContent = introductionContent;
     }
 }

--- a/src/main/java/com/foru/freebe/profile/entity/ProfileImage.java
+++ b/src/main/java/com/foru/freebe/profile/entity/ProfileImage.java
@@ -28,8 +28,10 @@ public class ProfileImage extends BaseEntity {
     @JoinColumn(name = "profile_id")
     private Profile profile;
 
+    @Column(length = 600)
     private String bannerOriginUrl;
 
+    @Column(length = 600)
     private String profileOriginUrl;
 
     public void assignBannerOriginUrl(String bannerOriginUrl) {

--- a/src/main/java/com/foru/freebe/profile/service/PhotographerProfileService.java
+++ b/src/main/java/com/foru/freebe/profile/service/PhotographerProfileService.java
@@ -8,6 +8,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.foru.freebe.common.dto.SingleImageLink;
 import com.foru.freebe.errors.errorcode.LinkErrorCode;
+import com.foru.freebe.errors.errorcode.ProfileErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
 import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.profile.dto.LinkInfo;
@@ -46,12 +47,21 @@ public class PhotographerProfileService {
         Profile profile = profileService.getProfile(photographer);
         ProfileImage profileImage = createProfileImageIfNotExists(profile);
 
-        validateLinkTitleDuplicate(request.getLinkInfos());
-
+        updateContact(profile, request.getContact());
         updateIntroductionContent(profile, request.getIntroductionContent());
+
+        validateLinkTitleDuplicate(request.getLinkInfos());
         updateLinks(profile, request.getLinkInfos());
+
         updateBannerImage(photographer.getId(), request.getExistingBannerImageUrl(), bannerImageFile, profileImage);
         updateProfileImage(photographer.getId(), request.getExistingProfileImageUrl(), profileImageFile, profileImage);
+    }
+
+    private static void updateContact(Profile profile, String updateContact) {
+        if (updateContact == null) {
+            throw new RestApiException(ProfileErrorCode.CONTACT_NOT_PROVIDED);
+        }
+        profile.updateContact(updateContact);
     }
 
     @Transactional

--- a/src/main/java/com/foru/freebe/profile/service/PhotographerProfileService.java
+++ b/src/main/java/com/foru/freebe/profile/service/PhotographerProfileService.java
@@ -8,7 +8,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.foru.freebe.common.dto.SingleImageLink;
 import com.foru.freebe.errors.errorcode.LinkErrorCode;
-import com.foru.freebe.errors.errorcode.ProfileErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
 import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.profile.dto.LinkInfo;
@@ -47,7 +46,7 @@ public class PhotographerProfileService {
         Profile profile = profileService.getProfile(photographer);
         ProfileImage profileImage = createProfileImageIfNotExists(profile);
 
-        updateContact(profile, request.getContact());
+        profile.updateContact(request.getContact());
         updateIntroductionContent(profile, request.getIntroductionContent());
 
         validateLinkTitleDuplicate(request.getLinkInfos());
@@ -55,13 +54,6 @@ public class PhotographerProfileService {
 
         updateBannerImage(photographer.getId(), request.getExistingBannerImageUrl(), bannerImageFile, profileImage);
         updateProfileImage(photographer.getId(), request.getExistingProfileImageUrl(), profileImageFile, profileImage);
-    }
-
-    private static void updateContact(Profile profile, String updateContact) {
-        if (updateContact == null) {
-            throw new RestApiException(ProfileErrorCode.CONTACT_NOT_PROVIDED);
-        }
-        profile.updateContact(updateContact);
     }
 
     @Transactional

--- a/src/main/java/com/foru/freebe/profile/service/ProfileService.java
+++ b/src/main/java/com/foru/freebe/profile/service/ProfileService.java
@@ -29,14 +29,14 @@ public class ProfileService {
     private final ProfileImageRepository profileImageRepository;
 
     @Transactional
-    public Profile initialProfileSetting(Member photographer, String profileName) {
+    public Profile initialProfileSetting(Member photographer, String profileName, String contact) {
         boolean isProfileExists = profileRepository.existsByMemberId(photographer.getId());
         if (isProfileExists) {
             throw new RestApiException(CommonErrorCode.INTERNAL_SERVER_ERROR);
         }
 
         validateProfileNameDuplicate(profileName);
-        return createMemberProfile(photographer, profileName);
+        return createMemberProfile(photographer, profileName, contact);
     }
 
     public Profile getProfile(String profileName) {
@@ -74,11 +74,12 @@ public class ProfileService {
         }
     }
 
-    private Profile createMemberProfile(Member member, String profileName) {
+    private Profile createMemberProfile(Member member, String profileName, String contact) {
         Profile profile = Profile.builder()
             .profileName(profileName)
             .introductionContent(null)
             .member(member)
+            .contact(contact)
             .build();
 
         return profileRepository.save(profile);

--- a/src/main/java/com/foru/freebe/reservation/controller/CustomerReservationController.java
+++ b/src/main/java/com/foru/freebe/reservation/controller/CustomerReservationController.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,10 +28,12 @@ import com.foru.freebe.reservation.service.CustomerReservationService;
 import com.foru.freebe.reservation.service.ReservationService;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
+@Validated
 @RequestMapping("/customer")
 public class CustomerReservationController {
     private final CustomerReservationService customerReservationService;
@@ -56,7 +59,8 @@ public class CustomerReservationController {
 
     @GetMapping("/reservation/form/{productId}")
     public ResponseEntity<ResponseBody<BasicReservationInfoResponse>> getBasicReservationForm(
-        @AuthenticationPrincipal MemberAdapter memberAdapter, @Valid @PathVariable("productId") Long productId) {
+        @AuthenticationPrincipal MemberAdapter memberAdapter,
+        @PositiveOrZero @PathVariable("productId") Long productId) {
 
         Member customer = memberAdapter.getMember();
         BasicReservationInfoResponse responseData = customerReservationService.getBasicReservationForm(
@@ -73,8 +77,7 @@ public class CustomerReservationController {
 
     @GetMapping("/reservation/{formId}")
     public ResponseEntity<ResponseBody<ReservationInfoResponse>> getReservationInfo(
-        @AuthenticationPrincipal MemberAdapter memberAdapter,
-        @Valid @PathVariable("formId") Long formId) {
+        @AuthenticationPrincipal MemberAdapter memberAdapter, @PositiveOrZero @PathVariable("formId") Long formId) {
 
         Member customer = memberAdapter.getMember();
         ReservationInfoResponse responseData = customerReservationService.getReservationInfo(formId, customer.getId());
@@ -90,7 +93,8 @@ public class CustomerReservationController {
 
     @PutMapping("/reservation/{formId}")
     public ResponseEntity<Void> updateBasicReservationForm(@AuthenticationPrincipal MemberAdapter memberAdapter,
-        @Valid @PathVariable("formId") Long formId, @Valid @RequestBody ReservationStatusUpdateRequest request) {
+        @PositiveOrZero @PathVariable("formId") Long formId,
+        @Valid @RequestBody ReservationStatusUpdateRequest request) {
 
         Member customer = memberAdapter.getMember();
         reservationService.updateReservationStatus(customer.getId(), formId, request, false);

--- a/src/main/java/com/foru/freebe/reservation/controller/PhotographerReservationController.java
+++ b/src/main/java/com/foru/freebe/reservation/controller/PhotographerReservationController.java
@@ -25,7 +25,7 @@ import com.foru.freebe.reservation.dto.FormListViewResponse;
 import com.foru.freebe.reservation.dto.PastReservationResponse;
 import com.foru.freebe.reservation.dto.ReservationStatusUpdateRequest;
 import com.foru.freebe.reservation.dto.ShootingDate;
-import com.foru.freebe.reservation.dto.UpdatePhotographerMemo;
+import com.foru.freebe.reservation.dto.UpdatePhotographerMemoRequest;
 import com.foru.freebe.reservation.service.PhotographerPastReservationService;
 import com.foru.freebe.reservation.service.PhotographerReservationDetails;
 import com.foru.freebe.reservation.service.PhotographerReservationService;
@@ -134,7 +134,7 @@ public class PhotographerReservationController {
     @PutMapping("/reservation/memo/{formId}")
     public ResponseEntity<ResponseBody<Void>> updatePhotographerMemo(
         @AuthenticationPrincipal MemberAdapter memberAdapter,
-        @RequestBody UpdatePhotographerMemo request,
+        @RequestBody UpdatePhotographerMemoRequest request,
         @PositiveOrZero @PathVariable("formId") Long formId) {
 
         Member photographer = memberAdapter.getMember();

--- a/src/main/java/com/foru/freebe/reservation/controller/PhotographerReservationController.java
+++ b/src/main/java/com/foru/freebe/reservation/controller/PhotographerReservationController.java
@@ -32,6 +32,7 @@ import com.foru.freebe.reservation.service.PhotographerReservationService;
 import com.foru.freebe.reservation.service.ReservationService;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -130,13 +131,14 @@ public class PhotographerReservationController {
             .body(responseBody);
     }
 
-    @PutMapping("/reservation/memo")
+    @PutMapping("/reservation/memo/{formId}")
     public ResponseEntity<ResponseBody<Void>> updatePhotographerMemo(
         @AuthenticationPrincipal MemberAdapter memberAdapter,
-        @RequestBody UpdatePhotographerMemo request) {
+        @RequestBody UpdatePhotographerMemo request,
+        @PositiveOrZero @PathVariable("formId") Long formId) {
 
         Member photographer = memberAdapter.getMember();
-        photographerReservationService.updatePhotographerMemo(photographer.getId(), request);
+        photographerReservationService.updatePhotographerMemo(photographer.getId(), request, formId);
 
         ResponseBody<Void> responseBody = ResponseBody.<Void>builder()
             .message("Successfully update photographer memo")

--- a/src/main/java/com/foru/freebe/reservation/controller/PhotographerReservationController.java
+++ b/src/main/java/com/foru/freebe/reservation/controller/PhotographerReservationController.java
@@ -25,6 +25,7 @@ import com.foru.freebe.reservation.dto.FormListViewResponse;
 import com.foru.freebe.reservation.dto.PastReservationResponse;
 import com.foru.freebe.reservation.dto.ReservationStatusUpdateRequest;
 import com.foru.freebe.reservation.dto.ShootingDate;
+import com.foru.freebe.reservation.dto.UpdatePhotographerMemo;
 import com.foru.freebe.reservation.service.PhotographerPastReservationService;
 import com.foru.freebe.reservation.service.PhotographerReservationDetails;
 import com.foru.freebe.reservation.service.PhotographerReservationService;
@@ -123,6 +124,22 @@ public class PhotographerReservationController {
 
         ResponseBody<Void> responseBody = ResponseBody.<Void>builder()
             .message("Successfully update shooting date")
+            .build();
+
+        return ResponseEntity.status(HttpStatus.OK.value())
+            .body(responseBody);
+    }
+
+    @PutMapping("/reservation/memo")
+    public ResponseEntity<ResponseBody<Void>> updatePhotographerMemo(
+        @AuthenticationPrincipal MemberAdapter memberAdapter,
+        @RequestBody UpdatePhotographerMemo request) {
+
+        Member photographer = memberAdapter.getMember();
+        photographerReservationService.updatePhotographerMemo(photographer.getId(), request);
+
+        ResponseBody<Void> responseBody = ResponseBody.<Void>builder()
+            .message("Successfully update photographer memo")
             .build();
 
         return ResponseEntity.status(HttpStatus.OK.value())

--- a/src/main/java/com/foru/freebe/reservation/dto/UpdatePhotographerMemo.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/UpdatePhotographerMemo.java
@@ -1,0 +1,14 @@
+package com.foru.freebe.reservation.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdatePhotographerMemo {
+
+    @NotNull
+    private Long reservationFormId;
+    private String photographerMemo;
+}

--- a/src/main/java/com/foru/freebe/reservation/dto/UpdatePhotographerMemo.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/UpdatePhotographerMemo.java
@@ -1,6 +1,5 @@
 package com.foru.freebe.reservation.dto;
 
-import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,7 +7,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class UpdatePhotographerMemo {
 
-    @NotNull
-    private Long reservationFormId;
     private String photographerMemo;
 }

--- a/src/main/java/com/foru/freebe/reservation/dto/UpdatePhotographerMemoRequest.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/UpdatePhotographerMemoRequest.java
@@ -5,7 +5,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class UpdatePhotographerMemo {
+public class UpdatePhotographerMemoRequest {
 
     private String photographerMemo;
 }

--- a/src/main/java/com/foru/freebe/reservation/entity/ReferenceImage.java
+++ b/src/main/java/com/foru/freebe/reservation/entity/ReferenceImage.java
@@ -29,9 +29,11 @@ public class ReferenceImage extends BaseEntity {
     private ReservationForm reservationForm;
 
     @NotBlank
+    @Column(length = 600)
     private String originUrl;
 
     @NotBlank
+    @Column(length = 600)
     private String thumbnailUrl;
 
     private ReferenceImage(String originUrl, String thumbnailUrl, ReservationForm reservationForm) {

--- a/src/main/java/com/foru/freebe/reservation/entity/ReservationForm.java
+++ b/src/main/java/com/foru/freebe/reservation/entity/ReservationForm.java
@@ -92,6 +92,10 @@ public class ReservationForm extends BaseEntity {
 
     private String photographerMemo;
 
+    public void updatePhotographerMemo(String updateMemo) {
+        this.photographerMemo = updateMemo;
+    }
+
     public void changeReservationStatus(ReservationStatus updateStatus) {
         this.reservationStatus = updateStatus;
     }

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationDetails.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationDetails.java
@@ -28,7 +28,6 @@ public class PhotographerReservationDetails {
         List<StatusHistory> statusHistories = reservationService.getStatusHistories(reservationForm);
 
         CustomerDetails customerDetails = buildCustomerDetails(reservationForm);
-        Map<String, String> shootDetails = reservationForm.getPhotoInfo();
         Map<Integer, TimeSlot> preferredDates = reservationForm.getPreferredDate();
         Map<String, String> photoInfo = reservationForm.getPhotoInfo();
         ReferenceImageUrls preferredImages = getPreferredImages(reservationForm);

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
@@ -15,6 +15,7 @@ import com.foru.freebe.errors.exception.RestApiException;
 import com.foru.freebe.reservation.dto.FormComponent;
 import com.foru.freebe.reservation.dto.FormListViewResponse;
 import com.foru.freebe.reservation.dto.ShootingDate;
+import com.foru.freebe.reservation.dto.UpdatePhotographerMemo;
 import com.foru.freebe.reservation.entity.ReservationForm;
 import com.foru.freebe.reservation.entity.ReservationStatus;
 import com.foru.freebe.reservation.repository.ReservationFormRepository;
@@ -42,6 +43,15 @@ public class PhotographerReservationService {
         validateShootingTime(shootingDate);
 
         reservationForm.updateShootingDate(shootingDate.getNewShootingDate());
+    }
+
+    @Transactional
+    public void updatePhotographerMemo(Long photographerId, UpdatePhotographerMemo request) {
+        ReservationForm reservationForm = reservationFormRepository.findByPhotographerIdAndId(photographerId,
+                request.getReservationFormId())
+            .orElseThrow(() -> new RestApiException(ReservationErrorCode.NO_RESERVATION_FORM));
+
+        reservationForm.updatePhotographerMemo(request.getPhotographerMemo());
     }
 
     private void validateShootingTime(ShootingDate shootingDate) {

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
@@ -46,9 +46,8 @@ public class PhotographerReservationService {
     }
 
     @Transactional
-    public void updatePhotographerMemo(Long photographerId, UpdatePhotographerMemo request) {
-        ReservationForm reservationForm = reservationFormRepository.findByPhotographerIdAndId(photographerId,
-                request.getReservationFormId())
+    public void updatePhotographerMemo(Long photographerId, UpdatePhotographerMemo request, Long formId) {
+        ReservationForm reservationForm = reservationFormRepository.findByPhotographerIdAndId(photographerId, formId)
             .orElseThrow(() -> new RestApiException(ReservationErrorCode.NO_RESERVATION_FORM));
 
         reservationForm.updatePhotographerMemo(request.getPhotographerMemo());

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
@@ -15,7 +15,7 @@ import com.foru.freebe.errors.exception.RestApiException;
 import com.foru.freebe.reservation.dto.FormComponent;
 import com.foru.freebe.reservation.dto.FormListViewResponse;
 import com.foru.freebe.reservation.dto.ShootingDate;
-import com.foru.freebe.reservation.dto.UpdatePhotographerMemo;
+import com.foru.freebe.reservation.dto.UpdatePhotographerMemoRequest;
 import com.foru.freebe.reservation.entity.ReservationForm;
 import com.foru.freebe.reservation.entity.ReservationStatus;
 import com.foru.freebe.reservation.repository.ReservationFormRepository;
@@ -46,7 +46,7 @@ public class PhotographerReservationService {
     }
 
     @Transactional
-    public void updatePhotographerMemo(Long photographerId, UpdatePhotographerMemo request, Long formId) {
+    public void updatePhotographerMemo(Long photographerId, UpdatePhotographerMemoRequest request, Long formId) {
         ReservationForm reservationForm = reservationFormRepository.findByPhotographerIdAndId(photographerId, formId)
             .orElseThrow(() -> new RestApiException(ReservationErrorCode.NO_RESERVATION_FORM));
 


### PR DESCRIPTION
## 체크리스트

- ✅ 불필요한 주석 처리가 없는가?

## 작업 내역
- 사진작가 회원가입 시 연락처 등록 API 보완
- 신청서에서 사진작가 메모 업데이트 API 구현 (null 값도 가능)
- 프로필 업데이트 API에서 request body에 연락처(contact) 필드 추가
- 이미지 관련 필드에 대한 문자열 제한을 600자로 늘림
- Kakao 앱 키 환경변수 등록

## 고민한 사항
- 신청서에 대한 formId를 경로변수로 받을지, request body를 통해 받을지 고민이 있었습니다. 기존에는 formId를 경로변수로 받고 있었는데(아닌 API도  있습니다.) 그런 경우에 service를 호출할 때 request 객체 이외에 formId에 대한 파라미터를 하나 더 넘겨줘야 한다는 단점이 있었습니다. 그래서 이번 티켓에서는 request body에 reservationFormId를 담아서 service를 호출하게 진행하였는데 @rheeri 의견 남겨주면 좋을 것 같아요! 
(의견이 모이더라도 하나로 통합해서 적용하는 건 추후에 유지보수할 때 진행하는 게 좋을 것 같아요. 기존 API들도 유진이가 수정이 필요하기 때문에...!)

## 리뷰 요청사항
- 시급도 높음! 환경변수 누락 때문에 서버 배포가 안되어 있어서 가능하면 리뷰 바로 부탁드려요!
- 이미지 관련 필드 중 문자열 제한 범위를 늘리지 않은 필드가 있는지 검토 부탁드려요!
- 추가된 로직 중 누락된 예외처리가 있는지 확인 부탁드려요!
- @eujin-shin API Docs에 **작가 회원가입, 프로필 업데이트, 사진작가 메모 업데이트** 3개의 API에서 확인해보고 특이사항 있으면 코멘트 남겨주세요!