### PR TITLE
[FU-313] UI 변경에 따른 회원가입 API/비즈니스 로직 업데이트

### DIFF
--- a/.github/workflows/cd_workflow_dev.yml
+++ b/.github/workflows/cd_workflow_dev.yml
@@ -51,6 +51,7 @@ jobs:
           echo "AWS_CODE_DEPLOY_GROUP=${{ secrets.AWS_CODE_DEPLOY_GROUP_DEV }}" >> .env
           echo "AWS_S3_CICD_BUCKET=${{ secrets.AWS_S3_CICD_BUCKET_DEV }}" >> .env
           echo "ENVIRONMENT=${{ secrets.ENVIRONMENT_DEV }}" >> .env
+          echo "TERMS_OF_MARKETING_TAG=${{ secrets.TERMS_OF_MARKETING_TAG }}" >> .env
 
       - name: gradlew에 실행 권한 부여
         run: chmod +x ./gradlew

--- a/.github/workflows/cd_workflow_prod.yml
+++ b/.github/workflows/cd_workflow_prod.yml
@@ -48,6 +48,7 @@ jobs:
           echo "AWS_CODE_DEPLOY_GROUP=${{ secrets.AWS_CODE_DEPLOY_GROUP }}" >> .env
           echo "AWS_S3_CICD_BUCKET=${{ secrets.AWS_S3_CICD_BUCKET }}" >> .env
           echo "ENVIRONMENT=${{ secrets.ENVIRONMENT }}" >> .env
+          echo "TERMS_OF_MARKETING_TAG=${{ secrets.TERMS_OF_MARKETING_TAG }}" >> .env
 
       - name: gradlew에 실행 권한 부여
         run: chmod +x ./gradlew

--- a/src/main/java/com/foru/freebe/auth/controller/AuthController.java
+++ b/src/main/java/com/foru/freebe/auth/controller/AuthController.java
@@ -42,6 +42,7 @@ public class AuthController {
         KakaoUser kakaoUser = kakaoAuthService.getUserInfo(accessToken);
 
         LoginResponse loginResponse = kakaoLoginService.findOrRegisterMember(kakaoUser, loginRequest.getRoleType());
+
         HttpHeaders headers = jwtService.setTokenHeaders(loginResponse.getToken());
         ResponseBody<?> responseBody = ResponseBody.builder()
             .message(loginResponse.getMessage())

--- a/src/main/java/com/foru/freebe/auth/model/ServiceTerms.java
+++ b/src/main/java/com/foru/freebe/auth/model/ServiceTerms.java
@@ -1,0 +1,16 @@
+package com.foru.freebe.auth.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ServiceTerms {
+    @JsonProperty("tag")
+    private String tag;
+
+    @JsonProperty("agreed")
+    private Boolean agreed;
+}

--- a/src/main/java/com/foru/freebe/auth/model/ServiceTermsAgreement.java
+++ b/src/main/java/com/foru/freebe/auth/model/ServiceTermsAgreement.java
@@ -1,0 +1,22 @@
+package com.foru.freebe.auth.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ServiceTermsAgreement {
+    @JsonProperty("id")
+    private Long kakaoId;
+
+    @JsonProperty("service_terms")
+    private List<ServiceTerms> scopes;
+
+    public Boolean getMarketingServiceTermsAgreement() {
+        return scopes.get(0).getAgreed();
+    }
+}

--- a/src/main/java/com/foru/freebe/config/CorsConfig.java
+++ b/src/main/java/com/foru/freebe/config/CorsConfig.java
@@ -15,7 +15,8 @@ public class CorsConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowCredentials(true);
-        configuration.setAllowedOrigins(Arrays.asList("https://www.freebe.co.kr", "http://localhost:3000"));
+        configuration.setAllowedOrigins(
+            Arrays.asList("https://www.freebe.co.kr", "http://localhost:3000", "15.164.160.132:3000"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setExposedHeaders(Arrays.asList("accessToken", "refreshToken"));
         configuration.setAllowedHeaders(Arrays.asList("Content-Type", "Authorization", "refreshToken"));

--- a/src/main/java/com/foru/freebe/member/dto/PhotographerJoinRequest.java
+++ b/src/main/java/com/foru/freebe/member/dto/PhotographerJoinRequest.java
@@ -1,6 +1,5 @@
 package com.foru.freebe.member.dto;
 
-import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -20,21 +19,9 @@ public class PhotographerJoinRequest {
     @Size(max = 100, message = "연락처는 최대 100자까지 입력 가능합니다.")
     private String contact;
 
-    @AssertTrue
-    private Boolean termsOfServiceAgreement;
-
-    @AssertTrue
-    private Boolean privacyPolicyAgreement;
-
-    private Boolean marketingAgreement;
-
     @Builder
-    public PhotographerJoinRequest(String profileName, String contact, Boolean termsOfServiceAgreement,
-        Boolean privacyPolicyAgreement, Boolean marketingAgreement) {
+    public PhotographerJoinRequest(String profileName, String contact) {
         this.profileName = profileName;
         this.contact = contact;
-        this.termsOfServiceAgreement = termsOfServiceAgreement;
-        this.privacyPolicyAgreement = privacyPolicyAgreement;
-        this.marketingAgreement = marketingAgreement;
     }
 }

--- a/src/main/java/com/foru/freebe/member/entity/MemberTermAgreement.java
+++ b/src/main/java/com/foru/freebe/member/entity/MemberTermAgreement.java
@@ -9,7 +9,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.AssertTrue;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,20 +28,11 @@ public class MemberTermAgreement {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @AssertTrue
-    private Boolean termsOfServiceAgreement;
-
-    @AssertTrue
-    private Boolean privacyPolicyAgreement;
-
     private Boolean marketingAgreement;
 
     @Builder
-    public MemberTermAgreement(Member member, Boolean termsOfServiceAgreement, Boolean privacyPolicyAgreement,
-        Boolean marketingAgreement) {
+    public MemberTermAgreement(Member member, Boolean marketingAgreement) {
         this.member = member;
-        this.termsOfServiceAgreement = termsOfServiceAgreement;
-        this.privacyPolicyAgreement = privacyPolicyAgreement;
         this.marketingAgreement = marketingAgreement;
     }
 }

--- a/src/main/java/com/foru/freebe/member/service/PhotographerJoinService.java
+++ b/src/main/java/com/foru/freebe/member/service/PhotographerJoinService.java
@@ -2,6 +2,8 @@ package com.foru.freebe.member.service;
 
 import org.springframework.stereotype.Service;
 
+import com.foru.freebe.auth.model.ServiceTermsAgreement;
+import com.foru.freebe.auth.service.KakaoAuthService;
 import com.foru.freebe.member.dto.PhotographerJoinRequest;
 import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.member.entity.MemberTermAgreement;
@@ -20,12 +22,14 @@ public class PhotographerJoinService {
     private final ProfileService profileService;
     private final MemberRepository memberRepository;
     private final MemberTermAgreementRepository memberTermAgreementRepository;
+    private final KakaoAuthService kakaoAuthService;
 
     @Transactional
     public String joinPhotographer(Member member, PhotographerJoinRequest request) {
         Member photographer = completePhotographerSignup(member);
 
-        savePhotographerAgreements(photographer, request);
+        ServiceTermsAgreement serviceTermsAgreement = kakaoAuthService.getAgreementStatus(photographer.getKakaoId());
+        savePhotographerAgreements(photographer, serviceTermsAgreement);
         Profile profile = profileService.initialProfileSetting(photographer, request.getProfileName(),
             request.getContact());
 
@@ -37,12 +41,10 @@ public class PhotographerJoinService {
         return memberRepository.save(member);
     }
 
-    private void savePhotographerAgreements(Member member, PhotographerJoinRequest request) {
+    private void savePhotographerAgreements(Member member, ServiceTermsAgreement serviceTermsAgreement) {
         MemberTermAgreement memberTermAgreement = MemberTermAgreement.builder()
             .member(member)
-            .termsOfServiceAgreement(request.getTermsOfServiceAgreement())
-            .privacyPolicyAgreement(request.getPrivacyPolicyAgreement())
-            .marketingAgreement(request.getMarketingAgreement())
+            .marketingAgreement(serviceTermsAgreement.getMarketingServiceTermsAgreement())
             .build();
         memberTermAgreementRepository.save(memberTermAgreement);
     }

--- a/src/main/java/com/foru/freebe/message/dto/MessageSendRequest.java
+++ b/src/main/java/com/foru/freebe/message/dto/MessageSendRequest.java
@@ -50,7 +50,7 @@ public class MessageSendRequest {
 
         String messageTemplate = """
             새 신청이 도착했어요!
-            아래 [자세히보기] 버튼을 눌러 상세 내역을 확인해주세요.
+            아래 [자세히 보기] 버튼을 눌러 상세 내역을 확인해주세요.
 
             * 기다리고 있는 고객님을 위해 빠른 확인 부탁드립니다.
             * 조율이 필요한 경우에는 예약 수락 후 고객과 직접 이야기를 나눠보세요!""";
@@ -60,7 +60,7 @@ public class MessageSendRequest {
 
         String webUrl = "https://www.freebe.co.kr/photographer/reservation/" + formId.toString();
         Button button1 = Button.builder()
-            .name("자세히보기")
+            .name("자세히 보기")
             .type(WEB_LINK_BUTTON_TYPE)
             .urlPc(webUrl)
             .urlMobile(webUrl)

--- a/src/main/java/com/foru/freebe/message/service/MessageSendService.java
+++ b/src/main/java/com/foru/freebe/message/service/MessageSendService.java
@@ -22,7 +22,7 @@ public class MessageSendService {
     private final WebClient kakaoMessageWebClient;
     private static final String JOIN_TEMPLATE = "freebe_join";
     private static final String CUSTOMER_NEW_TEMPLATE = "c_new_1014";
-    private static final String PHOTOGRAPHER_NEW_TEMPLATE = "p_new_1014";
+    private static final String PHOTOGRAPHER_NEW_TEMPLATE = "p_new_1023";
     private static final String CUSTOMER_CANCEL_TEMPLATE = "customer_cancel";
     private static final String PHOTOGRAPHER_CANCELLED_TEMPLATE = "photographer_cancelled";
     private static final String CUSTOMER_CANCELLED_TEMPLATE = "customer_cancelled";


### PR DESCRIPTION
## 체크리스트

- [x] 불필요한 주석 처리가 없는가?

## 작업 내역
- 기존에 [개인 정보 처리방침, 서비스 이용약관, 마케팅 동의여부]와 같은 약관을 회원가입 페이지에서 받아오던 것을 카카오 간편가입 기능에 포함시켜 카카오 로그인 연동 시 약관동의를 받게 되었습니다. 따라서 회원가입 API 요청 시 요청바디에서 약관 동의여부가 빠지게 되었습니다. 
  - `개인 정보 처리방침`, `서비스 이용약관`의 경우에는 필수 동의항목이라 동의하지 않으면 카카오 로그인에 성공할 수 없기때문에 DB에 저장된 회원의 경우 해당 항목이 동의되었다고 봐도 무방합니다.
  - 다만 `마케팅 동의여부`의 경우에는 선택 항목이므로 동의 여부를 미리 DB에 저장해두어야 추후에 활용이 필요한 상황에서 유용할 것 같다는 판단이 들어 사진작가 회원가입 시점에 카카오 API 서버로 부터 마케팅 동의여부만 받아오는 외부 API를 호출하게 되었습니다.
- 개발 서버에서 CORS 설정이 빠져있어 추가했습니다.
- 새 신청 접수 시, 사진작가에게 발송되는 알림톡 탬플릿을 변경했습니다.
  - 기존: (버튼명) `자세히보기`
  - 변경후: (버튼명) `자세히 보기`

## 고민한 사항
- 마케팅 동의 여부를 어느 시점에 받아오는 것이 좋을지에 대한 고민이 있었습니다. 사진작가와 고객 양쪽의 마케팅 동의여부를 전부 확인하려면 로그인 API에 해당 로직이 포함되어야 하는데, 마케팅 항목 동의는 카카오 최초 연동 시점에만 이루어지는데 매번 로그인을 할 때마다 카카오 API 서버로부터 요청을 보내 동의 여부를 받아오는게 불필요하다는 판단이 들었습니다. 또한 마케팅 동의 여부를 고객측에 활용하게 될 상황이 있을까라는 생각도 들었기 때문에 사진작가로 가입한 경우에만 회원가입 로직에서 동의여부를 저장하는 방식을 택하게 되었습니다.

## 리뷰 요청사항
- 고민사항에 적어둔 내용 읽어보고 다른 의견 있다면 코멘트 부탁합니당