### PR TITLE
[FU-334] 에러메시지 개선

### DIFF
--- a/src/main/java/com/foru/freebe/errors/errorcode/AwsErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/AwsErrorCode.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum AwsErrorCode implements ErrorCode {
-    AMAZON_S3_EXCEPTION(404, "Amazon S3 exception"),
+    AMAZON_S3_EXCEPTION(500, "Amazon S3 exception"),
     AMAZON_SERVICE_EXCEPTION(500, "Amazon service exception"),
     DELETE_OBJECT_EXCEPTION(500, "Failed to delete image to S3 due to an internal error"),
     MAXIMUM_UPLOAD_SIZE_EXCEEDED(413, "Maximum upload size exceeded");

--- a/src/main/java/com/foru/freebe/errors/errorcode/AwsErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/AwsErrorCode.java
@@ -9,7 +9,7 @@ public enum AwsErrorCode implements ErrorCode {
     AMAZON_S3_EXCEPTION(500, "Amazon S3 exception"),
     AMAZON_SERVICE_EXCEPTION(500, "Amazon service exception"),
     DELETE_OBJECT_EXCEPTION(500, "Failed to delete image to S3 due to an internal error"),
-    MAXIMUM_UPLOAD_SIZE_EXCEEDED(413, "Maximum upload size exceeded");
+    MAXIMUM_UPLOAD_SIZE_EXCEEDED(500, "Maximum upload size exceeded");
 
     private final int httpStatus;
     private final String message;

--- a/src/main/java/com/foru/freebe/errors/errorcode/CommonErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/CommonErrorCode.java
@@ -9,7 +9,7 @@ public enum CommonErrorCode implements ErrorCode {
 
     INVALID_PARAMETER(400, "Invalid parameter included"),
     ACCESS_DENIED(403, "You don't have permission to access this resource."),
-    RESOURCE_NOT_FOUND(404, "Resource not exists"),
+    RESOURCE_NOT_FOUND(500, "Resource not exists"),
     INTERNAL_SERVER_ERROR(500, "Internal server error"),
     IO_EXCEPTION(500, "IoException occurred");
 

--- a/src/main/java/com/foru/freebe/errors/errorcode/LinkErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/LinkErrorCode.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum LinkErrorCode implements ErrorCode {
 
-    DUPLICATE_TITLE(400, "Title is duplicated");
+    LINK_TITLE_DUPLICATE(400, "Title is duplicated");
 
     private final int httpStatus;
     private final String message;

--- a/src/main/java/com/foru/freebe/errors/errorcode/MemberErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/MemberErrorCode.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MemberErrorCode implements ErrorCode {
     INVALID_LOGIN_REQUEST(400, "Invalid login request"),
-    MEMBER_NOT_FOUND(400, "Member not found"),
+    MEMBER_NOT_FOUND(500, "Member not found"),
     ERROR_MEMBER_LEAVING_FAILED(500, "Failed to complete the membership leaving. Please try again later.");
 
     private final int httpStatus;

--- a/src/main/java/com/foru/freebe/errors/errorcode/NoticeErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/NoticeErrorCode.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum NoticeErrorCode implements ErrorCode {
 
-    TITLE_DUPLICATE(400, "중복된 제목이 존재합니다"),
+    NOTICE_TITLE_DUPLICATE(400, "중복된 제목이 존재합니다"),
     NOT_FOUND_ESSENTIAL_TITLE(400, "필수 규정이 포함되어 있지 않습니다");
 
     private final int httpStatus;

--- a/src/main/java/com/foru/freebe/errors/errorcode/ProductErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/ProductErrorCode.java
@@ -10,7 +10,7 @@ public enum ProductErrorCode implements ErrorCode {
     PRODUCT_INACTIVE_STATUS(400, "The product is currently inactive, so you can't register a booking form with it"),
     PRODUCT_ALREADY_EXISTS(400, "The product already exists, so it cannot be registered again"),
     COMPONENT_TITLE_ALREADY_EXISTS(400, "Component title already exists, so it cannot be registered again"),
-    PRODUCT_NOT_FOUND(404, "The product could not be found");
+    PRODUCT_NOT_FOUND(500, "The product could not be found");
 
     private final int httpStatus;
     private final String message;

--- a/src/main/java/com/foru/freebe/errors/errorcode/ProductImageErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/ProductImageErrorCode.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ProductImageErrorCode implements ErrorCode {
-    PRODUCT_IMAGE_NOT_FOUND(404, "The product image could not be found");
+    PRODUCT_IMAGE_NOT_FOUND(500, "The product image could not be found");
 
     private final int httpStatus;
     private final String message;

--- a/src/main/java/com/foru/freebe/errors/errorcode/ProfileErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/ProfileErrorCode.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum ProfileErrorCode implements ErrorCode {
     PROFILE_NAME_ALREADY_EXISTS(400, "이미 존재하는 프로필명입니다."),
     PROFILE_NAME_NOT_FOUND(404, "존재하지 않는 프로필명입니다."),
-    MEMBER_NOT_FOUND(404, "존재하지 않는 회원입니다.");
+    PROFILE_NOT_FOUND(404, "존재하지 않는 회원입니다.");
 
     private final int httpStatus;
     private final String message;

--- a/src/main/java/com/foru/freebe/errors/errorcode/ProfileErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/ProfileErrorCode.java
@@ -7,8 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ProfileErrorCode implements ErrorCode {
     PROFILE_NAME_ALREADY_EXISTS(400, "이미 존재하는 프로필명입니다."),
-    PROFILE_NAME_NOT_FOUND(404, "존재하지 않는 프로필명입니다."),
-    PROFILE_NOT_FOUND(404, "존재하지 않는 회원입니다.");
+    PROFILE_NAME_NOT_FOUND(500, "존재하지 않는 프로필명입니다."),
+    PROFILE_NOT_FOUND(500, "존재하지 않는 회원입니다.");
 
     private final int httpStatus;
     private final String message;

--- a/src/main/java/com/foru/freebe/notice/service/PhotographerNoticeService.java
+++ b/src/main/java/com/foru/freebe/notice/service/PhotographerNoticeService.java
@@ -102,7 +102,7 @@ public class PhotographerNoticeService {
 
         requestList.forEach(request -> {
             if (!titleSet.add(request.getTitle())) {
-                throw new RestApiException(NoticeErrorCode.TITLE_DUPLICATE);
+                throw new RestApiException(NoticeErrorCode.NOTICE_TITLE_DUPLICATE);
             }
         });
     }

--- a/src/main/java/com/foru/freebe/notice/service/PhotographerNoticeService.java
+++ b/src/main/java/com/foru/freebe/notice/service/PhotographerNoticeService.java
@@ -89,7 +89,7 @@ public class PhotographerNoticeService {
 
     private Profile getProfile(Member photographer) {
         return profileRepository.findByMember(photographer)
-            .orElseThrow(() -> new RestApiException(ProfileErrorCode.MEMBER_NOT_FOUND));
+            .orElseThrow(() -> new RestApiException(ProfileErrorCode.PROFILE_NOT_FOUND));
     }
 
     private Member getMember(Long photographerId) {

--- a/src/main/java/com/foru/freebe/product/controller/PhotographerProductController.java
+++ b/src/main/java/com/foru/freebe/product/controller/PhotographerProductController.java
@@ -40,7 +40,7 @@ public class PhotographerProductController {
     @PostMapping("/product")
     public ResponseEntity<ResponseBody<Void>> registerProduct(@AuthenticationPrincipal MemberAdapter memberAdapter,
         @Valid @RequestPart(value = "request") ProductRegisterRequest request,
-        @RequestPart(value = "images", required = false) List<MultipartFile> images) throws IOException {
+        @RequestPart(value = "images") List<MultipartFile> images) throws IOException {
 
         Member photographer = memberAdapter.getMember();
         photographerProductService.registerProduct(request, images, photographer.getId());

--- a/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
+++ b/src/main/java/com/foru/freebe/product/service/PhotographerProductService.java
@@ -344,8 +344,6 @@ public class PhotographerProductService {
     private void registerProductImage(List<MultipartFile> images, Product product, Long photographerId) throws
         IOException {
 
-        validateProductImage(images);
-
         ImageLinkSet productImageLinkSet = s3ImageService.imageUploadToS3(images, S3ImageType.PRODUCT, photographerId,
             true);
         saveProductImages(product, productImageLinkSet);
@@ -358,12 +356,6 @@ public class PhotographerProductService {
             ProductImage productImage = ProductImage.createProductImage(i, originalImages.get(i),
                 thumbnailImages.get(i), product);
             productImageRepository.save(productImage);
-        }
-    }
-
-    private void validateProductImage(List<MultipartFile> images) {
-        if (images.isEmpty()) {
-            throw new RestApiException(CommonErrorCode.INVALID_PARAMETER);
         }
     }
 

--- a/src/main/java/com/foru/freebe/profile/service/PhotographerProfileService.java
+++ b/src/main/java/com/foru/freebe/profile/service/PhotographerProfileService.java
@@ -105,7 +105,7 @@ public class PhotographerProfileService {
             .count();
 
         if (isDuplicatedTitle) {
-            throw new RestApiException(LinkErrorCode.DUPLICATE_TITLE);
+            throw new RestApiException(LinkErrorCode.LINK_TITLE_DUPLICATE);
         }
     }
 

--- a/src/main/java/com/foru/freebe/profile/service/ProfileService.java
+++ b/src/main/java/com/foru/freebe/profile/service/ProfileService.java
@@ -47,7 +47,7 @@ public class ProfileService {
 
     public Profile getProfile(Member photographer) {
         return profileRepository.findByMember(photographer)
-            .orElseThrow(() -> new RestApiException(ProfileErrorCode.MEMBER_NOT_FOUND));
+            .orElseThrow(() -> new RestApiException(ProfileErrorCode.PROFILE_NOT_FOUND));
     }
 
     public String getProfileName(Long id) {
@@ -103,7 +103,7 @@ public class ProfileService {
 
     private Profile getProfile(Long memberId) {
         return profileRepository.findByMemberId(memberId)
-            .orElseThrow(() -> new RestApiException(ProfileErrorCode.MEMBER_NOT_FOUND));
+            .orElseThrow(() -> new RestApiException(ProfileErrorCode.PROFILE_NOT_FOUND));
     }
 
     private List<LinkInfo> getProfileLinkInfos(Profile profile) {

--- a/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
+++ b/src/main/java/com/foru/freebe/reservation/service/CustomerReservationService.java
@@ -136,7 +136,7 @@ public class CustomerReservationService {
 
     private Member getMemberFromProfileName(String profileName) {
         Profile photographerProfile = profileRepository.findByProfileName(profileName)
-            .orElseThrow(() -> new RestApiException(ProfileErrorCode.MEMBER_NOT_FOUND));
+            .orElseThrow(() -> new RestApiException(ProfileErrorCode.PROFILE_NOT_FOUND));
 
         return photographerProfile.getMember();
     }

--- a/src/test/java/com/foru/freebe/profile/service/ProfileServiceTest.java
+++ b/src/test/java/com/foru/freebe/profile/service/ProfileServiceTest.java
@@ -60,7 +60,7 @@ class ProfileServiceTest {
     // @Nested
     // @DisplayName("프로필 조회 테스트")
     // class ProfileQueryTest {
-    //     private Profile profile;
+    //     private Profile profile;:Qa
     //     private ProfileImage profileImage;
     //     private List<Link> links;
     //


### PR DESCRIPTION
## 체크리스트

- ✅ 불필요한 주석 처리가 없는가?

## 작업 내역
- 상품 등록 시 등록된 사진이 없는지에 대한 검증을 controller에서 진행하도록 어노테이션 옵션 추가 (기존 검증 로직을 대체할 수 있어 검증 로직은 삭제했습니다.)
- 모호한 에러메시지명 수정
   - Profile에서 MEMBER_NOT_FOUND -> PROFILE_NOT_FOUND
   - TITLE_DUPLICATE를 NOTICE, LINK 엔티티에 맞게 명확한 의미로 수정
- 서비스 운영 상 크리티컬한 오류여서 분석이 필요한 에러의 HttpStatus를 500으로 수정 - 뉴렐릭에서 500번 에러를 트래킹하여 slack으로 알림을 받아 분석하기 위함입니다.
   - AMAZON_S3_EXCEPTION: 이미지 업로드 하는 과정에서 에러가 발생한 경우
   - PROFILE_NAME_NOT_FOUND: 알림톡이 정상적으로 전송되지 않은 경우 / 사진작가의 예약 페이지가 정상적으로 조회되지 않은 경우
   - PROFILE_NOT_FOUND: 예약이 정상적으로 이뤄지지 않은 경우    

## 고민한 사항
- 어떤 경우에 에러 메시지를 500번으로 변경해야 할지에 대한 고민이 있었습니다. 무조건 서버에서 조회하는 모든 경우를 500번으로 수정하기에는 우리가 예상한 정상적인 로직에 대한 400번대 에러는 굳이 알림을 받아 분석할 필요를 느끼지 못했습니다.(제가 기준을 명확하게 찾지 못한 것 같기도 해요🥲) 현재 변경된 에러들의 기준이 명확하지 않다고 느껴지면 코멘트 남겨주세요!
- 에러메시지들이 위에서 설명한 경우를 포함하고 있기 때문에 500번 에러로 수정하였고, 해당 에러메시지를 다른 경우에 사용하는 로직에서는 에러가 발생할 확률이 현저히 낮아 따로 메시지를 분리하지는 않았습니다. 혹시 500번 에러는 메시지를 따로 분리하는 게 더 효율적일 것 같다는 의견이 있다면 코멘트 남겨주세요! 

## 리뷰 요청사항
- 시급도는 중간입니다! v1.2.0을 릴리즈 하기 전에 완료하면 될 것 같아요.
- 변경된 에러 메시지가 변경되기에 타당한지 확인해주세요!