### PR TITLE
[FU-302] 지난예약건 조회 API 필터링기능 보완

### DIFF
--- a/src/main/java/com/foru/freebe/product/respository/ProductRepository.java
+++ b/src/main/java/com/foru/freebe/product/respository/ProductRepository.java
@@ -18,7 +18,5 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 
     Optional<Product> findByIdAndMember(Long productId, Member member);
 
-    Optional<Product> findByTitle(String title);
-
-    Boolean existsByTitle(String title);
+    Optional<Product> findByTitleAndMember(String title, Member member);
 }

--- a/src/main/java/com/foru/freebe/reservation/repository/ReservationFormRepository.java
+++ b/src/main/java/com/foru/freebe/reservation/repository/ReservationFormRepository.java
@@ -20,17 +20,9 @@ public interface ReservationFormRepository extends JpaRepository<ReservationForm
 
     List<ReservationForm> findAllByPhotographerIdAndProductTitle(Long photographerId, String productTitle);
 
-    Page<ReservationForm> findByPhotographerId(Long photographerId, Pageable pageable);
-
     Page<ReservationForm> findByPhotographerIdAndReservationStatusIn(Long photographerId,
         List<ReservationStatus> status, Pageable pageable);
 
-    Page<ReservationForm> findByPhotographerIdAndShootingDate_DateBetween(Long photographerId, LocalDate from,
-        LocalDate to,
-        Pageable pageable);
-
     Page<ReservationForm> findByPhotographerIdAndReservationStatusInAndShootingDate_DateBetween(Long photographerId,
         List<ReservationStatus> status, LocalDate from, LocalDate to, Pageable pageable);
-
-    List<ReservationForm> findByProductTitle(String title);
 }

--- a/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
@@ -113,7 +113,8 @@ public class CustomerReservationService {
         ReservationForm reservationForm = reservationFormRepository.findById(formId)
             .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
 
-        Product product = productRepository.findByTitle(reservationForm.getProductTitle())
+        Product product = productRepository.findByTitleAndMember(reservationForm.getProductTitle(),
+                reservationForm.getPhotographer())
             .orElseThrow(() -> new RestApiException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
         Map<String, PhotoNotice> photoNotice = product.getPhotoNotice();

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerPastReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerPastReservationService.java
@@ -66,10 +66,15 @@ public class PhotographerPastReservationService {
             }
         } else {
             if (from != null && to != null) {
-                reservationFormPage = reservationFormRepository.findByPhotographerIdAndShootingDate_DateBetween(
-                    photographerId, from, to, pageable);
+                reservationFormPage = reservationFormRepository.findByPhotographerIdAndReservationStatusInAndShootingDate_DateBetween(
+                    photographerId, Arrays.asList(ReservationStatus.CANCELLED_BY_PHOTOGRAPHER,
+                        ReservationStatus.CANCELLED_BY_PHOTOGRAPHER, ReservationStatus.PHOTO_COMPLETED), from, to,
+                    pageable);
             } else {
-                reservationFormPage = reservationFormRepository.findByPhotographerId(photographerId, pageable);
+                reservationFormPage = reservationFormRepository.findByPhotographerIdAndReservationStatusIn(
+                    photographerId,
+                    Arrays.asList(ReservationStatus.CANCELLED_BY_PHOTOGRAPHER, ReservationStatus.CANCELLED_BY_CUSTOMER,
+                        ReservationStatus.PHOTO_COMPLETED), pageable);
             }
         }
 

--- a/src/main/java/com/foru/freebe/reservation/service/PhotographerPastReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/PhotographerPastReservationService.java
@@ -111,7 +111,7 @@ public class PhotographerPastReservationService {
     }
 
     private PastReservationFormComponent convertToPastReservationComponent(ReservationForm form) {
-        Product product = productRepository.findByTitle(form.getProductTitle())
+        Product product = productRepository.findByTitleAndMember(form.getProductTitle(), form.getPhotographer())
             .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
 
         List<ProductImage> productImage = productImageRepository.findByProduct(product);


### PR DESCRIPTION
## 체크리스트

- [x] 불필요한 주석 처리가 없는가?

</br>

## 작업 내역
1. 지난예약 페이지에서 취소건, 완료건을 선택하지 않고 `전체`로 조회했을 때 취소+완료건이 조회될 수 있도록 수정했습니다.
2. ProductRepository에서 특정 상품을 찾을 때 findByTitle을 사용하지 않고, findByTitleAndMember 등으로 조회할 수 있게 수정했습니다. 기존 방식을 사용할 경우 상품제목이 겹치는 유저가 여러명일 때 sql query 실행 시 unique한 결과를 반환하지 못하는 문제가 있었습니다.
</br>

## 고민한 사항
지난예약 페이지에서 키워드를 포함해 검색할 경우 total pages가 적절하게 반환되지 않는 문제가 있습니다. 로컬환경에서는 이 문제가 재현되지 않고 있어서 해당 PR 병합하여 개발서버에서 테스트 진행해볼 예정입니다.

</br>

## 리뷰 요청사항
(시급도 높음) 개발 서버에서 테스트 필요합니다.
