### PR TITLE
[FU-301] 사진작가 필수 규정 설정

### DIFF
--- a/src/main/java/com/foru/freebe/errors/errorcode/NoticeErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/NoticeErrorCode.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum NoticeErrorCode implements ErrorCode {
 
-    TITLE_DUPLICATE(400, "중복된 제목이 존재합니다");
+    TITLE_DUPLICATE(400, "중복된 제목이 존재합니다"),
+    NOT_FOUND_ESSENTIAL_TITLE(400, "필수 규정에 대한 제목이 포함되어 있지 않습니다");
 
     private final int httpStatus;
     private final String message;

--- a/src/main/java/com/foru/freebe/notice/service/PhotographerNoticeService.java
+++ b/src/main/java/com/foru/freebe/notice/service/PhotographerNoticeService.java
@@ -36,6 +36,7 @@ public class PhotographerNoticeService {
         Profile profile = getProfile(photographer);
 
         validateDuplicateTitles(requestList);
+        validateIncludingEssentialTitle(requestList);
         noticeRepository.deleteAll();
 
         List<Notice> notices = requestList.stream()
@@ -47,6 +48,18 @@ public class PhotographerNoticeService {
             .collect(Collectors.toList());
 
         noticeRepository.saveAll(notices);
+    }
+
+    private void validateIncludingEssentialTitle(List<NoticeDto> requestList) {
+        boolean containsCancellationTitle = requestList.stream()
+            .anyMatch(notice -> "취소 및 환불 규정".equals(notice.getTitle()));
+
+        boolean containsChangeTitle = requestList.stream()
+            .anyMatch(notice -> "예약 변경 규정".equals(notice.getTitle()));
+
+        if (!containsCancellationTitle || !containsChangeTitle) {
+            throw new RestApiException(NoticeErrorCode.NOT_FOUND_ESSENTIAL_TITLE);
+        }
     }
 
     public List<NoticeDto> getNotices(Long photographerId) {

--- a/src/main/java/com/foru/freebe/reservation/dto/FormRegisterRequest.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/FormRegisterRequest.java
@@ -43,9 +43,6 @@ public class FormRegisterRequest {
     private Long totalPrice;
 
     @NotNull
-    private Boolean serviceTermAgreement;
-
-    @NotNull
-    private Boolean photographerTermAgreement;
+    private Boolean noticeAgreement;
 }
 

--- a/src/main/java/com/foru/freebe/reservation/dto/PhotoNotice.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/PhotoNotice.java
@@ -1,0 +1,18 @@
+package com.foru.freebe.reservation.dto;
+
+import java.io.Serializable;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PhotoNotice implements Serializable {
+
+    @NotNull
+    private String title;
+
+    @NotNull
+    private String content;
+}

--- a/src/main/java/com/foru/freebe/reservation/entity/ReservationForm.java
+++ b/src/main/java/com/foru/freebe/reservation/entity/ReservationForm.java
@@ -6,6 +6,7 @@ import org.hibernate.annotations.Type;
 
 import com.foru.freebe.common.entity.BaseEntity;
 import com.foru.freebe.member.entity.Member;
+import com.foru.freebe.reservation.dto.PhotoNotice;
 import com.foru.freebe.reservation.dto.PhotoOption;
 import com.foru.freebe.reservation.dto.TimeSlot;
 
@@ -63,11 +64,8 @@ public class ReservationForm extends BaseEntity {
     @Positive
     private Long totalPrice;
 
-    @NotNull(message = "Service term agreement must not be null")
-    private Boolean serviceTermAgreement;
-
-    @NotNull(message = "Photographer term agreement must not be null")
-    private Boolean photographerTermAgreement;
+    @NotNull(message = "Notice agreement must not be null")
+    private Boolean noticeAgreement;
 
     @Enumerated(EnumType.STRING)
     @NotNull(message = "Reservation status must not be null")
@@ -95,6 +93,10 @@ public class ReservationForm extends BaseEntity {
     @Column(name = "photo_option", columnDefinition = "longtext")
     private Map<Integer, PhotoOption> photoOption;
 
+    @Type(JsonType.class)
+    @Column(name = "photo_notice", columnDefinition = "longtext")
+    private Map<Integer, PhotoNotice> photoNotice;
+
     private String customerMemo;
 
     private String photographerMemo;
@@ -114,10 +116,10 @@ public class ReservationForm extends BaseEntity {
 
     @Builder
     public ReservationForm(Member photographer, Member customer, String instagramId, String productTitle,
-        Long basicPrice, String basicPlace, Long totalPrice, Boolean serviceTermAgreement,
-        Boolean photographerTermAgreement,
+        Long basicPrice, String basicPlace, Long totalPrice, Boolean noticeAgreement,
         ReservationStatus reservationStatus, Map<String, String> photoInfo, Map<Integer, TimeSlot> preferredDate,
-        String preferredPlace, Map<Integer, PhotoOption> photoOption, String customerMemo, String photographerMemo) {
+        String preferredPlace, Map<Integer, PhotoOption> photoOption, Map<Integer, PhotoNotice> photoNotice,
+        String customerMemo, String photographerMemo) {
         this.photographer = photographer;
         this.customer = customer;
         this.instagramId = instagramId;
@@ -125,20 +127,20 @@ public class ReservationForm extends BaseEntity {
         this.basicPrice = basicPrice;
         this.basicPlace = basicPlace;
         this.totalPrice = totalPrice;
-        this.serviceTermAgreement = serviceTermAgreement;
-        this.photographerTermAgreement = photographerTermAgreement;
+        this.noticeAgreement = noticeAgreement;
         this.reservationStatus = reservationStatus;
         this.photoInfo = photoInfo;
         this.preferredDate = preferredDate;
         this.preferredPlace = preferredPlace;
         this.photoOption = photoOption;
+        this.photoNotice = photoNotice;
         this.customerMemo = customerMemo;
         this.photographerMemo = photographerMemo;
     }
 
     public static ReservationFormBuilder builder(Member photographer, Member customer, String instagramId,
-        String productTitle, Long basicPrice, String basicPlace, Long totalPrice, Boolean serviceTermAgreement,
-        Boolean photographerTermAgreement, ReservationStatus reservationStatus) {
+        String productTitle, Long basicPrice, String basicPlace, Long totalPrice, Boolean noticeAgreement,
+        ReservationStatus reservationStatus, Map<Integer, PhotoNotice> photoNotice) {
         return new ReservationFormBuilder()
             .photographer(photographer)
             .customer(customer)
@@ -147,8 +149,8 @@ public class ReservationForm extends BaseEntity {
             .basicPrice(basicPrice)
             .basicPlace(basicPlace)
             .totalPrice(totalPrice)
-            .serviceTermAgreement(serviceTermAgreement)
-            .photographerTermAgreement(photographerTermAgreement)
-            .reservationStatus(reservationStatus);
+            .noticeAgreement(noticeAgreement)
+            .reservationStatus(reservationStatus)
+            .photoNotice(photoNotice);
     }
 }


### PR DESCRIPTION
## 체크리스트

- ✅ 불필요한 주석 처리가 없는가?

## 작업 내역
- 공지사항 업데이트 시 request의 title 중 '취소 및 환불 규정', '예약 변경 규정'이 모두 포함되어 있는지 검증하는 로직 추가
- 신청서 등록시 ReservationForm entity에  해당 공지사항을 스냅샷하여 저장하기 위한 필드 photoNotice 필드 추가
- 신청서 등록 시 ReservationForm entity에  기존의 동의항목 대신 공지에 대한 동의 항목인 noticeArgreement 필드를 추가
- (FU-300에서 처리) 의뢰자 측 신청서 상세조회 시 profileName 대신 productId를 response 필드로 변경
 
## 리뷰 요청사항
- 시급도는 높음! 빠른 통합테스트를 위해..ㅎㅎ
- 공지사항 업데이트의 검증로직과 ReservationForm entity에 추가된 필드와 해당 필드를 저장하는 로직에서 리뷰해주시면 좋을 것 같습니다~!