### PR TITLE
[FU-339] 상품 중복등록 방지를 위한 제약조건 추가

### DIFF
--- a/src/main/java/com/foru/freebe/errors/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/foru/freebe/errors/handler/GlobalExceptionHandler.java
@@ -40,12 +40,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return handleExceptionInternal(errorCode, e.getMessage());
     }
 
-    @ExceptionHandler(DataIntegrityViolationException.class)
+    @ExceptionHandler(DataTruncation.class)
     public ResponseEntity<Object> handleDataTruncation(DataTruncation e) {
         ErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
-        String message = e.getMessage();
+        return handleExceptionInternal(errorCode, e.getMessage());
+    }
 
-        return handleExceptionInternal(errorCode, message);
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<Object> handleDataIntegrityViolation(DataIntegrityViolationException e) {
+        ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
+        return handleExceptionInternal(errorCode, e.getMessage());
     }
 
     // 메서드 인자의 유효성 검사가 실패했을 때 발생

--- a/src/main/java/com/foru/freebe/product/entity/Product.java
+++ b/src/main/java/com/foru/freebe/product/entity/Product.java
@@ -21,6 +21,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -31,6 +33,11 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+    uniqueConstraints = @UniqueConstraint(
+        name = "unique_title",
+        columnNames = {"title", "member_id"})
+)
 public class Product extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## 문제 상황
- 동일한 제목의 상품 두 개가 중복 등록되는 문제가 발생했습니다.
<br>

## 문제 분석
- 상품등록 API 요청을 처리하는 과정에서 S3에 이미지를 업로드하는데 많은 시간이 소요되어 클라이언트 측에서 해당 요청을 타임아웃으로 간주하는 문제가 발생했습니다. 타임아웃이 발생하면서 고객에게 상품등록 재시도를 권유하는 메시지가 노출됨과 동시에 상품등록 버튼이 재차 활성화되면서, 서버에서 첫 요청에 대한 처리가 끝나기 전에  동일한 상품등록 요청이 중복되어 들어오게 되었습니다. 
- 트랜잭션으로 묶여 있는 경우 트랜잭션이 종료되는 시점에 커밋이 자동으로 이뤄지고 DB에 변경내역이 반영됩니다. 트랜잭션 A가 종료되기 전에 이미 10초 이상의 시간이 소요됐고, 트랜잭션 B가 시작됐을 때는 변경내역이 DB에 반영되기 전이었으므로 B요청에서 상품 제목의 중복여부를 검사하는 로직도 문제 없이 통과하게 되었습니다. 
<img width="1157" alt="image" src="https://github.com/user-attachments/assets/5c470f23-2f9e-497d-b790-f72dce9c9d35">

<br>

## 문제 해결
- 기존 코드에서 상품 제목의 중복여부 검사는 트랜잭션이 시작되자마자 이뤄지는데, 트랜잭션 시작 시점과 종료 시점 사이에 상당한 텀이 있으므로 (상품 이미지 업로드에 많은 시간이 소요되기 때문) 실제로 상품이 등록되는 트랜잭션 종료시점에는 상품 제목의 유일성을 보장하기 어려워진 것이 문제라고 볼 수 있습니다.
- 따라서 트랜잭션이 종료되고 변경내역이 DB에 반영되는 시점에도 상품 제목의 중복여부를 검증해줄 필요성이 있습니다. 이는 상품 테이블의 (member_id, product_title)을 결합한 unique 제약조건을 걸어 DB 단에서 유일성이 보장되도록 조치했습니다.
<br>

## 고민?
1. unique 제약조건을 위배하는 경우 `DataIntegrityViolationException` 예외가 발생합니다. 해당 예외는 이번 경우 말고도 다양한 이유로 발생할 수 있기때문에 `INTERNAL_SERVER_ERROR`로 광범위하게 처리하게 되었습니다.
2. 어쨌든 이번 문제의 근본적인 원인은 상품이미지 업로드에 많은 시간이 소요된것에서 시작된건데, 여기에 대한 조치는 없는 PR이라 책임감(?)을 느끼고 있습니당. 우선 이번 PR을 반영한 뒤에, 다음 PR쯤에서 리팩터링을 진행해 병렬처리를 하던지 아님 업로드 시간을 줄일 수 있는 다른 최적화 방안을 적용시켜 보겠습니닷 🥸
