### PR TITLE
[FU-300] 촬영 장소 관련한 필드 추가

### DIFF
--- a/src/main/java/com/foru/freebe/product/dto/customer/ProductDetailResponse.java
+++ b/src/main/java/com/foru/freebe/product/dto/customer/ProductDetailResponse.java
@@ -23,6 +23,12 @@ public class ProductDetailResponse {
     @NotNull
     private Long basicPrice;
 
+    @NotBlank
+    private String basicPlace;
+
+    @NotNull
+    private Boolean allowPreferredPlace;
+
     @NotNull
     private List<String> productImageUrls;
 
@@ -34,12 +40,14 @@ public class ProductDetailResponse {
     private List<ProductDiscountDto> productDiscounts;
 
     @Builder
-    public ProductDetailResponse(String productTitle, String productDescription, Long basicPrice,
-        List<String> productImageUrls, List<ProductComponentDto> productComponents,
+    public ProductDetailResponse(String productTitle, String productDescription, Long basicPrice, String basicPlace,
+        Boolean allowPreferredPlace, List<String> productImageUrls, List<ProductComponentDto> productComponents,
         List<ProductOptionDto> productOptions, List<ProductDiscountDto> productDiscounts) {
         this.productTitle = productTitle;
         this.productDescription = productDescription;
         this.basicPrice = basicPrice;
+        this.basicPlace = basicPlace;
+        this.allowPreferredPlace = allowPreferredPlace;
         this.productImageUrls = productImageUrls;
         this.productComponents = productComponents;
         this.productOptions = productOptions;

--- a/src/main/java/com/foru/freebe/product/dto/photographer/ProductRegisterRequest.java
+++ b/src/main/java/com/foru/freebe/product/dto/photographer/ProductRegisterRequest.java
@@ -21,6 +21,12 @@ public class ProductRegisterRequest {
     @NotNull(message = "Basic price must not be null")
     private Long basicPrice;
 
+    @NotBlank(message = "PhotoPlace name must not be blank")
+    private String basicPlace;
+
+    @NotNull
+    private Boolean allowPreferredPlace;
+
     @NotNull(message = "Product components must not be null")
     private List<ProductComponentDto> productComponents;
 

--- a/src/main/java/com/foru/freebe/product/dto/photographer/UpdateProductDetailRequest.java
+++ b/src/main/java/com/foru/freebe/product/dto/photographer/UpdateProductDetailRequest.java
@@ -28,6 +28,12 @@ public class UpdateProductDetailRequest {
     @NotNull(message = "Basic price must not be null")
     private Long basicPrice;
 
+    @NotBlank(message = "PhotoPlace name must not be blank")
+    private String basicPlace;
+
+    @NotNull
+    private Boolean allowPreferredPlace;
+
     @NotNull
     private List<ProductComponentDto> productComponents;
 
@@ -37,14 +43,16 @@ public class UpdateProductDetailRequest {
 
     @Builder
     public UpdateProductDetailRequest(Long productId, List<String> existingUrls, String productTitle,
-        String productDescription, Long basicPrice, List<ProductComponentDto> productComponents,
-        List<ProductOptionDto> productOptions,
+        String productDescription, Long basicPrice, String basicPlace, Boolean allowPreferredPlace,
+        List<ProductComponentDto> productComponents, List<ProductOptionDto> productOptions,
         List<ProductDiscountDto> productDiscounts) {
         this.productId = productId;
         this.existingUrls = existingUrls;
         this.productTitle = productTitle;
         this.productDescription = productDescription;
         this.basicPrice = basicPrice;
+        this.basicPlace = basicPlace;
+        this.allowPreferredPlace = allowPreferredPlace;
         this.productComponents = productComponents;
         this.productOptions = productOptions;
         this.productDiscounts = productDiscounts;

--- a/src/main/java/com/foru/freebe/product/entity/Product.java
+++ b/src/main/java/com/foru/freebe/product/entity/Product.java
@@ -72,13 +72,22 @@ public class Product extends BaseEntity {
         this.activeStatus = newStatus;
     }
 
-    public void assignTitle(String newTitle) {
-        this.title = newTitle;
+    public void assignBasicProductInfo(String updateTitle, String updateDescription, Long updateBasicPrice,
+        String updateBasicPlace, Boolean updateAllowPreferredPlace) {
+        this.title = updateTitle;
+        this.description = updateDescription;
+        this.basicPrice = updateBasicPrice;
+        this.basicPlace = updateBasicPlace;
+        this.allowPreferredPlace = updateAllowPreferredPlace;
     }
 
-    public void assignDescription(String newDescription) {
-        this.description = newDescription;
-    }
+    // public void assignTitle(String newTitle) {
+    //     this.title = newTitle;
+    // }
+    //
+    // public void assignDescription(String newDescription) {
+    //     this.description = newDescription;
+    // }
 
     public void assignBasicPrice(Long basicPrice) {
         this.basicPrice = basicPrice;

--- a/src/main/java/com/foru/freebe/product/entity/Product.java
+++ b/src/main/java/com/foru/freebe/product/entity/Product.java
@@ -15,8 +15,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -41,24 +43,26 @@ public class Product extends BaseEntity {
     @NotNull
     private Long basicPrice;
 
+    @NotBlank(message = "PhotoPlace name must not be blank")
+    private String basicPlace;
+
+    @NotNull
+    private Boolean allowPreferredPlace;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    public Product(String title, String description, ActiveStatus activeStatus, Long basicPrice, Member member) {
+    @Builder
+    public Product(String title, String description, ActiveStatus activeStatus, Long basicPrice, String basicPlace,
+        Boolean allowPreferredPlace, Member member) {
         this.title = title;
         this.description = description;
         this.activeStatus = activeStatus;
         this.basicPrice = basicPrice;
+        this.basicPlace = basicPlace;
+        this.allowPreferredPlace = allowPreferredPlace;
         this.member = member;
-    }
-
-    public static Product createProductAsActive(String title, String description, Long basicPrice, Member member) {
-        return new Product(title, description, ActiveStatus.ACTIVE, basicPrice, member);
-    }
-
-    public static Product createProductAsActiveWithoutDescription(String title, Long basicPrice, Member member) {
-        return new Product(title, null, ActiveStatus.ACTIVE, basicPrice, member);
     }
 
     public void updateProductActiveStatus(ActiveStatus newStatus) {

--- a/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
@@ -27,6 +27,7 @@ import com.foru.freebe.product.dto.photographer.ProductTitleResponse;
 import com.foru.freebe.product.dto.photographer.RegisteredProductResponse;
 import com.foru.freebe.product.dto.photographer.UpdateProductDetailRequest;
 import com.foru.freebe.product.dto.photographer.UpdateProductRequest;
+import com.foru.freebe.product.entity.ActiveStatus;
 import com.foru.freebe.product.entity.Product;
 import com.foru.freebe.product.entity.ProductComponent;
 import com.foru.freebe.product.entity.ProductDiscount;
@@ -290,19 +291,20 @@ public class PhotographerProductService {
     }
 
     private Product registerActiveProduct(ProductRegisterRequest request, Member photographer) {
-        String productTitle = request.getProductTitle();
-        String productDescription = request.getProductDescription();
-        Long basicPrice = request.getBasicPrice();
 
-        Product productAsActive;
-        if (productDescription != null) {
-            productAsActive = Product.createProductAsActive(productTitle, productDescription, basicPrice, photographer);
-        } else {
-            productAsActive = Product.createProductAsActiveWithoutDescription(productTitle, basicPrice, photographer);
-        }
+        validateProductTitleBeforeRegister(request.getProductTitle(), photographer);
 
-        validateProductTitleBeforeRegister(productTitle, photographer);
-        return productRepository.save(productAsActive);
+        Product product = Product.builder()
+            .title(request.getProductTitle())
+            .description(request.getProductDescription())
+            .activeStatus(ActiveStatus.ACTIVE)
+            .basicPrice(request.getBasicPrice())
+            .basicPlace(request.getBasicPlace())
+            .allowPreferredPlace(request.getAllowPreferredPlace())
+            .member(photographer)
+            .build();
+
+        return productRepository.save(product);
     }
 
     private void validateProductTitleBeforeRegister(String productTitle, Member photographer) {

--- a/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
@@ -119,9 +119,12 @@ public class PhotographerProductService {
             validateProductTitleBeforeRegister(updateProductDetailRequest.getProductTitle(), photographer);
         }
 
-        product.assignTitle(updateProductDetailRequest.getProductTitle());
-        product.assignDescription(updateProductDetailRequest.getProductDescription());
-        product.assignBasicPrice(updateProductDetailRequest.getBasicPrice());
+        product.assignBasicProductInfo(
+            updateProductDetailRequest.getProductTitle(),
+            updateProductDetailRequest.getProductDescription(),
+            updateProductDetailRequest.getBasicPrice(),
+            updateProductDetailRequest.getBasicPlace(),
+            updateProductDetailRequest.getAllowPreferredPlace());
 
         updateProductImage(photographer.getId(), updateProductDetailRequest, images, product);
         updateProductCompositionExcludingImage(updateProductDetailRequest, product);

--- a/src/main/java/com/foru/freebe/product/service/ProductDetailConvertor.java
+++ b/src/main/java/com/foru/freebe/product/service/ProductDetailConvertor.java
@@ -41,6 +41,8 @@ public class ProductDetailConvertor {
             .productTitle(product.getTitle())
             .productDescription(product.getDescription())
             .basicPrice(product.getBasicPrice())
+            .basicPlace(product.getBasicPlace())
+            .allowPreferredPlace(product.getAllowPreferredPlace())
             .productImageUrls(productImageUrls)
             .productComponents(productComponents)
             .productOptions(productOptions)

--- a/src/main/java/com/foru/freebe/reservation/controller/CustomerReservationController.java
+++ b/src/main/java/com/foru/freebe/reservation/controller/CustomerReservationController.java
@@ -92,7 +92,7 @@ public class CustomerReservationController {
     }
 
     @PutMapping("/reservation/{formId}")
-    public ResponseEntity<Void> updateBasicReservationForm(@AuthenticationPrincipal MemberAdapter memberAdapter,
+    public ResponseEntity<Void> updateReservationStatus(@AuthenticationPrincipal MemberAdapter memberAdapter,
         @PositiveOrZero @PathVariable("formId") Long formId,
         @Valid @RequestBody ReservationStatusUpdateRequest request) {
 

--- a/src/main/java/com/foru/freebe/reservation/controller/PhotographerReservationController.java
+++ b/src/main/java/com/foru/freebe/reservation/controller/PhotographerReservationController.java
@@ -24,7 +24,7 @@ import com.foru.freebe.reservation.dto.FormDetailsViewResponse;
 import com.foru.freebe.reservation.dto.FormListViewResponse;
 import com.foru.freebe.reservation.dto.PastReservationResponse;
 import com.foru.freebe.reservation.dto.ReservationStatusUpdateRequest;
-import com.foru.freebe.reservation.dto.ShootingDateRequest;
+import com.foru.freebe.reservation.dto.ShootingInfoRequest;
 import com.foru.freebe.reservation.dto.UpdatePhotographerMemoRequest;
 import com.foru.freebe.reservation.service.PhotographerPastReservationService;
 import com.foru.freebe.reservation.service.PhotographerReservationDetails;
@@ -119,11 +119,11 @@ public class PhotographerReservationController {
     public ResponseEntity<ResponseBody<Void>> setShootingDate(
         @AuthenticationPrincipal MemberAdapter memberAdapter,
         @PositiveOrZero @PathVariable("formId") Long formId,
-        @Valid @RequestBody ShootingDateRequest request) {
+        @Valid @RequestBody ShootingInfoRequest request) {
 
         Member photographer = memberAdapter.getMember();
 
-        photographerReservationService.setShootingDate(photographer.getId(), formId, request);
+        photographerReservationService.setShootingInfo(photographer.getId(), formId, request);
 
         ResponseBody<Void> responseBody = ResponseBody.<Void>builder()
             .message("Successfully update shooting date")

--- a/src/main/java/com/foru/freebe/reservation/controller/PhotographerReservationController.java
+++ b/src/main/java/com/foru/freebe/reservation/controller/PhotographerReservationController.java
@@ -69,7 +69,7 @@ public class PhotographerReservationController {
             member.getId(), formId);
 
         ResponseBody<FormDetailsViewResponse> responseBody = ResponseBody.<FormDetailsViewResponse>builder()
-            .message("Successfully get reservation list")
+            .message("Successfully get reservation details")
             .data(responseData)
             .build();
 
@@ -115,8 +115,8 @@ public class PhotographerReservationController {
             .body(responseBody);
     }
 
-    @PutMapping("/reservation/shooting-date/{formId}")
-    public ResponseEntity<ResponseBody<Void>> setShootingDate(
+    @PutMapping("/reservation/shooting-info/{formId}")
+    public ResponseEntity<ResponseBody<Void>> setShootingInfo(
         @AuthenticationPrincipal MemberAdapter memberAdapter,
         @PositiveOrZero @PathVariable("formId") Long formId,
         @Valid @RequestBody ShootingInfoRequest request) {

--- a/src/main/java/com/foru/freebe/reservation/dto/BasicReservationInfoResponse.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/BasicReservationInfoResponse.java
@@ -25,6 +25,9 @@ public class BasicReservationInfoResponse {
     @NotNull
     private Long basicPrice;
 
+    @NotBlank
+    private String basicPlace;
+
     @NotNull
     private List<ProductComponentDto> productComponentDtoList;
 
@@ -32,11 +35,13 @@ public class BasicReservationInfoResponse {
 
     @Builder
     public BasicReservationInfoResponse(String name, String phoneNumber, String instagramId, Long basicPrice,
-        List<ProductComponentDto> productComponentDtoList, List<ProductOptionDto> productOptionDtoList) {
+        String basicPlace, List<ProductComponentDto> productComponentDtoList,
+        List<ProductOptionDto> productOptionDtoList) {
         this.name = name;
         this.phoneNumber = phoneNumber;
         this.instagramId = instagramId;
         this.basicPrice = basicPrice;
+        this.basicPlace = basicPlace;
         this.productComponentDtoList = productComponentDtoList;
         this.productOptionDtoList = productOptionDtoList;
     }

--- a/src/main/java/com/foru/freebe/reservation/dto/BasicReservationInfoResponse.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/BasicReservationInfoResponse.java
@@ -29,19 +29,23 @@ public class BasicReservationInfoResponse {
     private String basicPlace;
 
     @NotNull
+    private Boolean allowPreferredPlace;
+
+    @NotNull
     private List<ProductComponentDto> productComponentDtoList;
 
     private List<ProductOptionDto> productOptionDtoList;
 
     @Builder
     public BasicReservationInfoResponse(String name, String phoneNumber, String instagramId, Long basicPrice,
-        String basicPlace, List<ProductComponentDto> productComponentDtoList,
+        String basicPlace, Boolean allowPreferredPlace, List<ProductComponentDto> productComponentDtoList,
         List<ProductOptionDto> productOptionDtoList) {
         this.name = name;
         this.phoneNumber = phoneNumber;
         this.instagramId = instagramId;
         this.basicPrice = basicPrice;
         this.basicPlace = basicPlace;
+        this.allowPreferredPlace = allowPreferredPlace;
         this.productComponentDtoList = productComponentDtoList;
         this.productOptionDtoList = productOptionDtoList;
     }

--- a/src/main/java/com/foru/freebe/reservation/dto/FormDetailsViewResponse.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/FormDetailsViewResponse.java
@@ -32,6 +32,9 @@ public class FormDetailsViewResponse {
     @NotNull
     private Long basicPrice;
 
+    @NotBlank
+    private String basicPlace;
+
     @NotNull
     private Map<String, String> photoInfo;
 
@@ -39,6 +42,8 @@ public class FormDetailsViewResponse {
 
     @NotNull
     private Map<Integer, TimeSlot> preferredDates;
+
+    private String preferredPlace;
 
     private TimeSlot shootingDate;
 
@@ -53,8 +58,8 @@ public class FormDetailsViewResponse {
     @Builder
     public FormDetailsViewResponse(Long reservationNumber, ReservationStatus currentReservationStatus,
         List<StatusHistory> statusHistory, String productTitle, CustomerDetails customerDetails, Long basicPrice,
-        Map<String, String> photoInfo, Map<Integer, PhotoOption> photoOptions,
-        Map<Integer, TimeSlot> preferredDates, TimeSlot shootingDate, List<String> originalImage,
+        String basicPlace, Map<String, String> photoInfo, Map<Integer, PhotoOption> photoOptions,
+        Map<Integer, TimeSlot> preferredDates, String preferredPlace, TimeSlot shootingDate, List<String> originalImage,
         List<String> thumbnailImage, String requestMemo, String photographerMemo) {
         this.reservationNumber = reservationNumber;
         this.currentReservationStatus = currentReservationStatus;
@@ -62,9 +67,11 @@ public class FormDetailsViewResponse {
         this.productTitle = productTitle;
         this.customerDetails = customerDetails;
         this.basicPrice = basicPrice;
+        this.basicPlace = basicPlace;
         this.photoInfo = photoInfo;
         this.photoOptions = photoOptions;
         this.preferredDates = preferredDates;
+        this.preferredPlace = preferredPlace;
         this.shootingDate = shootingDate;
         this.originalImage = originalImage;
         this.thumbnailImage = thumbnailImage;
@@ -75,7 +82,7 @@ public class FormDetailsViewResponse {
     public static FormDetailsViewResponseBuilder builder(Long reservationNumber,
         ReservationStatus currentReservationStatus,
         List<StatusHistory> statusHistory, String productTitle, CustomerDetails customerDetails,
-        Long basicPrice, Map<String, String> photoInfo, Map<Integer, TimeSlot> preferredDates) {
+        Long basicPrice, String basicPlace, Map<String, String> photoInfo, Map<Integer, TimeSlot> preferredDates) {
         return new FormDetailsViewResponseBuilder()
             .reservationNumber(reservationNumber)
             .currentReservationStatus(currentReservationStatus)
@@ -83,6 +90,7 @@ public class FormDetailsViewResponse {
             .productTitle(productTitle)
             .customerDetails(customerDetails)
             .basicPrice(basicPrice)
+            .basicPlace(basicPlace)
             .photoInfo(photoInfo)
             .preferredDates(preferredDates);
     }

--- a/src/main/java/com/foru/freebe/reservation/dto/FormDetailsViewResponse.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/FormDetailsViewResponse.java
@@ -47,6 +47,8 @@ public class FormDetailsViewResponse {
 
     private TimeSlot shootingDate;
 
+    private String shootingPlace;
+
     private List<String> originalImage;
 
     private List<String> thumbnailImage;
@@ -59,8 +61,8 @@ public class FormDetailsViewResponse {
     public FormDetailsViewResponse(Long reservationNumber, ReservationStatus currentReservationStatus,
         List<StatusHistory> statusHistory, String productTitle, CustomerDetails customerDetails, Long basicPrice,
         String basicPlace, Map<String, String> photoInfo, Map<Integer, PhotoOption> photoOptions,
-        Map<Integer, TimeSlot> preferredDates, String preferredPlace, TimeSlot shootingDate, List<String> originalImage,
-        List<String> thumbnailImage, String requestMemo, String photographerMemo) {
+        Map<Integer, TimeSlot> preferredDates, String preferredPlace, TimeSlot shootingDate, String shootingPlace,
+        List<String> originalImage, List<String> thumbnailImage, String requestMemo, String photographerMemo) {
         this.reservationNumber = reservationNumber;
         this.currentReservationStatus = currentReservationStatus;
         this.statusHistory = statusHistory;
@@ -73,6 +75,7 @@ public class FormDetailsViewResponse {
         this.preferredDates = preferredDates;
         this.preferredPlace = preferredPlace;
         this.shootingDate = shootingDate;
+        this.shootingPlace = shootingPlace;
         this.originalImage = originalImage;
         this.thumbnailImage = thumbnailImage;
         this.requestMemo = requestMemo;

--- a/src/main/java/com/foru/freebe/reservation/dto/FormRegisterRequest.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/FormRegisterRequest.java
@@ -28,6 +28,8 @@ public class FormRegisterRequest {
     @NotNull(message = "Preferred dates must not be null")
     private Map<Integer, TimeSlot> preferredDates;
 
+    private String preferredPlace;
+
     private Map<Integer, PhotoOption> photoOptions;
 
     @NotEmpty

--- a/src/main/java/com/foru/freebe/reservation/dto/ReservationInfoResponse.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/ReservationInfoResponse.java
@@ -28,19 +28,22 @@ public class ReservationInfoResponse {
     @NotNull
     private Map<Integer, TimeSlot> preferredDate;
 
+    private String preferredPlace;
+
     private Map<Integer, PhotoOption> photoOptions;
 
     private String customerMemo;
 
     @Builder
-    public ReservationInfoResponse(ReservationStatus reservationStatus, String productTitle,
-        Long basicPrice, Map<String, String> photoInfo, Map<Integer, TimeSlot> preferredDate,
+    public ReservationInfoResponse(ReservationStatus reservationStatus, String productTitle, Long basicPrice,
+        Map<String, String> photoInfo, Map<Integer, TimeSlot> preferredDate, String preferredPlace,
         Map<Integer, PhotoOption> photoOptions, String customerMemo) {
         this.reservationStatus = reservationStatus;
         this.productTitle = productTitle;
         this.basicPrice = basicPrice;
         this.photoInfo = photoInfo;
         this.preferredDate = preferredDate;
+        this.preferredPlace = preferredPlace;
         this.photoOptions = photoOptions;
         this.customerMemo = customerMemo;
     }

--- a/src/main/java/com/foru/freebe/reservation/dto/ReservationInfoResponse.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/ReservationInfoResponse.java
@@ -22,6 +22,9 @@ public class ReservationInfoResponse {
     @NotNull
     private Long basicPrice;
 
+    @NotBlank
+    private String basicPlace;
+
     @NotNull
     private Map<String, String> photoInfo;
 
@@ -36,11 +39,12 @@ public class ReservationInfoResponse {
 
     @Builder
     public ReservationInfoResponse(ReservationStatus reservationStatus, String productTitle, Long basicPrice,
-        Map<String, String> photoInfo, Map<Integer, TimeSlot> preferredDate, String preferredPlace,
+        String basicPlace, Map<String, String> photoInfo, Map<Integer, TimeSlot> preferredDate, String preferredPlace,
         Map<Integer, PhotoOption> photoOptions, String customerMemo) {
         this.reservationStatus = reservationStatus;
         this.productTitle = productTitle;
         this.basicPrice = basicPrice;
+        this.basicPlace = basicPlace;
         this.photoInfo = photoInfo;
         this.preferredDate = preferredDate;
         this.preferredPlace = preferredPlace;

--- a/src/main/java/com/foru/freebe/reservation/dto/ReservationInfoResponse.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/ReservationInfoResponse.java
@@ -16,6 +16,9 @@ public class ReservationInfoResponse {
     @NotNull
     private ReservationStatus reservationStatus;
 
+    @NotNull
+    private Long productId;
+
     @NotBlank
     private String productTitle;
 
@@ -42,10 +45,12 @@ public class ReservationInfoResponse {
     private String customerMemo;
 
     @Builder
-    public ReservationInfoResponse(ReservationStatus reservationStatus, String productTitle, Long basicPrice,
-        String basicPlace, Map<String, String> photoInfo, Map<Integer, TimeSlot> preferredDate, String preferredPlace,
-        TimeSlot shootingDate, String shootingPlace, Map<Integer, PhotoOption> photoOptions, String customerMemo) {
+    public ReservationInfoResponse(ReservationStatus reservationStatus, Long productId, String productTitle,
+        Long basicPrice, String basicPlace, Map<String, String> photoInfo, Map<Integer, TimeSlot> preferredDate,
+        String preferredPlace, TimeSlot shootingDate, String shootingPlace, Map<Integer, PhotoOption> photoOptions,
+        String customerMemo) {
         this.reservationStatus = reservationStatus;
+        this.productId = productId;
         this.productTitle = productTitle;
         this.basicPrice = basicPrice;
         this.basicPlace = basicPlace;

--- a/src/main/java/com/foru/freebe/reservation/dto/ReservationInfoResponse.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/ReservationInfoResponse.java
@@ -33,6 +33,10 @@ public class ReservationInfoResponse {
 
     private String preferredPlace;
 
+    private TimeSlot shootingDate;
+
+    private String shootingPlace;
+
     private Map<Integer, PhotoOption> photoOptions;
 
     private String customerMemo;
@@ -40,7 +44,7 @@ public class ReservationInfoResponse {
     @Builder
     public ReservationInfoResponse(ReservationStatus reservationStatus, String productTitle, Long basicPrice,
         String basicPlace, Map<String, String> photoInfo, Map<Integer, TimeSlot> preferredDate, String preferredPlace,
-        Map<Integer, PhotoOption> photoOptions, String customerMemo) {
+        TimeSlot shootingDate, String shootingPlace, Map<Integer, PhotoOption> photoOptions, String customerMemo) {
         this.reservationStatus = reservationStatus;
         this.productTitle = productTitle;
         this.basicPrice = basicPrice;
@@ -48,6 +52,8 @@ public class ReservationInfoResponse {
         this.photoInfo = photoInfo;
         this.preferredDate = preferredDate;
         this.preferredPlace = preferredPlace;
+        this.shootingDate = shootingDate;
+        this.shootingPlace = shootingPlace;
         this.photoOptions = photoOptions;
         this.customerMemo = customerMemo;
     }

--- a/src/main/java/com/foru/freebe/reservation/dto/ShootingInfoRequest.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/ShootingInfoRequest.java
@@ -2,6 +2,7 @@ package com.foru.freebe.reservation.dto;
 
 import com.foru.freebe.reservation.entity.ReservationStatus;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,16 +10,21 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class ShootingDateRequest {
+public class ShootingInfoRequest {
     @NotNull
     private ReservationStatus currentReservationStatus;
+
+    @NotBlank
+    private String newShootingPlace;
 
     @NotNull
     private TimeSlot newShootingDate;
 
     @Builder
-    public ShootingDateRequest(ReservationStatus currentReservationStatus, TimeSlot newShootingDate) {
+    public ShootingInfoRequest(ReservationStatus currentReservationStatus, String newShootingPlace,
+        TimeSlot newShootingDate) {
         this.currentReservationStatus = currentReservationStatus;
+        this.newShootingPlace = newShootingPlace;
         this.newShootingDate = newShootingDate;
     }
 }

--- a/src/main/java/com/foru/freebe/reservation/entity/ReservationForm.java
+++ b/src/main/java/com/foru/freebe/reservation/entity/ReservationForm.java
@@ -80,6 +80,8 @@ public class ReservationForm extends BaseEntity {
     @NotNull(message = "Preferred Date must not be null")
     private Map<Integer, TimeSlot> preferredDate;
 
+    private String preferredPlace;
+
     @Type(JsonType.class)
     @Column(name = "shooting_date", columnDefinition = "longtext")
     private TimeSlot shootingDate;
@@ -104,7 +106,7 @@ public class ReservationForm extends BaseEntity {
     public ReservationForm(Member photographer, Member customer, String instagramId, String productTitle,
         Long basicPrice, Long totalPrice, Boolean serviceTermAgreement, Boolean photographerTermAgreement,
         ReservationStatus reservationStatus, Map<String, String> photoInfo, Map<Integer, TimeSlot> preferredDate,
-        Map<Integer, PhotoOption> photoOption, String customerMemo, String photographerMemo) {
+        String preferredPlace, Map<Integer, PhotoOption> photoOption, String customerMemo, String photographerMemo) {
         this.photographer = photographer;
         this.customer = customer;
         this.instagramId = instagramId;
@@ -116,6 +118,7 @@ public class ReservationForm extends BaseEntity {
         this.reservationStatus = reservationStatus;
         this.photoInfo = photoInfo;
         this.preferredDate = preferredDate;
+        this.preferredPlace = preferredPlace;
         this.photoOption = photoOption;
         this.customerMemo = customerMemo;
         this.photographerMemo = photographerMemo;

--- a/src/main/java/com/foru/freebe/reservation/entity/ReservationForm.java
+++ b/src/main/java/com/foru/freebe/reservation/entity/ReservationForm.java
@@ -89,6 +89,8 @@ public class ReservationForm extends BaseEntity {
     @Column(name = "shooting_date", columnDefinition = "longtext")
     private TimeSlot shootingDate;
 
+    private String shootingPlace;
+
     @Type(JsonType.class)
     @Column(name = "photo_option", columnDefinition = "longtext")
     private Map<Integer, PhotoOption> photoOption;
@@ -103,6 +105,11 @@ public class ReservationForm extends BaseEntity {
 
     public void changeReservationStatus(ReservationStatus updateStatus) {
         this.reservationStatus = updateStatus;
+    }
+
+    public void updateShootingInfo(TimeSlot newShootingDate, String newShootingPlace) {
+        this.shootingDate = newShootingDate;
+        this.shootingPlace = newShootingPlace;
     }
 
     @Builder
@@ -143,9 +150,5 @@ public class ReservationForm extends BaseEntity {
             .serviceTermAgreement(serviceTermAgreement)
             .photographerTermAgreement(photographerTermAgreement)
             .reservationStatus(reservationStatus);
-    }
-
-    public void updateShootingDate(TimeSlot newShootingDate) {
-        this.shootingDate = newShootingDate;
     }
 }

--- a/src/main/java/com/foru/freebe/reservation/entity/ReservationForm.java
+++ b/src/main/java/com/foru/freebe/reservation/entity/ReservationForm.java
@@ -56,6 +56,9 @@ public class ReservationForm extends BaseEntity {
     @NotNull(message = "Basic price must not be null")
     private Long basicPrice;
 
+    @NotBlank(message = "Basic place must not be null")
+    private String basicPlace;
+
     @NotNull(message = "Total price must not be null")
     @Positive
     private Long totalPrice;
@@ -104,7 +107,8 @@ public class ReservationForm extends BaseEntity {
 
     @Builder
     public ReservationForm(Member photographer, Member customer, String instagramId, String productTitle,
-        Long basicPrice, Long totalPrice, Boolean serviceTermAgreement, Boolean photographerTermAgreement,
+        Long basicPrice, String basicPlace, Long totalPrice, Boolean serviceTermAgreement,
+        Boolean photographerTermAgreement,
         ReservationStatus reservationStatus, Map<String, String> photoInfo, Map<Integer, TimeSlot> preferredDate,
         String preferredPlace, Map<Integer, PhotoOption> photoOption, String customerMemo, String photographerMemo) {
         this.photographer = photographer;
@@ -112,6 +116,7 @@ public class ReservationForm extends BaseEntity {
         this.instagramId = instagramId;
         this.productTitle = productTitle;
         this.basicPrice = basicPrice;
+        this.basicPlace = basicPlace;
         this.totalPrice = totalPrice;
         this.serviceTermAgreement = serviceTermAgreement;
         this.photographerTermAgreement = photographerTermAgreement;
@@ -125,7 +130,7 @@ public class ReservationForm extends BaseEntity {
     }
 
     public static ReservationFormBuilder builder(Member photographer, Member customer, String instagramId,
-        String productTitle, Long basicPrice, Long totalPrice, Boolean serviceTermAgreement,
+        String productTitle, Long basicPrice, String basicPlace, Long totalPrice, Boolean serviceTermAgreement,
         Boolean photographerTermAgreement, ReservationStatus reservationStatus) {
         return new ReservationFormBuilder()
             .photographer(photographer)
@@ -133,6 +138,7 @@ public class ReservationForm extends BaseEntity {
             .instagramId(instagramId)
             .productTitle(productTitle)
             .basicPrice(basicPrice)
+            .basicPlace(basicPlace)
             .totalPrice(totalPrice)
             .serviceTermAgreement(serviceTermAgreement)
             .photographerTermAgreement(photographerTermAgreement)

--- a/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
@@ -97,6 +97,7 @@ public class CustomerReservationService {
             .phoneNumber(customer.getPhoneNumber())
             .instagramId(customer.getInstagramId())
             .basicPrice(product.getBasicPrice())
+            .basicPlace(product.getBasicPlace())
             .productComponentDtoList(productComponentDtoList)
             .productOptionDtoList(productOptionDtoList)
             .build();

--- a/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
@@ -113,6 +113,7 @@ public class CustomerReservationService {
             .reservationStatus(reservationForm.getReservationStatus())
             .productTitle(reservationForm.getProductTitle())
             .basicPrice(reservationForm.getBasicPrice())
+            .basicPlace(reservationForm.getBasicPlace())
             .photoInfo(reservationForm.getPhotoInfo())
             .preferredDate(reservationForm.getPreferredDate())
             .preferredPlace(reservationForm.getPreferredPlace())

--- a/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
@@ -183,6 +183,7 @@ public class CustomerReservationService {
                 request.getServiceTermAgreement(), request.getPhotographerTermAgreement(), ReservationStatus.NEW)
             .photoInfo(photoInfo)
             .preferredDate(request.getPreferredDates())
+            .preferredPlace(request.getPreferredPlace())
             .photoOption(request.getPhotoOptions())
             .customerMemo(request.getCustomerMemo());
         return builder.build();

--- a/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
@@ -108,11 +108,15 @@ public class CustomerReservationService {
         ReservationForm reservationForm = reservationFormRepository.findById(formId)
             .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
 
+        Product product = productRepository.findByTitle(reservationForm.getProductTitle())
+            .orElseThrow(() -> new RestApiException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
         reservationVerifier.validateCustomerAccess(reservationForm, customerId);
 
         return ReservationInfoResponse.builder()
             .reservationStatus(reservationForm.getReservationStatus())
             .productTitle(reservationForm.getProductTitle())
+            .productId(product.getId())
             .basicPrice(reservationForm.getBasicPrice())
             .basicPlace(reservationForm.getBasicPlace())
             .photoInfo(reservationForm.getPhotoInfo())

--- a/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
@@ -114,6 +114,7 @@ public class CustomerReservationService {
             .basicPrice(reservationForm.getBasicPrice())
             .photoInfo(reservationForm.getPhotoInfo())
             .preferredDate(reservationForm.getPreferredDate())
+            .preferredPlace(reservationForm.getPreferredPlace())
             .photoOptions(reservationForm.getPhotoOption())
             .customerMemo(reservationForm.getCustomerMemo())
             .build();

--- a/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
@@ -118,6 +118,8 @@ public class CustomerReservationService {
             .photoInfo(reservationForm.getPhotoInfo())
             .preferredDate(reservationForm.getPreferredDate())
             .preferredPlace(reservationForm.getPreferredPlace())
+            .shootingDate(reservationForm.getShootingDate())
+            .shootingPlace(reservationForm.getShootingPlace())
             .photoOptions(reservationForm.getPhotoOption())
             .customerMemo(reservationForm.getCustomerMemo())
             .build();

--- a/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
@@ -181,8 +181,9 @@ public class CustomerReservationService {
         Map<String, String> photoInfo = getProductComponentsTitleAndContent(productComponents);
 
         ReservationForm.ReservationFormBuilder builder = ReservationForm.builder(photographer, customer,
-                request.getInstagramId(), product.getTitle(), product.getBasicPrice(), request.getTotalPrice(),
-                request.getServiceTermAgreement(), request.getPhotographerTermAgreement(), ReservationStatus.NEW)
+                request.getInstagramId(), product.getTitle(), product.getBasicPrice(), product.getBasicPlace(),
+                request.getTotalPrice(), request.getServiceTermAgreement(), request.getPhotographerTermAgreement(),
+                ReservationStatus.NEW)
             .photoInfo(photoInfo)
             .preferredDate(request.getPreferredDates())
             .preferredPlace(request.getPreferredPlace())

--- a/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
@@ -98,6 +98,7 @@ public class CustomerReservationService {
             .instagramId(customer.getInstagramId())
             .basicPrice(product.getBasicPrice())
             .basicPlace(product.getBasicPlace())
+            .allowPreferredPlace(product.getAllowPreferredPlace())
             .productComponentDtoList(productComponentDtoList)
             .productOptionDtoList(productOptionDtoList)
             .build();

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationDetails.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationDetails.java
@@ -38,6 +38,7 @@ public class PhotographerReservationDetails {
             .photoOptions(reservationForm.getPhotoOption())
             .preferredPlace(reservationForm.getPreferredPlace())
             .shootingDate(reservationForm.getShootingDate())
+            .shootingPlace(reservationForm.getShootingPlace())
             .originalImage(preferredImages.getOriginalImage())
             .thumbnailImage(preferredImages.getThumbnailImage())
             .requestMemo(reservationForm.getCustomerMemo())

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationDetails.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationDetails.java
@@ -34,8 +34,9 @@ public class PhotographerReservationDetails {
 
         return FormDetailsViewResponse.builder(reservationForm.getId(), reservationForm.getReservationStatus(),
                 statusHistories, reservationForm.getProductTitle(), customerDetails, reservationForm.getBasicPrice(),
-                photoInfo, preferredDates)
+                reservationForm.getBasicPlace(), photoInfo, preferredDates)
             .photoOptions(reservationForm.getPhotoOption())
+            .preferredPlace(reservationForm.getPreferredPlace())
             .shootingDate(reservationForm.getShootingDate())
             .originalImage(preferredImages.getOriginalImage())
             .thumbnailImage(preferredImages.getThumbnailImage())

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerReservationService.java
@@ -14,7 +14,7 @@ import com.foru.freebe.errors.errorcode.ReservationErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
 import com.foru.freebe.reservation.dto.FormComponent;
 import com.foru.freebe.reservation.dto.FormListViewResponse;
-import com.foru.freebe.reservation.dto.ShootingDateRequest;
+import com.foru.freebe.reservation.dto.ShootingInfoRequest;
 import com.foru.freebe.reservation.dto.UpdatePhotographerMemoRequest;
 import com.foru.freebe.reservation.entity.ReservationForm;
 import com.foru.freebe.reservation.entity.ReservationStatus;
@@ -33,7 +33,7 @@ public class PhotographerReservationService {
     }
 
     @Transactional
-    public void setShootingDate(Long photographerId, Long formId, ShootingDateRequest request) {
+    public void setShootingInfo(Long photographerId, Long formId, ShootingInfoRequest request) {
         ReservationForm reservationForm = reservationFormRepository.findByPhotographerIdAndId(photographerId, formId)
             .orElseThrow(() -> new RestApiException(ReservationErrorCode.NO_RESERVATION_FORM));
 
@@ -41,7 +41,7 @@ public class PhotographerReservationService {
         validateShootingDate(request.getNewShootingDate().getDate());
         validateShootingTime(request);
 
-        reservationForm.updateShootingDate(request.getNewShootingDate());
+        reservationForm.updateShootingInfo(request.getNewShootingDate(), request.getNewShootingPlace());
     }
 
     @Transactional
@@ -52,7 +52,7 @@ public class PhotographerReservationService {
         reservationForm.updatePhotographerMemo(request.getPhotographerMemo());
     }
 
-    private void validateShootingTime(ShootingDateRequest request) {
+    private void validateShootingTime(ShootingInfoRequest request) {
         LocalTime startTime = request.getNewShootingDate().getStartTime();
         LocalTime endTime = request.getNewShootingDate().getEndTime();
 


### PR DESCRIPTION
## 체크리스트

- ✅ 불필요한 주석 처리가 없는가?

## 작업 내역
- 사진작가 측
   - 상품 등록 API: 기본 촬영장소(basicPlace), 고객 선호장소 작성 가능 여부(allowPreferredPlace) 필드 추가
   - 상품 상세 정보 조회 API: 기본 촬영장소, 고객 선호장소 작성 가능 여부 필드 추가
   - 상품 상세 정보 변경 API에 기본 촬영장소, 고객 선호장소 작성 가능 여부 필드 추가
   - 촬영날 정보(날짜, 장소) 업데이트 API: 새 촬영장소(newShootingPlace) 필드 추가
   - 신청서 상세보기 API: 사진의뢰자가 작성한 선호장소(preferredPlace) 필드 추가
- 사진의뢰자 측
   - 상품 상세 조회 API: 기본 촬영장소 필드 추가
   - 예약신청서 등록 API: 선호장소 필드 추가
   - 예약신청서 조회 API: 선호장소 필드, 기본 장소 추가
   - 예약신청서 조회 API: 기본 촬영장소 필드 추가
 
## 리뷰 요청사항
- 시급도 높음! 빠른 출시를 위해.. 시간 될 때 바로 해주시면 빠르게 적용할 수 있을 것 같습니다🥲
- 변경된 API가 많지만 각 볼륨이 적어서 빠진 필드가 있는지만 확인해주시면 좋을 것 같아요!
- @eujin-shin API Docs에 'API 수정됨' 상태로 변경해둔 API들 확인해주면 되고 오류가 있으면 코멘트 부탁드려요!