### PR TITLE
[FU-244] 백엔드 개발인프라 분리 구축 테스트

### DIFF
--- a/.github/workflows/cd_workflow_dev.yml
+++ b/.github/workflows/cd_workflow_dev.yml
@@ -27,81 +27,36 @@ jobs:
         run: |
           if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
             echo "KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET_DEV }}" >> .env
+            echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID_DEV }}" >> .env
+            echo "KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI_DEV }}" >> .env
+            echo "KAKAO_API_ADMIN_KEY=${{ secrets.KAKAO_API_ADMIN_KEY_DEV }}" >> .env
+            echo "SPRING_DATASOURCE_URL=${{ secrets.SPRING_DATASOURCE_URL_DEV }}" >> .env
+            echo "SPRING_DATASOURCE_USERNAME=${{ secrets.SPRING_DATASOURCE_USERNAME_DEV }}" >> .env
+            echo "SPRING_DATASOURCE_PASSWORD=${{ secrets.SPRING_DATASOURCE_PASSWORD_DEV }}" >> .env
+            echo "FREEBE_BASE_URL=${{ secrets.FREEBE_BASE_URL_DEV }}" >> .env
+            echo "AWS_S3_CICD_BUCKET=${{ secrets.AWS_S3_CICD_BUCKET_DEV }}" >> .env
+            echo "AWS_S3_DATA_BUCKET=${{ secrets.AWS_S3_DATA_BUCKET_DEV }}" >> .env
+            echo "AWS_CODE_DEPLOY_GROUP=${{ secrets.AWS_CODE_DEPLOY_GROUP_DEV }}" >> .env
+            echo "ENVIRONMENT=${{ secrets.ENVIRONMENT_DEV }}" >> .env
           else
             echo "KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }}" >> .env
-          fi
-          
-          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
-            echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID_DEV }}" >> .env
-          else
             echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}" >> .env
-          fi
-          
-          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
-            echo "KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI_DEV }}" >> .env
-          else
             echo "KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }}" >> .env
-          fi
-          
-          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
-            echo "KAKAO_API_ADMIN_KEY=${{ secrets.KAKAO_API_ADMIN_KEY_DEV }}" >> .env
-          else
             echo "KAKAO_API_ADMIN_KEY=${{ secrets.KAKAO_API_ADMIN_KEY }}" >> .env
-          fi
-          
-          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
-            echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID_DEV }}" >> .env
-          else
-            echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}" >> .env
-          fi
-          
-          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
-            echo "SPRING_DATASOURCE_URL=${{ secrets.SPRING_DATASOURCE_URL_DEV }}" >> .env
-          else
             echo "SPRING_DATASOURCE_URL=${{ secrets.SPRING_DATASOURCE_URL }}" >> .env
-          fi
-          
-          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
-            echo "SPRING_DATASOURCE_USERNAME=${{ secrets.SPRING_DATASOURCE_USERNAME_DEV }}" >> .env
-          else
             echo "SPRING_DATASOURCE_USERNAME=${{ secrets.SPRING_DATASOURCE_USERNAME }}" >> .env
-          fi
-          
-          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
-            echo "SPRING_DATASOURCE_PASSWORD=${{ secrets.SPRING_DATASOURCE_PASSWORD_DEV }}" >> .env
-          else
             echo "SPRING_DATASOURCE_PASSWORD=${{ secrets.SPRING_DATASOURCE_PASSWORD }}" >> .env
-          fi
-          
-          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
-            echo "FREEBE_BASE_URL=${{ secrets.FREEBE_BASE_URL_DEV }}" >> .env
-          else
             echo "FREEBE_BASE_URL=${{ secrets.FREEBE_BASE_URL }}" >> .env
+            echo "AWS_S3_CICD_BUCKET=${{ secrets.AWS_S3_CICD_BUCKET }}" >> .env
+            echo "AWS_S3_DATA_BUCKET=${{ secrets.AWS_S3_DATA_BUCKET }}" >> .env
+            echo "AWS_CODE_DEPLOY_GROUP=${{ secrets.AWS_CODE_DEPLOY_GROUP }}" >> .env
+            echo "ENVIRONMENT=${{ secrets.ENVIRONMENT }}" >> .env
           fi
-          
-          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
-            echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID_DEV }}" >> .env
-          else
-            echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}" >> .env
-          fi
-          
+
           echo "JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}" >> .env
           echo "AWS_REGION=${{ secrets.AWS_REGION }}" >> .env
           echo "AWS_ACCESS_KEY=${{ secrets.CICD_ACCESS_KEY }}" >> .env
           echo "AWS_SECRET_KEY=${{ secrets.CICD_SECRET_KEY }}" >> .env
-          
-          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
-            echo "AWS_S3_CICD_BUCKET=${{ secrets.AWS_S3_CICD_BUCKET_DEV }}" >> .env
-          else
-            echo "AWS_S3_CICD_BUCKET=${{ secrets.AWS_S3_CICD_BUCKET }}" >> .env
-          fi
-          
-          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
-            echo "AWS_S3_DATA_BUCKET=${{ secrets.AWS_S3_DATA_BUCKET_DEV }}" >> .env
-          else
-            echo "AWS_S3_DATA_BUCKET=${{ secrets.AWS_S3_DATA_BUCKET }}" >> .env
-          fi
-          
           echo "AWS_S3_ORIGINAL_PATH=${{ secrets.AWS_S3_ORIGINAL_PATH }}" >> .env
           echo "AWS_S3_THUMBNAIL_PATH=${{ secrets.AWS_S3_THUMBNAIL_PATH }}" >> .env
           echo "AWS_S3_PHOTOGRAPHER_PATH=${{ secrets.AWS_S3_PHOTOGRAPHER_PATH }}" >> .env
@@ -111,21 +66,8 @@ jobs:
           echo "AWS_S3_BANNER_PATH=${{ secrets.AWS_S3_BANNER_PATH }}" >> .env
           echo "AWS_S3_RESERVATION_PATH=${{ secrets.AWS_S3_RESERVATION_PATH }}" >> .env
           echo "AWS_CODE_DEPLOY_APPLICATION=${{ secrets.AWS_CODE_DEPLOY_APPLICATION }}" >> .env
-          
-          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
-            echo "AWS_CODE_DEPLOY_GROUP=${{ secrets.AWS_CODE_DEPLOY_GROUP_DEV }}" >> .env
-          else
-            echo "AWS_CODE_DEPLOY_GROUP=${{ secrets.AWS_CODE_DEPLOY_GROUP }}" >> .env
-          fi
-          
           echo "NEW_RELIC_LICENSE_KEY=${{ secrets.NEW_RELIC_LICENSE_KEY }}" >> .env
           echo "NEW_RELIC_APP_NAME=${{ secrets.NEW_RELIC_APP_NAME }}" >> .env
-          
-          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
-            echo "ENVIRONMENT=${{ secrets.ENVIRONMENT_DEV }}" >> .env
-          else
-            echo "ENVIRONMENT=${{ secrets.ENVIRONMENT }}" >> .env
-          fi
 
       - name: gradlew에 실행 권한 부여
         run: chmod +x ./gradlew
@@ -144,14 +86,31 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: S3에 jar 업로드(실행 파일)
-        run: aws s3 cp ./build/libs/freebe-0.0.1-SNAPSHOT.jar s3://${{secrets.AWS_S3_CICD_BUCKET}}/cicdtest/freebe.jar --region ap-northeast-2
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
+            aws s3 cp ./build/libs/freebe-0.0.1-SNAPSHOT.jar s3://${{secrets.AWS_S3_CICD_BUCKET_DEV}}/cicdtest/freebe.jar --region ap-northeast-2
+          else
+            aws s3 cp ./build/libs/freebe-0.0.1-SNAPSHOT.jar s3://${{secrets.AWS_S3_CICD_BUCKET}}/cicdtest/freebe.jar --region ap-northeast-2
+          fi
 
       - name: S3에 zip 업로드(전체 파일)
-        run: aws s3 cp freebe.zip s3://${{secrets.AWS_S3_CICD_BUCKET}}/cicdtest/freebe.zip --region ap-northeast-2
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
+            aws s3 cp freebe.zip s3://${{secrets.AWS_S3_CICD_BUCKET_DEV}}/cicdtest/freebe.zip --region ap-northeast-2
+          else
+            aws s3 cp freebe.zip s3://${{secrets.AWS_S3_CICD_BUCKET}}/cicdtest/freebe.zip --region ap-northeast-2
+          fi
 
       - name: Code Deploy 로 배포
-        run: >
-          aws deploy create-deployment --application-name ${{ secrets.AWS_CODE_DEPLOY_APPLICATION }}
-          --deployment-config-name CodeDeployDefault.AllAtOnce
-          --deployment-group-name ${{ secrets.AWS_CODE_DEPLOY_GROUP }}
-          --s3-location bucket=${{ secrets.AWS_S3_CICD_BUCKET }},bundleType=zip,key=cicdtest/freebe.zip
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
+            aws deploy create-deployment --application-name ${{ secrets.AWS_CODE_DEPLOY_APPLICATION }}
+            --deployment-config-name CodeDeployDefault.AllAtOnce
+            --deployment-group-name ${{ secrets.AWS_CODE_DEPLOY_GROUP_DEV }}
+            --s3-location bucket=${{ secrets.AWS_S3_CICD_BUCKET_DEV }},bundleType=zip,key=cicdtest/freebe.zip
+          else
+            aws deploy create-deployment --application-name ${{ secrets.AWS_CODE_DEPLOY_APPLICATION }}
+            --deployment-config-name CodeDeployDefault.AllAtOnce
+            --deployment-group-name ${{ secrets.AWS_CODE_DEPLOY_GROUP }}
+            --s3-location bucket=${{ secrets.AWS_S3_CICD_BUCKET }},bundleType=zip,key=cicdtest/freebe.zip
+          fi

--- a/.github/workflows/cd_workflow_dev.yml
+++ b/.github/workflows/cd_workflow_dev.yml
@@ -24,7 +24,6 @@ jobs:
 
       - name: env 설정
         run:
-          # 소스코드에 필요한 env
           echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID_DEV }}" >> .env
           echo "KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET_DEV }}" >> .env
           echo "KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI_DEV }}" >> .env
@@ -49,12 +48,10 @@ jobs:
           echo "NEW_RELIC_LICENSE_KEY=${{ secrets.NEW_RELIC_LICENSE_KEY }}" >> .env
           echo "NEW_RELIC_APP_NAME=${{ secrets.NEW_RELIC_APP_NAME }}" >> .env
           
-          # 소스코드에 필요하지 않은 env
           echo "AWS_CODE_DEPLOY_APPLICATION=${{ secrets.AWS_CODE_DEPLOY_APPLICATION }}" >> .env
           echo "AWS_CODE_DEPLOY_GROUP=${{ secrets.AWS_CODE_DEPLOY_GROUP_DEV }}" >> .env
           echo "AWS_S3_CICD_BUCKET=${{ secrets.AWS_S3_CICD_BUCKET_DEV }}" >> .env
           echo "ENVIRONMENT=${{ secrets.ENVIRONMENT_DEV }}" >> .env
-
 
       - name: gradlew에 실행 권한 부여
         run: chmod +x ./gradlew

--- a/.github/workflows/cd_workflow_dev.yml
+++ b/.github/workflows/cd_workflow_dev.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - fix/**
+      - dev-infra-test
 
 jobs:
   build:
@@ -24,20 +25,83 @@ jobs:
 
       - name: env 설정
         run: |
-          echo "KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }}" >> .env
-          echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}" >> .env
-          echo "KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }}" >> .env
-          echo "KAKAO_API_ADMIN_KEY=${{ secrets.KAKAO_API_ADMIN_KEY }}" >> .env
-          echo "SPRING_DATASOURCE_URL=${{ secrets.SPRING_DATASOURCE_URL }}" >> .env
-          echo "SPRING_DATASOURCE_USERNAME=${{ secrets.SPRING_DATASOURCE_USERNAME }}" >> .env
-          echo "SPRING_DATASOURCE_PASSWORD=${{ secrets.SPRING_DATASOURCE_PASSWORD }}" >> .env
-          echo "FREEBE_BASE_URL=${{ secrets.FREEBE_BASE_URL }}" >> .env
+          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
+            echo "KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET_DEV }}" >> .env
+          else
+            echo "KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }}" >> .env
+          fi
+          
+          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
+            echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID_DEV }}" >> .env
+          else
+            echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}" >> .env
+          fi
+          
+          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
+            echo "KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI_DEV }}" >> .env
+          else
+            echo "KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }}" >> .env
+          fi
+          
+          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
+            echo "KAKAO_API_ADMIN_KEY=${{ secrets.KAKAO_API_ADMIN_KEY_DEV }}" >> .env
+          else
+            echo "KAKAO_API_ADMIN_KEY=${{ secrets.KAKAO_API_ADMIN_KEY }}" >> .env
+          fi
+          
+          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
+            echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID_DEV }}" >> .env
+          else
+            echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}" >> .env
+          fi
+          
+          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
+            echo "SPRING_DATASOURCE_URL=${{ secrets.SPRING_DATASOURCE_URL_DEV }}" >> .env
+          else
+            echo "SPRING_DATASOURCE_URL=${{ secrets.SPRING_DATASOURCE_URL }}" >> .env
+          fi
+          
+          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
+            echo "SPRING_DATASOURCE_USERNAME=${{ secrets.SPRING_DATASOURCE_USERNAME_DEV }}" >> .env
+          else
+            echo "SPRING_DATASOURCE_USERNAME=${{ secrets.SPRING_DATASOURCE_USERNAME }}" >> .env
+          fi
+          
+          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
+            echo "SPRING_DATASOURCE_PASSWORD=${{ secrets.SPRING_DATASOURCE_PASSWORD_DEV }}" >> .env
+          else
+            echo "SPRING_DATASOURCE_PASSWORD=${{ secrets.SPRING_DATASOURCE_PASSWORD }}" >> .env
+          fi
+          
+          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
+            echo "FREEBE_BASE_URL=${{ secrets.FREEBE_BASE_URL_DEV }}" >> .env
+          else
+            echo "FREEBE_BASE_URL=${{ secrets.FREEBE_BASE_URL }}" >> .env
+          fi
+          
+          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
+            echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID_DEV }}" >> .env
+          else
+            echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}" >> .env
+          fi
+          
           echo "JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}" >> .env
           echo "AWS_REGION=${{ secrets.AWS_REGION }}" >> .env
           echo "AWS_ACCESS_KEY=${{ secrets.CICD_ACCESS_KEY }}" >> .env
           echo "AWS_SECRET_KEY=${{ secrets.CICD_SECRET_KEY }}" >> .env
-          echo "AWS_S3_CICD_BUCKET=${{ secrets.AWS_S3_CICD_BUCKET }}" >> .env
-          echo "AWS_S3_DATA_BUCKET=${{ secrets.AWS_S3_DATA_BUCKET }}" >> .env
+          
+          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
+            echo "AWS_S3_CICD_BUCKET=${{ secrets.AWS_S3_CICD_BUCKET_DEV }}" >> .env
+          else
+            echo "AWS_S3_CICD_BUCKET=${{ secrets.AWS_S3_CICD_BUCKET }}" >> .env
+          fi
+          
+          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
+            echo "AWS_S3_DATA_BUCKET=${{ secrets.AWS_S3_DATA_BUCKET_DEV }}" >> .env
+          else
+            echo "AWS_S3_DATA_BUCKET=${{ secrets.AWS_S3_DATA_BUCKET }}" >> .env
+          fi
+          
           echo "AWS_S3_ORIGINAL_PATH=${{ secrets.AWS_S3_ORIGINAL_PATH }}" >> .env
           echo "AWS_S3_THUMBNAIL_PATH=${{ secrets.AWS_S3_THUMBNAIL_PATH }}" >> .env
           echo "AWS_S3_PHOTOGRAPHER_PATH=${{ secrets.AWS_S3_PHOTOGRAPHER_PATH }}" >> .env
@@ -47,9 +111,21 @@ jobs:
           echo "AWS_S3_BANNER_PATH=${{ secrets.AWS_S3_BANNER_PATH }}" >> .env
           echo "AWS_S3_RESERVATION_PATH=${{ secrets.AWS_S3_RESERVATION_PATH }}" >> .env
           echo "AWS_CODE_DEPLOY_APPLICATION=${{ secrets.AWS_CODE_DEPLOY_APPLICATION }}" >> .env
-          echo "AWS_CODE_DEPLOY_GROUP=${{ secrets.AWS_CODE_DEPLOY_GROUP }}" >> .env
+          
+          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
+            echo "AWS_CODE_DEPLOY_GROUP=${{ secrets.AWS_CODE_DEPLOY_GROUP_DEV }}" >> .env
+          else
+            echo "AWS_CODE_DEPLOY_GROUP=${{ secrets.AWS_CODE_DEPLOY_GROUP }}" >> .env
+          fi
+          
           echo "NEW_RELIC_LICENSE_KEY=${{ secrets.NEW_RELIC_LICENSE_KEY }}" >> .env
           echo "NEW_RELIC_APP_NAME=${{ secrets.NEW_RELIC_APP_NAME }}" >> .env
+          
+          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
+            echo "ENVIRONMENT=${{ secrets.ENVIRONMENT_DEV }}" >> .env
+          else
+            echo "ENVIRONMENT=${{ secrets.ENVIRONMENT }}" >> .env
+          fi
 
       - name: gradlew에 실행 권한 부여
         run: chmod +x ./gradlew

--- a/.github/workflows/cd_workflow_dev.yml
+++ b/.github/workflows/cd_workflow_dev.yml
@@ -101,6 +101,14 @@ jobs:
             aws s3 cp freebe.zip s3://${{secrets.AWS_S3_CICD_BUCKET}}/cicdtest/freebe.zip --region ap-northeast-2
           fi
 
+      - name: 배포 그룹 정보 출력
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
+            echo "Using dev deployment group: ${{ secrets.AWS_CODE_DEPLOY_GROUP_DEV }}"
+          else
+            echo "Using production deployment group: ${{ secrets.AWS_CODE_DEPLOY_GROUP }}"
+          fi
+          
       - name: Code Deploy 로 배포
         run: |
           if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then

--- a/.github/workflows/cd_workflow_dev.yml
+++ b/.github/workflows/cd_workflow_dev.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: env 설정
         run: |
-          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
+          if [[ "${{ github.ref }}" == "refs/pull/62/merge" ]]; then
             echo "KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET_DEV }}" >> .env
             echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID_DEV }}" >> .env
             echo "KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI_DEV }}" >> .env
@@ -87,7 +87,7 @@ jobs:
 
       - name: S3에 jar 업로드(실행 파일)
         run: |
-          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
+          if [[ "${{ github.ref }}" == "refs/pull/62/merge" ]]; then
             aws s3 cp ./build/libs/freebe-0.0.1-SNAPSHOT.jar s3://${{secrets.AWS_S3_CICD_BUCKET_DEV}}/cicdtest/freebe.jar --region ap-northeast-2
           else
             aws s3 cp ./build/libs/freebe-0.0.1-SNAPSHOT.jar s3://${{secrets.AWS_S3_CICD_BUCKET}}/cicdtest/freebe.jar --region ap-northeast-2
@@ -95,7 +95,7 @@ jobs:
 
       - name: S3에 zip 업로드(전체 파일)
         run: |
-          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
+          if [[ "${{ github.ref }}" == "refs/pull/62/merge" ]]; then
             aws s3 cp freebe.zip s3://${{secrets.AWS_S3_CICD_BUCKET_DEV}}/cicdtest/freebe.zip --region ap-northeast-2
           else
             aws s3 cp freebe.zip s3://${{secrets.AWS_S3_CICD_BUCKET}}/cicdtest/freebe.zip --region ap-northeast-2
@@ -103,15 +103,15 @@ jobs:
 
       - name: 배포 그룹 정보 출력
         run: |
-          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
+          if [[ "${{ github.ref }}" == "refs/pull/62/merge" ]]; then
             echo "Using dev deployment group: ${{ secrets.AWS_CODE_DEPLOY_GROUP_DEV }}"
           else
             echo "Using production deployment group: ${{ secrets.AWS_CODE_DEPLOY_GROUP }}"
           fi
-          
+
       - name: Code Deploy 로 배포
         run: |
-          if [[ "${{ github.ref }}" == "refs/heads/dev-infra-test" ]]; then
+          if [[ "${{ github.ref }}" == "refs/pull/62/merge" ]]; then
             aws deploy create-deployment --application-name ${{ secrets.AWS_CODE_DEPLOY_APPLICATION }}
             --deployment-config-name CodeDeployDefault.AllAtOnce
             --deployment-group-name ${{ secrets.AWS_CODE_DEPLOY_GROUP_DEV }}

--- a/.github/workflows/cd_workflow_dev.yml
+++ b/.github/workflows/cd_workflow_dev.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Code Deploy 로 배포
         run:
-          aws deploy create-deployment --application-name ${{ secrets.AWS_CODE_DEPLOY_APPLICATION }} \
-          --deployment-config-name CodeDeployDefault.AllAtOnce \
-          --deployment-group-name ${{ secrets.AWS_CODE_DEPLOY_GROUP_DEV }} \
+          aws deploy create-deployment --application-name ${{ secrets.AWS_CODE_DEPLOY_APPLICATION }}
+          --deployment-config-name CodeDeployDefault.AllAtOnce
+          --deployment-group-name ${{ secrets.AWS_CODE_DEPLOY_GROUP_DEV }}
           --s3-location bucket=${{ secrets.AWS_S3_CICD_BUCKET_DEV }},bundleType=zip,key=cicdtest/freebe.zip

--- a/.github/workflows/cd_workflow_dev.yml
+++ b/.github/workflows/cd_workflow_dev.yml
@@ -112,13 +112,13 @@ jobs:
       - name: Code Deploy 로 배포
         run: |
           if [[ "${{ github.ref }}" == "refs/pull/62/merge" ]]; then
-            aws deploy create-deployment --application-name ${{ secrets.AWS_CODE_DEPLOY_APPLICATION }}
-            --deployment-config-name CodeDeployDefault.AllAtOnce
-            --deployment-group-name ${{ secrets.AWS_CODE_DEPLOY_GROUP_DEV }}
+            aws deploy create-deployment --application-name ${{ secrets.AWS_CODE_DEPLOY_APPLICATION }} \
+            --deployment-config-name CodeDeployDefault.AllAtOnce \
+            --deployment-group-name ${{ secrets.AWS_CODE_DEPLOY_GROUP_DEV }} \
             --s3-location bucket=${{ secrets.AWS_S3_CICD_BUCKET_DEV }},bundleType=zip,key=cicdtest/freebe.zip
           else
-            aws deploy create-deployment --application-name ${{ secrets.AWS_CODE_DEPLOY_APPLICATION }}
-            --deployment-config-name CodeDeployDefault.AllAtOnce
-            --deployment-group-name ${{ secrets.AWS_CODE_DEPLOY_GROUP }}
+            aws deploy create-deployment --application-name ${{ secrets.AWS_CODE_DEPLOY_APPLICATION }} \
+            --deployment-config-name CodeDeployDefault.AllAtOnce \
+            --deployment-group-name ${{ secrets.AWS_CODE_DEPLOY_GROUP }} \
             --s3-location bucket=${{ secrets.AWS_S3_CICD_BUCKET }},bundleType=zip,key=cicdtest/freebe.zip
           fi

--- a/.github/workflows/cd_workflow_prod.yml
+++ b/.github/workflows/cd_workflow_prod.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Code Deploy 로 배포
         run:
-          aws deploy create-deployment --application-name ${{ secrets.AWS_CODE_DEPLOY_APPLICATION }} \
-          --deployment-config-name CodeDeployDefault.AllAtOnce \
-          --deployment-group-name ${{ secrets.AWS_CODE_DEPLOY_GROUP }} \
+          aws deploy create-deployment --application-name ${{ secrets.AWS_CODE_DEPLOY_APPLICATION }}
+          --deployment-config-name CodeDeployDefault.AllAtOnce
+          --deployment-group-name ${{ secrets.AWS_CODE_DEPLOY_GROUP }}
           --s3-location bucket=${{ secrets.AWS_S3_CICD_BUCKET }},bundleType=zip,key=cicdtest/freebe.zip

--- a/.github/workflows/cd_workflow_prod.yml
+++ b/.github/workflows/cd_workflow_prod.yml
@@ -21,7 +21,6 @@ jobs:
 
       - name: env 설정
         run:
-          # 소스코드에 필요한 env
           echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}" >> .env
           echo "KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }}" >> .env
           echo "KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }}" >> .env
@@ -46,7 +45,6 @@ jobs:
           echo "NEW_RELIC_LICENSE_KEY=${{ secrets.NEW_RELIC_LICENSE_KEY }}" >> .env
           echo "NEW_RELIC_APP_NAME=${{ secrets.NEW_RELIC_APP_NAME }}" >> .env
           
-          # 소스코드에 필요하지 않은 env
           echo "AWS_CODE_DEPLOY_APPLICATION=${{ secrets.AWS_CODE_DEPLOY_APPLICATION }}" >> .env
           echo "AWS_CODE_DEPLOY_GROUP=${{ secrets.AWS_CODE_DEPLOY_GROUP }}" >> .env
           echo "AWS_S3_CICD_BUCKET=${{ secrets.AWS_S3_CICD_BUCKET }}" >> .env

--- a/.github/workflows/cd_workflow_prod.yml
+++ b/.github/workflows/cd_workflow_prod.yml
@@ -1,12 +1,9 @@
-name: Backend Dev Server CD
+name: Backend Prod Server CD
 
 on:
   push:
     branches:
-      - 'release/**'
-  pull_request:
-    branches:
-      - feat/FU-244-dev-infra-test
+      - master
 
 jobs:
   build:
@@ -25,19 +22,19 @@ jobs:
       - name: env 설정
         run:
           # 소스코드에 필요한 env
-          echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID_DEV }}" >> .env
-          echo "KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET_DEV }}" >> .env
-          echo "KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI_DEV }}" >> .env
-          echo "KAKAO_API_ADMIN_KEY=${{ secrets.KAKAO_API_ADMIN_KEY_DEV }}" >> .env
-          echo "SPRING_DATASOURCE_URL=${{ secrets.SPRING_DATASOURCE_URL_DEV }}" >> .env
-          echo "SPRING_DATASOURCE_USERNAME=${{ secrets.SPRING_DATASOURCE_USERNAME_DEV }}" >> .env
-          echo "SPRING_DATASOURCE_PASSWORD=${{ secrets.SPRING_DATASOURCE_PASSWORD_DEV }}" >> .env
-          echo "FREEBE_BASE_URL=${{ secrets.FREEBE_BASE_URL_DEV }}" >> .env
+          echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}" >> .env
+          echo "KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }}" >> .env
+          echo "KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }}" >> .env
+          echo "KAKAO_API_ADMIN_KEY=${{ secrets.KAKAO_API_ADMIN_KEY }}" >> .env
+          echo "SPRING_DATASOURCE_URL=${{ secrets.SPRING_DATASOURCE_URL }}" >> .env
+          echo "SPRING_DATASOURCE_USERNAME=${{ secrets.SPRING_DATASOURCE_USERNAME }}" >> .env
+          echo "SPRING_DATASOURCE_PASSWORD=${{ secrets.SPRING_DATASOURCE_PASSWORD }}" >> .env
+          echo "FREEBE_BASE_URL=${{ secrets.FREEBE_BASE_URL }}" >> .env
           echo "JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}" >> .env
           echo "AWS_REGION=${{ secrets.AWS_REGION }}" >> .env
           echo "AWS_ACCESS_KEY=${{ secrets.CICD_ACCESS_KEY }}" >> .env
           echo "AWS_SECRET_KEY=${{ secrets.CICD_SECRET_KEY }}" >> .env
-          echo "AWS_S3_DATA_BUCKET=${{ secrets.AWS_S3_DATA_BUCKET_DEV }}" >> .env
+          echo "AWS_S3_DATA_BUCKET=${{ secrets.AWS_S3_DATA_BUCKET }}" >> .env
           echo "AWS_S3_ORIGINAL_PATH=${{ secrets.AWS_S3_ORIGINAL_PATH }}" >> .env
           echo "AWS_S3_THUMBNAIL_PATH=${{ secrets.AWS_S3_THUMBNAIL_PATH }}" >> .env
           echo "AWS_S3_PHOTOGRAPHER_PATH=${{ secrets.AWS_S3_PHOTOGRAPHER_PATH }}" >> .env
@@ -51,10 +48,9 @@ jobs:
           
           # 소스코드에 필요하지 않은 env
           echo "AWS_CODE_DEPLOY_APPLICATION=${{ secrets.AWS_CODE_DEPLOY_APPLICATION }}" >> .env
-          echo "AWS_CODE_DEPLOY_GROUP=${{ secrets.AWS_CODE_DEPLOY_GROUP_DEV }}" >> .env
-          echo "AWS_S3_CICD_BUCKET=${{ secrets.AWS_S3_CICD_BUCKET_DEV }}" >> .env
-          echo "ENVIRONMENT=${{ secrets.ENVIRONMENT_DEV }}" >> .env
-
+          echo "AWS_CODE_DEPLOY_GROUP=${{ secrets.AWS_CODE_DEPLOY_GROUP }}" >> .env
+          echo "AWS_S3_CICD_BUCKET=${{ secrets.AWS_S3_CICD_BUCKET }}" >> .env
+          echo "ENVIRONMENT=${{ secrets.ENVIRONMENT }}" >> .env
 
       - name: gradlew에 실행 권한 부여
         run: chmod +x ./gradlew
@@ -74,15 +70,15 @@ jobs:
 
       - name: S3에 jar 업로드(실행 파일)
         run:
-          aws s3 cp ./build/libs/freebe-0.0.1-SNAPSHOT.jar s3://${{secrets.AWS_S3_CICD_BUCKET_DEV}}/cicdtest/freebe.jar --region ap-northeast-2
+          aws s3 cp ./build/libs/freebe-0.0.1-SNAPSHOT.jar s3://${{secrets.AWS_S3_CICD_BUCKET}}/cicdtest/freebe.jar --region ap-northeast-2
 
       - name: S3에 zip 업로드(전체 파일)
         run:
-          aws s3 cp freebe.zip s3://${{secrets.AWS_S3_CICD_BUCKET_DEV}}/cicdtest/freebe.zip --region ap-northeast-2
+          aws s3 cp freebe.zip s3://${{secrets.AWS_S3_CICD_BUCKET}}/cicdtest/freebe.zip --region ap-northeast-2
 
       - name: Code Deploy 로 배포
         run:
           aws deploy create-deployment --application-name ${{ secrets.AWS_CODE_DEPLOY_APPLICATION }} \
           --deployment-config-name CodeDeployDefault.AllAtOnce \
-          --deployment-group-name ${{ secrets.AWS_CODE_DEPLOY_GROUP_DEV }} \
-          --s3-location bucket=${{ secrets.AWS_S3_CICD_BUCKET_DEV }},bundleType=zip,key=cicdtest/freebe.zip
+          --deployment-group-name ${{ secrets.AWS_CODE_DEPLOY_GROUP }} \
+          --s3-location bucket=${{ secrets.AWS_S3_CICD_BUCKET }},bundleType=zip,key=cicdtest/freebe.zip

--- a/.github/workflows/cd_workflow_prod.yml
+++ b/.github/workflows/cd_workflow_prod.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - feat/FU-244-dev-infra-test
 
 jobs:
   build:

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -35,7 +35,11 @@ fi
 
 # 애플리케이션 실행
 echo "[$NOW] > $JAR 실행" >> $START_LOG
-nohup java -javaagent:$NEW_RELIC_JAR_FILE -Dnewrelic.config.license_key=$NEW_RELIC_LICENSE_KEY -Dnewrelic.config.app_name=$NEW_RELIC_APP_NAME -jar $JAR > $APP_LOG 2> $ERROR_LOG &
+if [ "$ENVIRONMENT" = "develop" ]; then
+  nohup java -jar $JAR > $APP_LOG 2 > $ERROR_LOG &
+else
+  nohup java -javaagent:$NEW_RELIC_JAR_FILE -Dnewrelic.config.license_key=$NEW_RELIC_LICENSE_KEY -Dnewrelic.config.app_name=$NEW_RELIC_APP_NAME -jar $JAR > $APP_LOG 2> $ERROR_LOG &
+fi
 
   # 실행된 프로세스의 PID 확인
 NEW_SERVICE_PID=$(pgrep -f $JAR)

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -36,7 +36,7 @@ fi
 # 애플리케이션 실행
 echo "[$NOW] > $JAR 실행" >> $START_LOG
 if [ "$ENVIRONMENT" = "develop" ]; then
-  nohup java -jar $JAR > $APP_LOG 2 > $ERROR_LOG &
+  nohup java -jar $JAR > $APP_LOG 2> $ERROR_LOG &
 else
   nohup java -javaagent:$NEW_RELIC_JAR_FILE -Dnewrelic.config.license_key=$NEW_RELIC_LICENSE_KEY -Dnewrelic.config.app_name=$NEW_RELIC_APP_NAME -jar $JAR > $APP_LOG 2> $ERROR_LOG &
 fi


### PR DESCRIPTION
## 체크리스트

- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
- gitflow 전략에 맞춰 개발 환경과 프로덕션 환경의 배포 자동화를 분리했습니다.
*hot fix 브랜치는 사용하지 않습니다.
- develop -> release로 병합되는 경우에는 개발 서버로 향하는 code deploy group으로 배포되게끔 하고, release -> master로 병합되는 경우에는 운영 서버로 향하는 code deploy group으로 배포되게끔 했습니다.
![image](https://github.com/user-attachments/assets/758cc078-6811-4b11-a23d-e4c1a8d74629)

## 고민한 사항
(겪었던 에러)
cd_workflow 실행 시, build 과정에서 `Code Deploy로 배포` 프로세스에서 아래와 같은 에러가 발생했습니다.
```
An error occurred (DeploymentGroupNameRequiredException) when calling the CreateDeployment operation: Deployment Group name is missing
Error: Process completed with exit code 254.
```


DeploymentGroupName이 환경변수 세팅 되어있음에도 지속적으로 에러가 발생했고, 에러를 재현하던 중 아래와 같은 하나의 명령어가 줄바꿈 처리 되면서 여러 개의 명령어로 인식되어 발생하는 문제임을 파악했습니다. 따라서 이런 경우에는 명령어의 각 줄 끝에 `\` 백슬래시를 추가해 하나의 명령어로 인식되게끔 하는게 필요했습니다. 

```
          aws deploy create-deployment --application-name ${{ secrets.AWS_CODE_DEPLOY_APPLICATION }}
          --deployment-config-name CodeDeployDefault.AllAtOnce
          --deployment-group-name ${{ secrets.AWS_CODE_DEPLOY_GROUP_DEV }}
          --s3-location bucket=${{ secrets.AWS_S3_CICD_BUCKET_DEV }},bundleType=zip,key=cicdtest/freebe.zip
```

그런데 백슬래시로 명령어를 구분하는건 파이프로 명령어를 실행할때만 필요하고, 그 이외에는 오히려 백슬래시로 구분하지 않아야 에러가 나지 않는 것 같습니다.. 초기 커밋에서 if/else문으로 개발 환경과 프로덕션 환경의 코드 디플로이 명령을 구분할 때는 파이프로 명령어를 실행했는데 이 경우에는 백슬래시 개행이 필요했던 반면, 이후 커밋에서는 개발환경과 프로덕션환경의 워크플로우 자체를 구분해 파이프를 통하지 않은 명령어를 실행하니 백슬래시 개행을 지워줘야 정상 동작하는 것을 확인했습니다. 
(나중에 유사한 문제가 발생할 때 기억하기 위해 기록해둡니당 ✍️)

## 리뷰 요청사항
📣 develop이 아닌, feat/FU-244-dev-infrat-test로 향하는 PR입니다. 
해당 풀리퀘 병합된 직후에 feat/FU-244-dev-infra-test -> develop으로 향하는 PR 하나 더 올라갈 예정입니다.