### PR TITLE
[FU-361] 날짜별 스케줄 수정 시, 시작시간 검증 로직 변경

### DIFF
--- a/src/main/java/com/foru/freebe/schedule/service/DailyScheduleService.java
+++ b/src/main/java/com/foru/freebe/schedule/service/DailyScheduleService.java
@@ -35,9 +35,9 @@ public class DailyScheduleService {
     }
 
     public DailyScheduleAddResponse addDailySchedule(Member photographer, DailyScheduleRequest request) {
-        validator.validateTimeRange(request.getStartTime(), request.getEndTime());
+        validator.validateStartTimeBeforeEndTime(request.getStartTime(), request.getEndTime());
         validator.validateScheduleUnit(photographer.getScheduleUnit(), request.getStartTime(), request.getEndTime());
-        validator.validateScheduleInFuture(request);
+        validator.validateScheduleStartInFuture(request);
         validator.validateConflictingSchedules(photographer, request);
 
         DailySchedule dailySchedule = DailySchedule.builder()
@@ -53,19 +53,19 @@ public class DailyScheduleService {
     }
 
     public void updateDailySchedule(Member photographer, Long scheduleId, DailyScheduleRequest request) {
-        validator.validateTimeRange(request.getStartTime(), request.getEndTime());
+        validator.validateStartTimeBeforeEndTime(request.getStartTime(), request.getEndTime());
         validator.validateScheduleUnit(photographer.getScheduleUnit(), request.getStartTime(), request.getEndTime());
 
-        DailySchedule dailySchedule = dailyScheduleRepository.findByMemberAndId(photographer, scheduleId)
+        DailySchedule existingSchedule = dailyScheduleRepository.findByMemberAndId(photographer, scheduleId)
             .orElseThrow(() -> new RestApiException(ScheduleErrorCode.DAILY_SCHEDULE_NOT_FOUND));
 
-        validator.validateScheduleInFuture(request);
+        validator.validateScheduleUpdateStartTime(existingSchedule, request);
         validator.validateConflictingSchedules(photographer, request, scheduleId);
 
-        dailySchedule.updateScheduleStatus(request.getScheduleStatus());
-        dailySchedule.updateDate(request.getDate());
-        dailySchedule.updateStartTime(request.getStartTime());
-        dailySchedule.updateEndTime(request.getEndTime());
+        existingSchedule.updateScheduleStatus(request.getScheduleStatus());
+        existingSchedule.updateDate(request.getDate());
+        existingSchedule.updateStartTime(request.getStartTime());
+        existingSchedule.updateEndTime(request.getEndTime());
     }
 
     public void deleteDailySchedule(Member photographer, Long scheduleId) {

--- a/src/main/java/com/foru/freebe/schedule/service/DailyScheduleValidator.java
+++ b/src/main/java/com/foru/freebe/schedule/service/DailyScheduleValidator.java
@@ -26,7 +26,7 @@ public class DailyScheduleValidator {
     private final Clock clock;
     private final DailyScheduleRepository dailyScheduleRepository;
 
-    public void validateTimeRange(LocalTime startTime, LocalTime endTime) {
+    public void validateStartTimeBeforeEndTime(LocalTime startTime, LocalTime endTime) {
         if (startTime.isAfter(endTime) || startTime.equals(endTime)) {
             throw new RestApiException(ScheduleErrorCode.START_TIME_AFTER_END_TIME);
         }
@@ -49,10 +49,19 @@ public class DailyScheduleValidator {
         }
     }
 
-    public void validateScheduleInFuture(DailyScheduleRequest request) {
-        LocalDateTime requestDateTime = request.getDate().atTime(request.getStartTime());
+    public void validateScheduleStartInFuture(DailyScheduleRequest request) {
+        LocalDateTime requestedStartTime = request.getDate().atTime(request.getStartTime());
 
-        if (requestDateTime.isBefore(LocalDateTime.now(clock))) {
+        if (requestedStartTime.isBefore(LocalDateTime.now(clock))) {
+            throw new RestApiException(ScheduleErrorCode.DAILY_SCHEDULE_IN_PAST);
+        }
+    }
+
+    public void validateScheduleUpdateStartTime(DailySchedule existingSchedule, DailyScheduleRequest request) {
+        LocalDateTime requestedStartTime = request.getDate().atTime(request.getStartTime());
+        LocalDateTime existingStartTime = existingSchedule.getDate().atTime(existingSchedule.getStartTime());
+
+        if (!requestedStartTime.equals(existingStartTime) && requestedStartTime.isBefore(LocalDateTime.now(clock))) {
             throw new RestApiException(ScheduleErrorCode.DAILY_SCHEDULE_IN_PAST);
         }
     }

--- a/src/test/java/com/foru/freebe/schedule/service/DailyScheduleValidatorTest.java
+++ b/src/test/java/com/foru/freebe/schedule/service/DailyScheduleValidatorTest.java
@@ -112,7 +112,7 @@ public class DailyScheduleValidatorTest {
 
             //when & then
             RestApiException exception = assertThrows(RestApiException.class, () -> {
-                dailyScheduleValidator.validateScheduleInFuture(request);
+                dailyScheduleValidator.validateScheduleStartInFuture(request);
             });
 
             assertThat(exception.getErrorCode()).isEqualTo(ScheduleErrorCode.DAILY_SCHEDULE_IN_PAST);

--- a/src/test/java/com/foru/freebe/schedule/service/DailyScheduleValidatorTest.java
+++ b/src/test/java/com/foru/freebe/schedule/service/DailyScheduleValidatorTest.java
@@ -117,6 +117,72 @@ public class DailyScheduleValidatorTest {
 
             assertThat(exception.getErrorCode()).isEqualTo(ScheduleErrorCode.DAILY_SCHEDULE_IN_PAST);
         }
+
+        @Test
+        @DisplayName("이미 진행 중인 스케줄을 수정할 때, 시작 시간이 과거 시점이어도 변경하지 않으면 예외가 발생하지 않는다")
+        void validateStartTimeNotChanged() {
+            // given
+            DailySchedule existingSchedule = createExistingSchedule();
+
+            DailyScheduleRequest sameStartTimeRequest = DailyScheduleRequest.builder()
+                .scheduleStatus(ScheduleStatus.OPEN)
+                .date(now.toLocalDate())
+                .startTime(existingSchedule.getStartTime())
+                .endTime(existingSchedule.getEndTime().plusHours(1L))
+                .build();
+
+            // when & then
+            assertDoesNotThrow(
+                () -> dailyScheduleValidator.validateScheduleUpdateStartTime(existingSchedule, sameStartTimeRequest));
+        }
+
+        @Test
+        @DisplayName("이미 진행 중인 스케줄을 수정할 때, 시작 시간을 현재 시각 이후로 변경하면 예외가 발생하지 않는다")
+        void validateStartTimeUpdatedToFuture() {
+            // given
+            DailySchedule existingSchedule = createExistingSchedule();
+
+            DailyScheduleRequest futureStartTimeRequest = DailyScheduleRequest.builder()
+                .scheduleStatus(ScheduleStatus.OPEN)
+                .date(now.toLocalDate())
+                .startTime(now.toLocalTime().plusHours(1L)) // 현재 시각보다 미래
+                .endTime(existingSchedule.getEndTime().plusHours(1L))
+                .build();
+
+            // when & then
+            assertDoesNotThrow(
+                () -> dailyScheduleValidator.validateScheduleUpdateStartTime(existingSchedule, futureStartTimeRequest));
+        }
+
+        @Test
+        @DisplayName("이미 진행 중인 스케줄을 수정할 때, 시작 시간을 현재 시각보다 과거로 변경하면 예외가 발생한다")
+        void validateStartTimeUpdatedToPast() {
+            // given
+            DailySchedule existingSchedule = createExistingSchedule();
+
+            DailyScheduleRequest pastStartTimeRequest = DailyScheduleRequest.builder()
+                .scheduleStatus(ScheduleStatus.OPEN)
+                .date(now.toLocalDate())
+                .startTime(now.toLocalTime().minusHours(1L)) // 현재보다 과거
+                .endTime(existingSchedule.getEndTime().plusHours(1L))
+                .build();
+
+            // when & then
+            RestApiException exception = assertThrows(RestApiException.class, () -> {
+                dailyScheduleValidator.validateScheduleUpdateStartTime(existingSchedule, pastStartTimeRequest);
+            });
+
+            assertThat(exception.getErrorCode()).isEqualTo(ScheduleErrorCode.DAILY_SCHEDULE_IN_PAST);
+        }
+
+        DailySchedule createExistingSchedule() {
+            return DailySchedule.builder()
+                .member(photographer)
+                .date(now.toLocalDate())
+                .startTime(now.toLocalTime().minusHours(2L))
+                .endTime(now.toLocalTime().plusHours(1L))
+                .build();
+        }
     }
 
     @Nested


### PR DESCRIPTION
## 체크리스트

- [ ] 불필요한 주석 처리가 없는가?

<br>

## 작업 내역
[#96](https://github.com/SWM-15th-ForU/freebe-frontend/pull/96) 논의에 따라, 이미 진행 중인 날짜별 스케줄을 수정할 수 있도록 백엔드 검증 로직을 변경했습니다.

- 기존: 이미 진행 중인 날짜별 스케줄에 대해 `시작시간` `종료시간` 모두 현시점 이후로만 수정 가능
- 변경: 이미 진행 중인 날짜별 스케줄에 대해 `시작시간`은 그대로 두거나, 현시점 이후로 수정 가능 (종료시간 검증은 변경된 사항 없음)

<br>

검증 로직 변경에 따른 변화
- 기등록 되어 있던 스케줄이 `14:00 - 17:00`라고 가정할 때, (현시각 15:00)
  - `14:00 - 18:00`로 업데이트가 가능해짐 -> 기존에는 시작시간도 현시각보다 미래여야만 수정 가능했음
  - `13:00 - 18:00`로 업데이트는 불가능 -> 시작시간이 변경되었으므로
  - `16:00 - 17:00`로 업데이트는 기존과 같이 가능 -> 시작시간/종료시간 모두 미래 시각인 경우

<br>

## 고민한 사항
비즈니스 요구사항에 부합하는 요청인지 확인하기 위해 `DailyScheduleService`가 `DailyScheduleValidator`를 호출해서 검증을 수행하고 있습니다. 테스트는 편리해졌지만(DailyScheduleValidator에 대한 테스트 코드만 작성하면 되니까), 하나의 서비스 메서드가 여러 개의 validator 메서드를 호출해야 하는 번거로움과, validator 메서드를 호출하는 순서가 중요하게 작용한다는 점이 불편..💆‍♀️한 요소입니다.

보다 더 좋은 검증 방식을 찾고 싶네요.. 💭 해결책을 찾게 되면 수정+공유하겠습니다 -!

<Br>

## 리뷰 요청사항
[#96](https://github.com/SWM-15th-ForU/freebe-frontend/pull/96) 논의 내용이 잘 반영되었는지 검토 부탁드립니다!