### PR TITLE
Fix/fu 305 register product

### DIFF
--- a/src/main/java/com/foru/freebe/product/dto/customer/ProductDetailResponse.java
+++ b/src/main/java/com/foru/freebe/product/dto/customer/ProductDetailResponse.java
@@ -2,11 +2,13 @@ package com.foru.freebe.product.dto.customer;
 
 import java.util.List;
 
+import com.foru.freebe.notice.dto.NoticeDto;
 import com.foru.freebe.product.dto.photographer.ProductComponentDto;
 import com.foru.freebe.product.dto.photographer.ProductDiscountDto;
 import com.foru.freebe.product.dto.photographer.ProductOptionDto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,6 +28,9 @@ public class ProductDetailResponse {
     @NotBlank
     private String basicPlace;
 
+    @NotEmpty
+    private List<NoticeDto> notices;
+
     @NotNull
     private Boolean allowPreferredPlace;
 
@@ -41,12 +46,14 @@ public class ProductDetailResponse {
 
     @Builder
     public ProductDetailResponse(String productTitle, String productDescription, Long basicPrice, String basicPlace,
-        Boolean allowPreferredPlace, List<String> productImageUrls, List<ProductComponentDto> productComponents,
-        List<ProductOptionDto> productOptions, List<ProductDiscountDto> productDiscounts) {
+        List<NoticeDto> notices, Boolean allowPreferredPlace, List<String> productImageUrls,
+        List<ProductComponentDto> productComponents, List<ProductOptionDto> productOptions,
+        List<ProductDiscountDto> productDiscounts) {
         this.productTitle = productTitle;
         this.productDescription = productDescription;
         this.basicPrice = basicPrice;
         this.basicPlace = basicPlace;
+        this.notices = notices;
         this.allowPreferredPlace = allowPreferredPlace;
         this.productImageUrls = productImageUrls;
         this.productComponents = productComponents;

--- a/src/main/java/com/foru/freebe/product/dto/photographer/ProductRegisterRequest.java
+++ b/src/main/java/com/foru/freebe/product/dto/photographer/ProductRegisterRequest.java
@@ -2,7 +2,10 @@ package com.foru.freebe.product.dto.photographer;
 
 import java.util.List;
 
+import com.foru.freebe.notice.dto.NoticeDto;
+
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -23,6 +26,9 @@ public class ProductRegisterRequest {
 
     @NotBlank(message = "PhotoPlace name must not be blank")
     private String basicPlace;
+
+    @NotEmpty(message = "Notice must not be empty")
+    private List<NoticeDto> notices;
 
     @NotNull
     private Boolean allowPreferredPlace;

--- a/src/main/java/com/foru/freebe/product/dto/photographer/UpdateProductDetailRequest.java
+++ b/src/main/java/com/foru/freebe/product/dto/photographer/UpdateProductDetailRequest.java
@@ -2,7 +2,10 @@ package com.foru.freebe.product.dto.photographer;
 
 import java.util.List;
 
+import com.foru.freebe.notice.dto.NoticeDto;
+
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
@@ -31,6 +34,9 @@ public class UpdateProductDetailRequest {
     @NotBlank(message = "PhotoPlace name must not be blank")
     private String basicPlace;
 
+    @NotEmpty(message = "Notice must not be empty")
+    private List<NoticeDto> notices;
+
     @NotNull
     private Boolean allowPreferredPlace;
 
@@ -43,7 +49,8 @@ public class UpdateProductDetailRequest {
 
     @Builder
     public UpdateProductDetailRequest(Long productId, List<String> existingUrls, String productTitle,
-        String productDescription, Long basicPrice, String basicPlace, Boolean allowPreferredPlace,
+        String productDescription, Long basicPrice, String basicPlace, List<NoticeDto> notices,
+        Boolean allowPreferredPlace,
         List<ProductComponentDto> productComponents, List<ProductOptionDto> productOptions,
         List<ProductDiscountDto> productDiscounts) {
         this.productId = productId;
@@ -52,6 +59,7 @@ public class UpdateProductDetailRequest {
         this.productDescription = productDescription;
         this.basicPrice = basicPrice;
         this.basicPlace = basicPlace;
+        this.notices = notices;
         this.allowPreferredPlace = allowPreferredPlace;
         this.productComponents = productComponents;
         this.productOptions = productOptions;

--- a/src/main/java/com/foru/freebe/product/entity/Product.java
+++ b/src/main/java/com/foru/freebe/product/entity/Product.java
@@ -84,11 +84,12 @@ public class Product extends BaseEntity {
     }
 
     public void assignBasicProductInfo(String updateTitle, String updateDescription, Long updateBasicPrice,
-        String updateBasicPlace, Boolean updateAllowPreferredPlace) {
+        String updateBasicPlace, Boolean updateAllowPreferredPlace, Map<String, PhotoNotice> photoNotice) {
         this.title = updateTitle;
         this.description = updateDescription;
         this.basicPrice = updateBasicPrice;
         this.basicPlace = updateBasicPlace;
         this.allowPreferredPlace = updateAllowPreferredPlace;
+        this.photoNotice = photoNotice;
     }
 }

--- a/src/main/java/com/foru/freebe/product/entity/Product.java
+++ b/src/main/java/com/foru/freebe/product/entity/Product.java
@@ -1,10 +1,16 @@
 package com.foru.freebe.product.entity;
 
+import java.util.Map;
+
+import org.hibernate.annotations.Type;
+
 import com.foru.freebe.common.entity.BaseEntity;
 import com.foru.freebe.errors.errorcode.ProductErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
 import com.foru.freebe.member.entity.Member;
+import com.foru.freebe.reservation.dto.PhotoNotice;
 
+import io.hypersistence.utils.hibernate.type.json.JsonType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -49,19 +55,24 @@ public class Product extends BaseEntity {
     @NotNull
     private Boolean allowPreferredPlace;
 
+    @Type(JsonType.class)
+    @Column(name = "photo_notice", columnDefinition = "longtext")
+    private Map<String, PhotoNotice> photoNotice;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
     @Builder
     public Product(String title, String description, ActiveStatus activeStatus, Long basicPrice, String basicPlace,
-        Boolean allowPreferredPlace, Member member) {
+        Boolean allowPreferredPlace, Map<String, PhotoNotice> photoNotice, Member member) {
         this.title = title;
         this.description = description;
         this.activeStatus = activeStatus;
         this.basicPrice = basicPrice;
         this.basicPlace = basicPlace;
         this.allowPreferredPlace = allowPreferredPlace;
+        this.photoNotice = photoNotice;
         this.member = member;
     }
 

--- a/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
@@ -122,12 +122,15 @@ public class PhotographerProductService {
             validateProductTitleBeforeRegister(updateProductDetailRequest.getProductTitle(), photographer);
         }
 
+        Map<String, PhotoNotice> photoNotice = getStringPhotoNoticeMap(updateProductDetailRequest.getNotices());
+
         product.assignBasicProductInfo(
             updateProductDetailRequest.getProductTitle(),
             updateProductDetailRequest.getProductDescription(),
             updateProductDetailRequest.getBasicPrice(),
             updateProductDetailRequest.getBasicPlace(),
-            updateProductDetailRequest.getAllowPreferredPlace());
+            updateProductDetailRequest.getAllowPreferredPlace(),
+            photoNotice);
 
         updateProductImage(photographer.getId(), updateProductDetailRequest, images, product);
         updateProductCompositionExcludingImage(updateProductDetailRequest, product);

--- a/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
@@ -3,6 +3,7 @@ package com.foru.freebe.product.service;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -18,6 +19,7 @@ import com.foru.freebe.errors.errorcode.ProductImageErrorCode;
 import com.foru.freebe.errors.exception.RestApiException;
 import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.member.repository.MemberRepository;
+import com.foru.freebe.notice.dto.NoticeDto;
 import com.foru.freebe.product.dto.customer.ProductDetailResponse;
 import com.foru.freebe.product.dto.photographer.ProductComponentDto;
 import com.foru.freebe.product.dto.photographer.ProductDiscountDto;
@@ -38,6 +40,7 @@ import com.foru.freebe.product.respository.ProductDiscountRepository;
 import com.foru.freebe.product.respository.ProductImageRepository;
 import com.foru.freebe.product.respository.ProductOptionRepository;
 import com.foru.freebe.product.respository.ProductRepository;
+import com.foru.freebe.reservation.dto.PhotoNotice;
 import com.foru.freebe.reservation.entity.ReservationStatus;
 import com.foru.freebe.reservation.repository.ReservationFormRepository;
 import com.foru.freebe.s3.S3ImageService;
@@ -297,6 +300,8 @@ public class PhotographerProductService {
 
         validateProductTitleBeforeRegister(request.getProductTitle(), photographer);
 
+        Map<String, PhotoNotice> photoNotice = getStringPhotoNoticeMap(request.getNotices());
+
         Product product = Product.builder()
             .title(request.getProductTitle())
             .description(request.getProductDescription())
@@ -304,10 +309,22 @@ public class PhotographerProductService {
             .basicPrice(request.getBasicPrice())
             .basicPlace(request.getBasicPlace())
             .allowPreferredPlace(request.getAllowPreferredPlace())
+            .photoNotice(photoNotice)
             .member(photographer)
             .build();
 
         return productRepository.save(product);
+    }
+
+    private Map<String, PhotoNotice> getStringPhotoNoticeMap(List<NoticeDto> noticeDtoList) {
+        Map<String, PhotoNotice> photoNoticeMap = new HashMap<>();
+
+        int index = 1;
+        for (NoticeDto noticeDto : noticeDtoList) {
+            photoNoticeMap.put(String.valueOf(index), new PhotoNotice(noticeDto.getTitle(), noticeDto.getContent()));
+            index += 1;
+        }
+        return photoNoticeMap;
     }
 
     private void validateProductTitleBeforeRegister(String productTitle, Member photographer) {

--- a/src/main/java/com/foru/freebe/product/service/ProductDetailConvertor.java
+++ b/src/main/java/com/foru/freebe/product/service/ProductDetailConvertor.java
@@ -3,9 +3,12 @@ package com.foru.freebe.product.service;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
+import com.foru.freebe.notice.dto.NoticeDto;
 import com.foru.freebe.product.dto.customer.ProductDetailResponse;
 import com.foru.freebe.product.dto.photographer.ProductComponentDto;
 import com.foru.freebe.product.dto.photographer.ProductDiscountDto;
@@ -19,6 +22,7 @@ import com.foru.freebe.product.respository.ProductComponentRepository;
 import com.foru.freebe.product.respository.ProductDiscountRepository;
 import com.foru.freebe.product.respository.ProductImageRepository;
 import com.foru.freebe.product.respository.ProductOptionRepository;
+import com.foru.freebe.reservation.dto.PhotoNotice;
 
 import lombok.RequiredArgsConstructor;
 
@@ -36,18 +40,26 @@ public class ProductDetailConvertor {
         List<ProductComponentDto> productComponents = convertToProductComponentDtoList(product);
         List<ProductOptionDto> productOptions = convertToProductOptionDtoList(product);
         List<ProductDiscountDto> productDiscounts = convertToProductDiscountDtoList(product);
+        List<NoticeDto> notices = convertToNoticeDtoList(product.getPhotoNotice());
 
         return ProductDetailResponse.builder()
             .productTitle(product.getTitle())
             .productDescription(product.getDescription())
             .basicPrice(product.getBasicPrice())
             .basicPlace(product.getBasicPlace())
+            .notices(notices)
             .allowPreferredPlace(product.getAllowPreferredPlace())
             .productImageUrls(productImageUrls)
             .productComponents(productComponents)
             .productOptions(productOptions)
             .productDiscounts(productDiscounts)
             .build();
+    }
+
+    private List<NoticeDto> convertToNoticeDtoList(Map<String, PhotoNotice> photoNoticeMap) {
+        return photoNoticeMap.values().stream()
+            .map(photoNotice -> new NoticeDto(photoNotice.getTitle(), photoNotice.getContent()))
+            .collect(Collectors.toList());
     }
 
     private List<ProductDiscountDto> convertToProductDiscountDtoList(Product product) {

--- a/src/main/java/com/foru/freebe/reservation/dto/PhotoNotice.java
+++ b/src/main/java/com/foru/freebe/reservation/dto/PhotoNotice.java
@@ -5,9 +5,11 @@ import java.io.Serializable;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class PhotoNotice implements Serializable {
 
     @NotBlank


### PR DESCRIPTION
## 체크리스트

- ✅ 불필요한 주석 처리가 없는가?

## 작업 내역
- Product entity에 촬영상품에 대한 공지 필드(photoNotice) 추가
- 상품 등록, 상품 상세정보 조회, 상품 상세정보 변경 API에서 공지 필드 추가

## 고민한 사항
- 클라이언트에서 전달하는 공지사항에 대한 타입이 List<NoticeDto>인데 이 타입을 Map<Integer, PhotoNotice>로 변환(이 과정에서 직렬화가 발생한 것 같습니다.)해서 저장을 했고, 이때 저장될 때는 Integer 타입이 아닌 String 타입으로 저장되는 이슈가 있었습니다. 그렇기에 다시 조회하는 과정에서 기존 Product에서는 Map<Integer, PhotoNotice> 타입으로 정의되어 있는게 productRepository를 통해 조회해올 때는 Map<String, PhotoNotice> 타입이 되어 에러가 발생했습니다. 그래서 현재는 Map<String, PhotoNotice>타입으로 photoNotice를 정의했습니다.
- 추가로 직렬화 관련된 이슈가 있었는데 이런 이슈는 어느 파트에서 해당 에러가 발생하는지 찾기가 너무 어렵더라구요...ㅠㅠ (1시간 가까이 GPT와 방황을 했습니다..ㅠㅠ) 기존에는 PhotoNotice를 단순히 객체로 사용하고 있어서 @AllArgsConstructor만 클래스에 정의가 되어 있었는데 이제 Json 타입으로 변환할 때 발생하는 직렬화를 해결하기 위한 기본 생성자를 만들어주는 @NoArgsConstructor가 필요했습니다.. 지난 PR에서 이러한 이슈가 있었던 걸 제가 언급했었는데 복기가 안된게 아쉽네요..ㅠㅠ (나중에 비슷한 에러를 만났을 때 다른 분들도 시간 소비 안했으면 하는 마음에 장황하게 작성했습니다🥲)

- 현재 촬영상품에 대한 공지 필드를 photoNotice 으로 작성한 이유는 Map<String, PhotoNotice> 타입으로 가져가고 있기 때문입니다. PhotoNotice의 경우 신청서 등록할 때 촬영에 대한 Notice라고 하기 위해서 이전 PR에서 정의를 했었고 해당 클래스를 상품 엔티티에서도 적용하게 되었습니다. 혹시 이 변수명이 촬영상품 공지에 어울리지 않는다면 코멘트 남겨주시면 productNotice와 같은 다른 변수로 수정하겠습니다! (사실 조금 더 고민하고 싶었지만 오늘 멘토링 때 최종 데모를 해야해서 급하게 작성한 감도 없지 않아 있습니다🥲)

## 리뷰 요청사항
- 시급도 매우 높음!
- 필드 추가와 동시에 3개의 API 로직이 업데이트 되었는데 API나 특정 로직에서 추가된 필드가 누락되진 않았는지 확인 부탁드려요!
