### PR TITLE
[FU-357] 날짜별 스케줄 검증로직 개선 및 리팩터링

### DIFF
--- a/src/main/java/com/foru/freebe/errors/errorcode/ScheduleErrorCode.java
+++ b/src/main/java/com/foru/freebe/errors/errorcode/ScheduleErrorCode.java
@@ -9,7 +9,8 @@ public enum ScheduleErrorCode implements ErrorCode {
     DAILY_SCHEDULE_NOT_FOUND(500, "해당하는 날짜별 스케줄을 찾을 수 없습니다."),
     DAILY_SCHEDULE_OVERLAP(400, "해당 일정에 이미 등록된 스케줄이 있습니다."),
     DAILY_SCHEDULE_IN_PAST(400, "현재 시점 이전의 스케줄은 등록할 수 없습니다."),
-    START_TIME_AFTER_END_TIME(400, "시작시간과 종료시간이 올바르지 않습니다.");
+    START_TIME_AFTER_END_TIME(400, "시작시간과 종료시간이 올바르지 않습니다."),
+    INVALID_SCHEDULE_UNIT(400, "기본스케줄 단위와 일치하지 않습니다.");
 
     private final int httpStatus;
     private final String message;

--- a/src/main/java/com/foru/freebe/member/entity/ScheduleUnit.java
+++ b/src/main/java/com/foru/freebe/member/entity/ScheduleUnit.java
@@ -3,7 +3,6 @@ package com.foru.freebe.member.entity;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public enum ScheduleUnit {
-
     @JsonProperty("THIRTY_MINUTES")
     THIRTY_MINUTES,
     @JsonProperty("SIXTY_MINUTES")

--- a/src/main/java/com/foru/freebe/schedule/repository/DailyScheduleRepository.java
+++ b/src/main/java/com/foru/freebe/schedule/repository/DailyScheduleRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 
 import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.schedule.entity.DailySchedule;
+import com.foru.freebe.schedule.entity.ScheduleStatus;
 
 public interface DailyScheduleRepository extends JpaRepository<DailySchedule, Long> {
     Optional<DailySchedule> findByMemberAndId(Member member, Long scheduleId);
@@ -18,7 +19,8 @@ public interface DailyScheduleRepository extends JpaRepository<DailySchedule, Lo
 
     @Query("SELECT ds FROM DailySchedule ds WHERE ds.member = :photographer "
         + "AND ds.date = :date "
-        + "AND ((ds.startTime < :endTime AND ds.endTime > :startTime))")
-    List<DailySchedule> findOverlappingSchedules(Member photographer, LocalDate date, LocalTime startTime,
-        LocalTime endTime);
+        + "AND ((ds.startTime < :endTime AND ds.endTime > :startTime))"
+        + "AND ds.scheduleStatus IN (:scheduleStatuses)")
+    List<DailySchedule> findConflictingSchedulesByStatuses(Member photographer, LocalDate date, LocalTime startTime,
+        LocalTime endTime, List<ScheduleStatus> scheduleStatuses);
 }

--- a/src/main/java/com/foru/freebe/schedule/service/BaseScheduleService.java
+++ b/src/main/java/com/foru/freebe/schedule/service/BaseScheduleService.java
@@ -1,24 +1,23 @@
 package com.foru.freebe.schedule.service;
 
 import java.time.LocalTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.foru.freebe.errors.errorcode.MemberErrorCode;
+import com.foru.freebe.errors.errorcode.ScheduleErrorCode;
+import com.foru.freebe.errors.exception.RestApiException;
+import com.foru.freebe.member.entity.Member;
+import com.foru.freebe.member.repository.MemberRepository;
 import com.foru.freebe.schedule.dto.BaseScheduleDto;
 import com.foru.freebe.schedule.dto.ScheduleUnitDto;
 import com.foru.freebe.schedule.entity.BaseSchedule;
 import com.foru.freebe.schedule.entity.DayOfWeek;
 import com.foru.freebe.schedule.entity.OperationStatus;
 import com.foru.freebe.schedule.repository.BaseScheduleRepository;
-import com.foru.freebe.errors.errorcode.MemberErrorCode;
-import com.foru.freebe.errors.errorcode.ScheduleErrorCode;
-import com.foru.freebe.errors.exception.RestApiException;
-import com.foru.freebe.member.entity.Member;
-import com.foru.freebe.member.repository.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -62,7 +61,7 @@ public class BaseScheduleService {
     }
 
     public void createDefaultSchedule(Member photographer) {
-        for(DayOfWeek dayOfWeek : DayOfWeek.values()) {
+        for (DayOfWeek dayOfWeek : DayOfWeek.values()) {
             BaseSchedule baseSchedule = BaseSchedule.builder()
                 .photographer(photographer)
                 .dayOfWeek(dayOfWeek)

--- a/src/main/java/com/foru/freebe/schedule/service/DailyScheduleValidator.java
+++ b/src/main/java/com/foru/freebe/schedule/service/DailyScheduleValidator.java
@@ -71,15 +71,14 @@ public class DailyScheduleValidator {
     public void validateConflictingSchedules(Member member, DailyScheduleRequest request, Long scheduleId) {
         List<ScheduleStatus> scheduleStatuses = determineConflictingStatuses(request.getScheduleStatus());
 
-        List<DailySchedule> overlappingSchedules = dailyScheduleRepository.findConflictingSchedulesByStatuses(member,
+        List<DailySchedule> conflictingSchedules = dailyScheduleRepository.findConflictingSchedulesByStatuses(member,
             request.getDate(), request.getStartTime(), request.getEndTime(), scheduleStatuses);
 
-        if (overlappingSchedules.size() == 1 && overlappingSchedules.get(0).getId().equals(scheduleId)) {
+        if (conflictingSchedules.isEmpty() || isSelfConflictOnly(scheduleId, conflictingSchedules)) {
             return;
         }
-        if (!overlappingSchedules.isEmpty()) {
-            throw new RestApiException(ScheduleErrorCode.DAILY_SCHEDULE_OVERLAP);
-        }
+
+        throw new RestApiException(ScheduleErrorCode.DAILY_SCHEDULE_OVERLAP);
     }
 
     private List<ScheduleStatus> determineConflictingStatuses(ScheduleStatus scheduleStatus) {
@@ -90,4 +89,7 @@ public class DailyScheduleValidator {
         }
     }
 
+    private boolean isSelfConflictOnly(Long scheduleId, List<DailySchedule> conflictingSchedules) {
+        return conflictingSchedules.size() == 1 && conflictingSchedules.get(0).getId().equals(scheduleId);
+    }
 }

--- a/src/main/java/com/foru/freebe/schedule/service/DailyScheduleValidator.java
+++ b/src/main/java/com/foru/freebe/schedule/service/DailyScheduleValidator.java
@@ -1,0 +1,93 @@
+package com.foru.freebe.schedule.service;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.foru.freebe.errors.errorcode.ScheduleErrorCode;
+import com.foru.freebe.errors.exception.RestApiException;
+import com.foru.freebe.member.entity.Member;
+import com.foru.freebe.member.entity.ScheduleUnit;
+import com.foru.freebe.schedule.dto.DailyScheduleRequest;
+import com.foru.freebe.schedule.entity.DailySchedule;
+import com.foru.freebe.schedule.entity.ScheduleStatus;
+import com.foru.freebe.schedule.repository.DailyScheduleRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DailyScheduleValidator {
+    private final Clock clock;
+    private final DailyScheduleRepository dailyScheduleRepository;
+
+    public void validateTimeRange(LocalTime startTime, LocalTime endTime) {
+        if (startTime.isAfter(endTime) || startTime.equals(endTime)) {
+            throw new RestApiException(ScheduleErrorCode.START_TIME_AFTER_END_TIME);
+        }
+    }
+
+    public void validateScheduleUnit(ScheduleUnit scheduleUnit, LocalTime startTime, LocalTime endTime) {
+        switch (scheduleUnit) {
+            case SIXTY_MINUTES -> {
+                if (startTime.getMinute() != 0 || endTime.getMinute() != 0) {
+                    throw new RestApiException(ScheduleErrorCode.INVALID_SCHEDULE_UNIT);
+                }
+            }
+            case THIRTY_MINUTES -> {
+                if (startTime.getMinute() != 0 && startTime.getMinute() != 30) {
+                    throw new RestApiException(ScheduleErrorCode.INVALID_SCHEDULE_UNIT);
+                } else if (endTime.getMinute() != 0 && endTime.getMinute() != 30) {
+                    throw new RestApiException(ScheduleErrorCode.INVALID_SCHEDULE_UNIT);
+                }
+            }
+        }
+    }
+
+    public void validateScheduleInFuture(DailyScheduleRequest request) {
+        LocalDateTime requestDateTime = request.getDate().atTime(request.getStartTime());
+
+        if (requestDateTime.isBefore(LocalDateTime.now(clock))) {
+            throw new RestApiException(ScheduleErrorCode.DAILY_SCHEDULE_IN_PAST);
+        }
+    }
+
+    public void validateConflictingSchedules(Member member, DailyScheduleRequest request) {
+        List<ScheduleStatus> scheduleStatuses = determineConflictingStatuses(request.getScheduleStatus());
+
+        List<DailySchedule> overlappingSchedules = dailyScheduleRepository.findConflictingSchedulesByStatuses(member,
+            request.getDate(), request.getStartTime(), request.getEndTime(), scheduleStatuses);
+
+        if (!overlappingSchedules.isEmpty()) {
+            throw new RestApiException(ScheduleErrorCode.DAILY_SCHEDULE_OVERLAP);
+        }
+    }
+
+    public void validateConflictingSchedules(Member member, DailyScheduleRequest request, Long scheduleId) {
+        List<ScheduleStatus> scheduleStatuses = determineConflictingStatuses(request.getScheduleStatus());
+
+        List<DailySchedule> overlappingSchedules = dailyScheduleRepository.findConflictingSchedulesByStatuses(member,
+            request.getDate(), request.getStartTime(), request.getEndTime(), scheduleStatuses);
+
+        if (overlappingSchedules.size() == 1 && overlappingSchedules.get(0).getId().equals(scheduleId)) {
+            return;
+        }
+        if (!overlappingSchedules.isEmpty()) {
+            throw new RestApiException(ScheduleErrorCode.DAILY_SCHEDULE_OVERLAP);
+        }
+    }
+
+    private List<ScheduleStatus> determineConflictingStatuses(ScheduleStatus scheduleStatus) {
+        if (scheduleStatus == ScheduleStatus.CONFIRMED) {
+            return List.of(ScheduleStatus.CONFIRMED);
+        } else {
+            return List.of(ScheduleStatus.OPEN, ScheduleStatus.CLOSED);
+        }
+    }
+
+}

--- a/src/test/java/com/foru/freebe/schedule/DailyScheduleServiceTest.java
+++ b/src/test/java/com/foru/freebe/schedule/DailyScheduleServiceTest.java
@@ -122,7 +122,7 @@ public class DailyScheduleServiceTest {
         }
 
         @Test
-        @DisplayName("중복되는 스케줄이 있을 때 예외가 발생한다")
+        @DisplayName("예약오픈, 예약중지 간 중복되는 스케줄이 있을 때 예외가 발생한다")
         void shouldThrowExceptionWhenSchedulesOverlap() {
             // given
             DailyScheduleRequest request = DailyScheduleRequest.builder()
@@ -135,14 +135,14 @@ public class DailyScheduleServiceTest {
             List<DailySchedule> overlappingSchedules = new ArrayList<>();
             overlappingSchedules.add(DailySchedule.builder()
                 .member(photographer)
-                .scheduleStatus(ScheduleStatus.OPEN)
+                .scheduleStatus(ScheduleStatus.CLOSED)
                 .date(now.toLocalDate())
                 .startTime(now.toLocalTime().plusHours(1).plusMinutes(30))
                 .endTime(now.toLocalTime().plusHours(3))
                 .build());
 
-            given(dailyScheduleRepository.findOverlappingSchedules(photographer, request.getDate(),
-                request.getStartTime(), request.getEndTime()))
+            given(dailyScheduleRepository.findConflictingSchedulesByStatuses(photographer, request.getDate(),
+                request.getStartTime(), request.getEndTime(), List.of(ScheduleStatus.OPEN, ScheduleStatus.CLOSED)))
                 .willReturn(overlappingSchedules);
 
             // when & then
@@ -166,8 +166,8 @@ public class DailyScheduleServiceTest {
 
             List<DailySchedule> overlappingSchedules = new ArrayList<>();
 
-            given(dailyScheduleRepository.findOverlappingSchedules(photographer, request.getDate(),
-                request.getStartTime(), request.getEndTime()))
+            given(dailyScheduleRepository.findConflictingSchedulesByStatuses(photographer, request.getDate(),
+                request.getStartTime(), request.getEndTime(), List.of(ScheduleStatus.OPEN, ScheduleStatus.CLOSED)))
                 .willReturn(overlappingSchedules);
 
             given(dailyScheduleRepository.save(any(DailySchedule.class))).willReturn(

--- a/src/test/java/com/foru/freebe/schedule/service/BaseScheduleServiceTest.java
+++ b/src/test/java/com/foru/freebe/schedule/service/BaseScheduleServiceTest.java
@@ -3,6 +3,7 @@ package com.foru.freebe.schedule.service;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalTime;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
 import com.foru.freebe.member.entity.Member;
 import com.foru.freebe.member.entity.Role;
 import com.foru.freebe.schedule.dto.BaseScheduleDto;
@@ -21,7 +23,6 @@ import com.foru.freebe.schedule.repository.BaseScheduleRepository;
 
 @ExtendWith(MockitoExtension.class)
 class BaseScheduleServiceTest {
-
     @Mock
     private BaseScheduleRepository baseScheduleRepository;
 
@@ -92,10 +93,12 @@ class BaseScheduleServiceTest {
         Assertions.assertEquals(LocalTime.of(9, 0), existingBaseSchedule.getStartTime());
         Assertions.assertEquals(LocalTime.of(18, 0), existingBaseSchedule.getEndTime());
 
-        verify(baseScheduleRepository, times(1)).findByDayOfWeekAndPhotographerId(baseScheduleDto.getDayOfWeek(), photographer.getId());
+        verify(baseScheduleRepository, times(1)).findByDayOfWeekAndPhotographerId(baseScheduleDto.getDayOfWeek(),
+            photographer.getId());
     }
 
-    private BaseScheduleDto createBaseScheduleDto(DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime, OperationStatus operationStatus) {
+    private BaseScheduleDto createBaseScheduleDto(DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime,
+        OperationStatus operationStatus) {
         return BaseScheduleDto.builder()
             .dayOfWeek(dayOfWeek)
             .startTime(startTime)

--- a/src/test/java/com/foru/freebe/schedule/service/DailyScheduleServiceTest.java
+++ b/src/test/java/com/foru/freebe/schedule/service/DailyScheduleServiceTest.java
@@ -1,0 +1,98 @@
+package com.foru.freebe.schedule.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.foru.freebe.member.entity.Member;
+import com.foru.freebe.member.entity.Role;
+import com.foru.freebe.schedule.dto.DailyScheduleMonthlyRequest;
+import com.foru.freebe.schedule.dto.DailyScheduleResponse;
+import com.foru.freebe.schedule.entity.DailySchedule;
+import com.foru.freebe.schedule.entity.ScheduleStatus;
+import com.foru.freebe.schedule.repository.DailyScheduleRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class DailyScheduleServiceTest {
+    @Mock
+    private DailyScheduleRepository dailyScheduleRepository;
+
+    @Mock
+    private Clock clock;
+
+    @InjectMocks
+    private DailyScheduleService dailyScheduleService;
+
+    private Member photographer;
+    private LocalDateTime now;
+
+    @BeforeEach
+    void setUp() {
+        Instant fixedInstant = Instant.parse("2024-12-05T10:00:00Z");
+        ZoneId zoneId = ZoneId.systemDefault();
+
+        given(clock.instant()).willReturn(fixedInstant);
+        given(clock.getZone()).willReturn(zoneId);
+
+        now = LocalDateTime.now(clock);
+        photographer = Member
+            .builder(1L, Role.PHOTOGRAPHER, "tester", "test@email", "010-0000-0000")
+            .build();
+        photographer.initializeScheduleUnit();
+    }
+
+    @Nested
+    @DisplayName("날짜별 스케줄 조회 테스트")
+    class FindDailySchedule {
+        @Test
+        @DisplayName("날짜별 스케줄 조회 시 월별 데이터를 불러온다")
+        void shouldFetchSchedulesAfterCurrentDate() {
+            // given
+            List<DailySchedule> dailySchedules = new ArrayList<>();
+            DailySchedule dailySchedule1 = DailySchedule.builder()
+                .member(photographer)
+                .scheduleStatus(ScheduleStatus.OPEN)
+                .date(now.toLocalDate())
+                .startTime(LocalTime.of(10, 0, 0))
+                .endTime(LocalTime.of(11, 0, 0))
+                .build();
+            DailySchedule dailySchedule2 = DailySchedule.builder()
+                .member(photographer)
+                .scheduleStatus(ScheduleStatus.OPEN)
+                .date(now.toLocalDate().plusMonths(1L))
+                .startTime(now.toLocalTime().minusSeconds(1L))
+                .endTime(now.toLocalTime())
+                .build();
+            dailySchedules.add(dailySchedule1);
+            dailySchedules.add(dailySchedule2);
+
+            DailyScheduleMonthlyRequest request = new DailyScheduleMonthlyRequest(
+                now.toLocalDate().getYear(), now.toLocalDate().getMonthValue());
+
+            given(dailyScheduleRepository.findByMember(photographer)).willReturn(dailySchedules);
+
+            // when
+            List<DailyScheduleResponse> responses = dailyScheduleService.getDailySchedules(photographer, request);
+
+            // then
+            assertThat(responses).size().isEqualTo(1);
+            assertThat(responses.get(0).getDate()).isEqualTo(now.toLocalDate());
+        }
+    }
+}


### PR DESCRIPTION
## 체크리스트

- [x] 불필요한 주석 처리가 없는가?

<br>

## 작업 내역
이번 PR에서는 스케줄 유형에 따른 위계 구조를 명확히 하고, 같은 레벨의 스케줄 간에만 충돌 여부를 검증하도록 로직을 보완했습니다.
또한, 날짜별 스케줄은 기본 스케줄 단위와 일치하도록 설정했습니다.

- 스케줄 위계 구조 개선
|--- 예약 확정 스케줄
|-- 추가오픈 or 예약 중지 스케줄
|- 기본 스케줄
  - `추가오픈`과 `예약 중지` 간에 충돌 여부를 검증
  - `예약 확정` 스케줄은 동일한 유형의 `예약 확정` 스케줄과만 충돌 여부를 검증
  
- 날짜별 스케줄 로직 보완
  - 기본 스케줄 단위가 `60분`이면, 시작/종료 시간은 반드시 **정시**여야 함.
  - 기본 스케줄 단위가 `30분`이면, 시작/종료 시간은 **정시 또는 30분 단위**여야 함.

<br>

## 고민한 사항
날짜별 스케줄의 등록/수정 요청 시, 요청 객체의 유효성 검증과 비즈니스 요구사항을 해치지 않는지 검증하는 과정이 복잡해짐에 따라, 자연스럽게 `DailyScheduleService`도 무거워졌습니다. `DailyScheduleService`는 스케줄 생성, 조회, 삭제, 검증 등 다양한 책임을 가지게 되었습니다.😓

점점 `DailyScheduleService`에 메서드를 추가하는 과정이 부담스러워지고, 테스트 코드를 작성하는 데도 부담이 커지는 것을 느껴 리팩터링을 고려하게 되었습니다. 그 중에서도 검증 로직을 전담 클래스로 분리하여 API 요청으로부터 호출되는 서비스 클래스를 간결하게 관리하고, 단일 책임 원칙(SRP)을 따르는 방향을 고려했습니다. 물론 클래스를 분리함에 따라 테스트 코드도 연쇄적으로 수정해야 했지만, 오히려 아래와 같은 장점을 발견했습니다.

✨ 서비스가 단일 책임 원칙을 따르게 됨
✨ 검증 로직의 재사용성이 증가함
✨ 테스트를 더 작고 집중적으로 작성할 수 있음 (예: DailyScheduleValidator에 대한 단위 테스트 작성)

<Br>

## 리뷰 요청사항
이번 PR은 #90 에서 논의한 내용을 바탕으로 기존 PR을 보완하기 위해 작성되었습니다.
논의했던 내용이 잘 반영 되었는지 위주로 검토 부탁드립니당 🙌